### PR TITLE
packetio/stack: fixes bug/issue #39 causing unclean shutdown

### DIFF
--- a/src/modules/packetio/generic_stack.h
+++ b/src/modules/packetio/generic_stack.h
@@ -96,6 +96,11 @@ public:
         return m_self->stats();
     }
 
+    void shutdown()
+    {
+        m_self->shutdown();
+    }
+
 private:
     struct stack_concept {
         virtual ~stack_concept() = default;
@@ -105,6 +110,7 @@ private:
         virtual tl::expected<int, std::string> create_interface(const interface::config_data& config) = 0;
         virtual void delete_interface(int id) = 0;
         virtual std::unordered_map<std::string, stats_data> stats() const = 0;
+        virtual void shutdown() const = 0;
     };
 
     template <typename Stack>
@@ -141,6 +147,10 @@ private:
         std::unordered_map<std::string, stats_data> stats() const
         {
             return m_stack.stats();
+        }
+        void shutdown() const
+        {
+            m_stack.shutdown();
         }
 
         Stack m_stack;

--- a/src/modules/packetio/init.cpp
+++ b/src/modules/packetio/init.cpp
@@ -13,8 +13,6 @@
 #include "packetio/port_server.h"
 #include "packetio/stack_server.h"
 
-#include "packetio/drivers/dpdk/topology_utils.h"
-
 namespace icp {
 namespace packetio {
 
@@ -24,11 +22,7 @@ extern "C" int tcpip_shutdown(void);
 
 struct service {
     ~service() {
-
-        if (tcpip_shutdown() == 0) {
-            int id = icp::packetio::dpdk::topology::get_stack_lcore_id();
-            rte_eal_wait_lcore(id);
-        }
+        m_stack->shutdown();
         if (m_worker.joinable()) {
             m_worker.join();
         }

--- a/src/modules/packetio/stack/dpdk/lwip.h
+++ b/src/modules/packetio/stack/dpdk/lwip.h
@@ -53,6 +53,7 @@ public:
     std::optional<interface::generic_interface> interface(int id) const;
     tl::expected<int, std::string> create_interface(const interface::config_data& config);
     void delete_interface(int id);
+    void shutdown() const;
 
     std::unordered_map<std::string, stack::stats_data> stats() const;
 


### PR DESCRIPTION
The "tcpip_thread" requires an explicit shutdown notification
so its resources can be closed/cleaned-up. No such notification
existed and cleanup depended on the thread being in a certain
event loop state when the termination signal was caught.

This gap is closed by notifying the thread it needs to shutdown
and exit its forever loop causing the destructor to be called.

A simple "tcpip_shutdown()" function was added and called by lwip
destructor. The destructor then waits for termination of tcpip_thread.

Closes #39

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirentorion/inception-core/76)
<!-- Reviewable:end -->
