### PR TITLE
modules/packetio: Use eth ring devs with inception stack

### DIFF
--- a/src/modules/packetio/stack/dpdk/net_interface.cpp
+++ b/src/modules/packetio/stack/dpdk/net_interface.cpp
@@ -390,7 +390,7 @@ int net_interface::handle_tx(struct pbuf* p)
     }
 
     /* Setup tx offload metadata if offloads are enabled. */
-    if (~(m_netif.chksum_flags & netif_tx_chksum_mask)) {
+    if ((~(m_netif.chksum_flags & netif_tx_chksum_mask)) & netif_tx_chksum_mask) {
         set_tx_offload_metadata(m_head, m_netif.mtu);
     }
 


### PR DESCRIPTION
1. Added "-- -r" ('r' for ring) option to existing set
    a. DPDK "--vdev eth_ringN" does not work due to loopback issues
    b. -r will create 2 ports and RX/TX is configured in non-loopback
    c. -r option is first round to allow for AAT test creation and
       will likely change as more topologies are supported
2. Fixed minor issue with TX offload incorrectly staying enabled
3. Added "copy-on-tx" for ring devs so mbufs are not shared between
   RX and TX ports/interfaces

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirentorion/inception-core/56)
<!-- Reviewable:end -->
