### PR TITLE
packetio/stack: fixes bug/issue #39 causing unclean shutdown

### DIFF
--- a/src/modules/packetio/init.cpp
+++ b/src/modules/packetio/init.cpp
@@ -13,13 +13,21 @@
 #include "packetio/port_server.h"
 #include "packetio/stack_server.h"
 
+#include "packetio/drivers/dpdk/topology_utils.h"
+
 namespace icp {
 namespace packetio {
 
 static int module_version = 1;
 
+extern "C" int tcpip_shutdown(void);
+
 struct service {
     ~service() {
+
+        if (tcpip_shutdown() == 0) {
+            rte_eal_wait_lcore(icp::packetio::dpdk::topology::get_stack_lcore_id());
+        }
         if (m_worker.joinable()) {
             m_worker.join();
         }


### PR DESCRIPTION
The "tcpip_thread" requires an explicit shutdown notification
so its resources can be closed/cleaned-up. No such notification
existed and cleanup depended on the thread being in a certain
event loop state when the termination signal was caught.

This gap is closed by notifying the thread it needs to shutdown
and exit its forever loop causing the destructor to be called.

A simple "tcpip_shutdown()" function was added and called by lwip
destructor. The destructor then waits for termination of tcpip_thread.

Closes #39

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirentorion/inception-core/75)
<!-- Reviewable:end -->
