### PR TITLE
modules/socket: fix connect()

### DIFF
--- a/src/modules/socket/client/dgram_channel.cpp
+++ b/src/modules/socket/client/dgram_channel.cpp
@@ -79,7 +79,12 @@ dgram_channel::~dgram_channel()
     close(client_fds.server_fd);
 }
 
-int dgram_channel::flags()
+int dgram_channel::error() const
+{
+    return (0);
+}
+
+int dgram_channel::flags() const
 {
     return (socket_flags.load(std::memory_order_acquire));
 }
@@ -156,12 +161,6 @@ tl::expected<size_t, int> dgram_channel::recv(pid_t pid, iovec iov[], size_t iov
     }
 
     return (result);
-}
-
-int dgram_channel::recv_clear()
-{
-    uint64_t counter = 0;
-    return (eventfd_read(client_fds.client_fd, &counter));
 }
 
 }

--- a/src/modules/socket/client/dgram_channel.h
+++ b/src/modules/socket/client/dgram_channel.h
@@ -23,7 +23,9 @@ public:
     dgram_channel(dgram_channel&&) = default;
     dgram_channel& operator=(dgram_channel&&) = default;
 
-    int flags();
+    int error() const;
+
+    int flags() const;
     int flags(int);
 
     tl::expected<size_t, int> send(pid_t pid, const iovec iov[], size_t iovcnt,
@@ -31,8 +33,6 @@ public:
 
     tl::expected<size_t, int> recv(pid_t pid, iovec iov[], size_t iovcnt,
                                    sockaddr *from, socklen_t *fromlen);
-
-    int recv_clear();
 };
 
 }

--- a/src/modules/socket/client/io_channel_wrapper.cpp
+++ b/src/modules/socket/client/io_channel_wrapper.cpp
@@ -42,7 +42,15 @@ io_channel_wrapper& io_channel_wrapper::operator=(io_channel_wrapper&& other)
     return (*this);
 }
 
-int io_channel_wrapper::flags()
+int io_channel_wrapper::error() const
+{
+    auto error_visitor = [](auto channel) -> int {
+                             return (channel->error());
+                         };
+    return (std::visit(error_visitor, m_channel));
+}
+
+int io_channel_wrapper::flags() const
 {
     auto flags_visitor = [](auto channel) -> int {
                              return (channel->flags());
@@ -78,12 +86,28 @@ tl::expected<size_t, int> io_channel_wrapper::recv(pid_t pid,
     return (std::visit(recv_visitor, m_channel));
 }
 
-int io_channel_wrapper::recv_clear()
+tl::expected<void, int> io_channel_wrapper::block_writes()
 {
-    auto recv_clear_visitor = [](auto channel) -> int {
-                                  return (channel->recv_clear());
-                              };
-    return (std::visit(recv_clear_visitor, m_channel));
+    if (!std::holds_alternative<stream_channel*>(m_channel)) {
+        return {};
+    }
+    return (std::get<stream_channel*>(m_channel))->block_writes();
+}
+
+tl::expected<void, int> io_channel_wrapper::wait_readable()
+{
+    if (!std::holds_alternative<stream_channel*>(m_channel)) {
+        return {};
+    }
+    return (std::get<stream_channel*>(m_channel))->wait_readable();
+}
+
+tl::expected<void, int> io_channel_wrapper::wait_writable()
+{
+    if (!std::holds_alternative<stream_channel*>(m_channel)) {
+        return {};
+    }
+    return (std::get<stream_channel*>(m_channel))->wait_writable();
 }
 
 }

--- a/src/modules/socket/client/io_channel_wrapper.h
+++ b/src/modules/socket/client/io_channel_wrapper.h
@@ -29,7 +29,9 @@ public:
     io_channel_wrapper(io_channel_wrapper&&);
     io_channel_wrapper& operator=(io_channel_wrapper&&);
 
-    int flags();
+    int error() const;
+
+    int flags() const;
     int flags(int);
 
     tl::expected<size_t, int> send(pid_t pid, const iovec iov[], size_t iovcnt,
@@ -38,7 +40,9 @@ public:
     tl::expected<size_t, int> recv(pid_t pid, iovec iov[], size_t iovcnt,
                                    sockaddr *from, socklen_t *fromlen);
 
-    int recv_clear();
+    tl::expected<void, int> block_writes();
+    tl::expected<void, int> wait_readable();
+    tl::expected<void, int> wait_writable();
 };
 
 }

--- a/src/modules/socket/client/stream_channel.h
+++ b/src/modules/socket/client/stream_channel.h
@@ -65,6 +65,8 @@ public:
     stream_channel(stream_channel&&) = default;
     stream_channel& operator=(stream_channel&&) = default;
 
+    int error() const;
+
     int flags() const;
     int flags(int);
 
@@ -74,7 +76,9 @@ public:
     tl::expected<size_t, int> recv(pid_t pid, iovec iov[], size_t iovcnt,
                                    sockaddr *from, socklen_t *fromlen);
 
-    int recv_clear();
+    tl::expected<void, int> block_writes();
+    tl::expected<void, int> wait_readable();
+    tl::expected<void, int> wait_writable();
 };
 
 }

--- a/src/modules/socket/server/tcp_socket.h
+++ b/src/modules/socket/server/tcp_socket.h
@@ -137,15 +137,14 @@ public:
     }
 
     /* getsockopt handlers */
-    on_request_reply on_request(const api::request_getsockopt&, const tcp_error& error);
-
     static tl::expected<socklen_t, int> do_getsockopt(const tcp_pcb*,
-                                                      const api::request_getsockopt&);
+                                                      const api::request_getsockopt&,
+                                                      const tcp_socket_state& state);
 
     template <typename State>
     on_request_reply on_request(const api::request_getsockopt& name, const State&)
     {
-        auto result = do_getsockopt(m_pcb.get(), name);
+        auto result = do_getsockopt(m_pcb.get(), name, state());
         if (!result) return {tl::make_unexpected(result.error()), std::nullopt};
         return {api::reply_socklen{*result}, std::nullopt};
     }


### PR DESCRIPTION
The first version of the connect function had numerous deficiencies.
1) For blocking sockets, it did not block until the connection
   succeeded.
2) For non-blocking sockets, it neglected to make the socket
   non-writable nor return the correct error code.

This change fixes both of those issues.  Additionally, this change adds
the SO_ERROR socket option for TCP sockets, as some clients use that to
retrieve the error code for connect in the non-blocking case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirentorion/inception-core/64)
<!-- Reviewable:end -->
