### PR TITLE
SO_BINDTODEVICE socket option (#45)

### DIFF
--- a/src/modules/socket/server/lwip_utils.cpp
+++ b/src/modules/socket/server/lwip_utils.cpp
@@ -86,6 +86,22 @@ tl::expected<void, int> do_sock_setsockopt(ip_pcb* pcb,
         else      ip_reset_option(pcb, SOF_REUSEADDR);
         break;
     }
+    case SO_BINDTODEVICE: {
+        char optval[NETIF_NAMESIZE];
+        if (setsockopt.optlen > NETIF_NAMESIZE) return (tl::make_unexpected(EINVAL));
+        auto opt = copy_in(optval,
+                           setsockopt.id.pid,
+                           reinterpret_cast<const char*>(setsockopt.optval),
+                           setsockopt.optlen,
+                           NETIF_NAMESIZE);
+        if (!opt) return (tl::make_unexpected(opt.error()));
+        struct netif* n = netif_find((const char *)optval);
+        if (n == nullptr) {
+            return (tl::make_unexpected(ENODEV));
+        }
+        pcb->netif_idx = netif_get_index(n);
+        break;
+    }
     default:
         return (tl::make_unexpected(ENOPROTOOPT));
     }

--- a/src/modules/socket/server/socket_utils.cpp
+++ b/src/modules/socket/server/socket_utils.cpp
@@ -98,6 +98,28 @@ tl::expected<void, int> copy_in(struct sockaddr_storage& dst,
     return {};
 }
 
+tl::expected<void, int> copy_in(char* dst,
+                                pid_t src_pid, const char* src_ptr,
+                                socklen_t dstlength, socklen_t srclength)
+{
+    auto local = iovec{
+	.iov_base = dst,
+	.iov_len = dstlength
+    };
+
+    auto remote = iovec{
+	.iov_base = (char *)src_ptr,
+	.iov_len = srclength
+    };
+
+    auto size = process_vm_readv(src_pid, &local, 1, &remote, 1, 0);
+    if (size == -1) {
+        return (tl::make_unexpected(errno));
+    }
+
+    return {};
+}
+
 tl::expected<int, int> copy_in(pid_t src_pid, const int *src_int)
 {
     int value = 0;

--- a/src/modules/socket/server/socket_utils.h
+++ b/src/modules/socket/server/socket_utils.h
@@ -69,7 +69,11 @@ tl::expected<void, int> copy_in(struct sockaddr_storage& dst,
                                 pid_t src_pid, const sockaddr* src_ptr,
                                 socklen_t length);
 
-tl::expected<int, int> copy_in(pid_t src_pid, const int *src_int);
+tl::expected<void, int> copy_in(char* dst,
+                                pid_t src_pid, const char* src_ptr,
+                                socklen_t dstlength, socklen_t srclength);
+
+tl::expected<int, int> copy_in(pid_t src_pid, const int* src_int);
 
 tl::expected<void, int> copy_out(pid_t dst_pid, sockaddr* dst_ptr,
                                  const struct sockaddr_storage& src,

--- a/src/modules/socket/server/tcp_socket.cpp
+++ b/src/modules/socket/server/tcp_socket.cpp
@@ -185,6 +185,7 @@ int tcp_socket::do_lwip_accept(tcp_pcb *newpcb, int err)
      * to the c++ socket wrapper, that behavior is very unhelpful for us.
      */
     ::tcp_arg(newpcb, nullptr);
+    newpcb->netif_idx = m_pcb->netif_idx;
     m_acceptq.emplace(newpcb);
     tcp_backlog_delayed(newpcb);
     m_channel->maybe_notify();
@@ -349,14 +350,23 @@ tcp_socket::on_request_reply tcp_socket::on_request(const api::request_listen& l
      * to be careful with pcb ownership and the callback argument here.
      */
     auto orig_pcb = m_pcb.release();
+    /* 
+     * cache idx and transfer to "listen_pcb" since netif_idx is assigned the
+     * DEFAULT value when listen_pcb is created
+     */
+    auto netif_idx = orig_pcb->netif_idx;
+
     ::tcp_arg(orig_pcb, nullptr);
     auto listen_pcb = tcp_listen_with_backlog(orig_pcb, listen.backlog);
+
 
     if (!listen_pcb) {
         m_pcb.reset(orig_pcb);
         ::tcp_arg(orig_pcb, this);
         return {tl::make_unexpected(ENOMEM), std::nullopt};
     }
+
+    listen_pcb->netif_idx = netif_idx;
 
     m_pcb.reset(listen_pcb);
     ::tcp_arg(listen_pcb, this);

--- a/targets/libicp-shim/libc_wrapper.cpp
+++ b/targets/libicp-shim/libc_wrapper.cpp
@@ -50,6 +50,7 @@ void wrapper::init()
     send        = load_symbol<decltype(send)>(RTLD_NEXT, "send");
     sendmsg     = load_symbol<decltype(sendmsg)>(RTLD_NEXT, "sendmsg");
     sendto      = load_symbol<decltype(sendto)>(RTLD_NEXT, "sendto");
+    setsockopt	= load_symbol<decltype(setsockopt)>(RTLD_NEXT, "setsockopt");
     write       = load_symbol<decltype(write)>(RTLD_NEXT, "write");
     writev      = load_symbol<decltype(writev)>(RTLD_NEXT, "writev");
 }


### PR DESCRIPTION
Add SO_BINDTODEVICE option to setsockopt call where interface
name is defined in ICP_BINDTODEVICE environment variable for
ICP SHIM layer binaries.  The interface name must currently be
the internal lwip interface “ioN”.

Closes #45

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirentorion/inception-core/54)
<!-- Reviewable:end -->
