### PR TITLE
tests/aat: drop all capabilities in inception after dpdk start

### DIFF
--- a/src/modules/packetio/drivers/dpdk/eal.cpp
+++ b/src/modules/packetio/drivers/dpdk/eal.cpp
@@ -473,6 +473,19 @@ static void create_test_portpairs(const int test_portpairs)
     }
 }
 
+static void drop_caps()
+{
+    cap_t caps = cap_get_proc();
+    if (caps == nullptr) {
+        throw std::runtime_error("Could not retrieve any capabilities");
+    }
+    cap_clear(caps);
+    if (cap_set_proc(caps) < 0) {
+        throw std::runtime_error("Could not drop all capabilities");
+    }
+    cap_free(caps);
+}
+
 eal::eal(void* context, std::vector<std::string> args, int test_portpairs)
     : m_initialized(false)
     , m_switch(std::make_shared<vif_map<netif>>())
@@ -586,6 +599,7 @@ eal::eal(void* context, std::vector<std::string> args, int test_portpairs)
     }
 
     start();
+    drop_caps();
 }
 
 eal::~eal()

--- a/src/modules/socket/server/api_server.cpp
+++ b/src/modules/socket/server/api_server.cpp
@@ -7,6 +7,7 @@
 #include <variant>
 
 #include <sys/mman.h>
+#include <sys/prctl.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/uio.h>
@@ -143,6 +144,16 @@ server::server(icp::core::event_loop& loop)
     /* Put socket in the listen state and wait for connections */
     if (listen(m_sock.get(), 8) == -1) {
         throw std::runtime_error("Could not listen to socket: "
+                                 + std::string(strerror(errno)));
+    }
+
+    if (prctl(PR_SET_DUMPABLE, 1, 0, 0, 0) < 0) {
+        throw std::runtime_error("Could not set dumpable: "
+                                 + std::string(strerror(errno)));
+    }
+
+    if (prctl(PR_SET_PTRACER, PR_SET_PTRACER_ANY, 0, 0, 0) < 0) {
+        throw std::runtime_error("Could not set ptracer_any: "
                                  + std::string(strerror(errno)));
     }
 


### PR DESCRIPTION
This change is necessary so shim-enabled clients do not require
root privilege. After capabilities are dropped, inception opens
its memory space to client process_vm_readv/writev operations by
calling prctl(PR_SET_PTRACE, PR_SET_PTRACER_ANY, ...).

PR_SET_PTRACER_ANY is necessary as opposed to using the client pid
because only 1 pid at a time is granted access (see man prctl for
details).  Inception client requests are not serialized and can
occur concurrently.

This change is required to complete issue #77.

Closes #86

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirentorion/inception-core/96)
<!-- Reviewable:end -->
