### PR TITLE
Fix failing unit tests due to missing file

### DIFF
--- a/tests/unit/framework/test_config_file_utils.cpp
+++ b/tests/unit/framework/test_config_file_utils.cpp
@@ -2,7 +2,6 @@
 #include <string>
 #include <string.h>
 
-#include "icp_config_file.h"
 #include "config_file_utils.h"
 #include "yaml_json_emitter.h"
 


### PR DESCRIPTION
Missed removing a #include directive for a file that was intentionally
not included with the last check-in for config file support.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirentorion/inception-core/66)
<!-- Reviewable:end -->
