### PR TITLE
modules/packetio: handle 1-core runs more gracefully

### DIFF
--- a/src/modules/packetio/drivers/dpdk/topology_utils.cpp
+++ b/src/modules/packetio/drivers/dpdk/topology_utils.cpp
@@ -152,6 +152,8 @@ unsigned get_stack_lcore_id()
         nodes[rte_lcore_to_socket_id(lcore_id)].push_back(lcore_id);
     }
 
+    assert(!nodes.empty());
+
     /* Find the numa node with the most cores */
     auto max = std::max_element(begin(nodes), end(nodes),
                                 [](const cores_by_id::value_type& a,


### PR DESCRIPTION
The NUMA distribution code can't really do any distributing when only
one CPU core, and hence zero DPDK workers cores, is available. Instead
of crashing, update the EAL init code to catch the one CPU case and
exit with a useful error message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirentorion/inception-core/46)
<!-- Reviewable:end -->
