### PR TITLE
Update top-level Makefile test targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,10 @@ inception: deps
 	@cd targets/inception && $(MAKE)
 
 .PHONY: test
-test: test_aat
+test: test_unit test_aat
 
 .PHONY: test_aat
-test_aat:
+test_aat: inception
 	@cd tests/aat && $(MAKE)
 
 .PHONY: test_unit


### PR DESCRIPTION
*Add top-level target to make unit tests (`test_unit`).
*Add unit test target as a dependency of `test` target.
*Add `inception` target as a dependency of `test_aat` target.

Unit tests will build and execute before building Inception and running AATs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirentorion/inception-core/73)
<!-- Reviewable:end -->
