### PR TITLE
Add --version option to inception

### DIFF
--- a/src/framework/core/icp_version.c
+++ b/src/framework/core/icp_version.c
@@ -1,0 +1,42 @@
+#include "core/icp_core.h"
+#include "sys/utsname.h"
+#include <ctype.h>
+
+#ifndef BUILD_VERSION
+#error BUILD_VERSION must be defined
+#endif
+
+void make_lower_case(char *input)
+{
+    for (; *input; input++)
+        *input = tolower(*input);
+}
+
+static int version_option_handler(int opt __attribute__((unused)),
+                                  const char *opt_arg __attribute__((unused)))
+{
+    struct utsname info;
+    if (uname(&info) < 0) exit(EXIT_FAILURE);
+    make_lower_case(info.sysname);
+    make_lower_case(info.machine);
+
+    FILE *output = stderr;
+
+    fprintf(output, "Spirent Inception, version %s (%s-%s)\n", BUILD_VERSION, info.machine,
+            info.sysname);
+    fprintf(output, "Copyright (C) 2019 Spirent Communications\n");
+    exit(EXIT_SUCCESS);
+}
+
+static struct icp_options_data version_options = {
+  .name     = "VERSION",
+  .init     = NULL,
+  .callback = version_option_handler,
+  .options =
+    {
+      {"Version", "version", 'v', false},
+      {0, 0, 0, 0},
+    },
+};
+
+REGISTER_OPTIONS(version_options)

--- a/src/framework/core/module.mk
+++ b/src/framework/core/module.mk
@@ -12,7 +12,8 @@ FW_SOURCES += \
 	core/icp_options.c \
 	core/icp_reference.c \
 	core/icp_socket.c \
-	core/icp_task.c
+	core/icp_task.c \
+	core/icp_version.c
 
 ifeq ($(PLATFORM), linux)
 	FW_LDLIBS += -rdynamic
@@ -33,3 +34,7 @@ else
 	core/icp_exit.c \
 	core/icp_thread_bsd.c
 endif
+
+.PHONY: $(FW_SRC_DIR)/core/icp_version.c
+$(FW_OBJ_DIR)/core/icp_version.o: ICP_CFLAGS += \
+        -DBUILD_VERSION="\"$(GIT_VERSION)\""


### PR DESCRIPTION
--version/-v option outputs version information before exiting.

Sample output from the build Docker container:
Spirent Inception, version v0.1.0-14-g5cde83e (x86_64-linux)
Copyright (C) 2019 Spirent Communications

closes #95

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirentorion/inception-core/100)
<!-- Reviewable:end -->
