### PR TITLE
modules/packetio: copy, don't clone, mbufs in EAL tx copy function

### DIFF
--- a/src/modules/packetio/drivers/dpdk/eal.cpp
+++ b/src/modules/packetio/drivers/dpdk/eal.cpp
@@ -332,18 +332,82 @@ static uint16_t eal_tx_burst_function(int id, uint32_t hash, struct rte_mbuf* mb
     return (eal_port_queues[id]->tx(hash)->enqueue(mbufs, nb_mbufs));
 }
 
+/* Copy mbuf header and packet data */
+static void eal_mbuf_copy_seg(rte_mbuf *dst, const rte_mbuf* src)
+{
+    assert(dst);
+    assert(src);
+
+    dst->data_off = src->data_off;
+    dst->port = src->port;
+    dst->ol_flags = src->ol_flags;
+    dst->packet_type = src->packet_type;
+    dst->pkt_len = src->pkt_len;
+    dst->data_len = src->data_len;
+    dst->vlan_tci = src->vlan_tci;
+    dst->vlan_tci_outer = src->vlan_tci_outer;
+    dst->timestamp = src->timestamp;
+    dst->udata64 = src->udata64;
+    dst->tx_offload = src->tx_offload;
+    dst->timesync = src->timesync;
+
+    rte_memcpy(rte_pktmbuf_mtod(dst, void*),
+               rte_pktmbuf_mtod(src, const void*),
+               rte_pktmbuf_data_len(src));
+}
+
+/* Make a complete copy of an mbuf chain with mbufs from the same pool as the source */
+static rte_mbuf* eal_mbuf_copy_chain(const rte_mbuf* src_head)
+{
+    assert(src_head);
+
+    rte_mbuf* dst_head = rte_pktmbuf_alloc(src_head->pool);
+    if (!dst_head) return (nullptr);
+    eal_mbuf_copy_seg(dst_head, src_head);
+
+    /*
+     * Ugh.  The mbuf free function sanity checks the mbufs, so it can panic
+     * if pkt_len and nb_segs is not accurate.  Hence, we have to update those
+     * fields as we go along so that we can free the mbuf if there is an error.
+     */
+    rte_pktmbuf_pkt_len(dst_head) = rte_pktmbuf_data_len(dst_head);
+
+    const rte_mbuf* src = src_head;
+    rte_mbuf* dst = dst_head;
+    while (src->next != nullptr) {
+        src = src->next;
+        auto next = rte_pktmbuf_alloc(src->pool);
+        if (!next) {
+            rte_pktmbuf_free(dst_head);
+            return (nullptr);
+        }
+        eal_mbuf_copy_seg(next, src);
+        dst->next = next;
+        dst = dst->next;
+        dst_head->nb_segs++;
+        rte_pktmbuf_pkt_len(dst_head) += rte_pktmbuf_data_len(dst);
+    }
+
+    rte_mbuf_sanity_check(dst_head, true);
+
+    return (dst_head);
+}
+
 static uint16_t eal_tx_burst_copy_function(int id, uint32_t hash, struct rte_mbuf* mbufs[], uint16_t nb_mbufs)
 {
     assert(eal_port_queues[id]);
 
-    for (uint16_t n = 0; n < nb_mbufs; n++) {
-        struct rte_mbuf* mb = rte_pktmbuf_clone(mbufs[n], (mbufs[n])->pool);
-        assert(mb != nullptr);
-        rte_pktmbuf_free(mbufs[n]);
-        auto n_mb = eal_port_queues[id]->tx(hash)->enqueue(&mb, 1);
-        assert(n_mb == 1);
+    uint16_t sent = 0;
+    for (uint16_t i = 0; i < nb_mbufs; i++) {
+        /* Note: caller expects us to free the original mbuf; driver frees the copy */
+        auto copy = eal_mbuf_copy_chain(mbufs[i]);
+        rte_pktmbuf_free(mbufs[i]);
+        if (!copy || !eal_port_queues[id]->tx(hash)->enqueue(&copy, 1)) {
+            return (sent);
+        }
+        sent++;
     }
-    return (nb_mbufs);
+    return (sent);
 }
 
 static uint16_t eal_tx_dummy_function(int, uint32_t, struct rte_mbuf**, uint16_t)


### PR DESCRIPTION
The eal_tx_burst_copy_function is intended to allow the stack to
transmit and receive data over DPDK ring interfaces.  However, an mbuf
clone is insufficient for this purpose.  Whle cloned mbufs have
independent mbuf headers, and hence independent pbuf data, clones do not
have independent payload data.  Thus, when transmitted over a ring, both
the source and destination sockets have pointers to the same payload
data inside the original mbuf.  This is especially problematic for TCP
sockets, as the sender must maintain, reference, and possibly modify
transmitted data in order to process incoming ACKs.

Hence, the only way for the stack to operate in a back-to-back manner
using DPDK ring devices is for both the sender and the receiver to have
independent copies of packet data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirentorion/inception-core/69)
<!-- Reviewable:end -->
