### PR TITLE
Change stack so it works with 2 cores

### DIFF
--- a/src/modules/packetio/drivers/dpdk/topology_utils.cpp
+++ b/src/modules/packetio/drivers/dpdk/topology_utils.cpp
@@ -23,7 +23,7 @@ using cores_by_id = std::unordered_map<unsigned, std::vector<unsigned>>;
  * allow everything to work.
  */
 std::vector<queue::descriptor>
-queue_distribute(const std::vector<model::port_info>& port_info)
+queue_distribute(const std::vector<model::port_info>& port_info, bool single_core)
 {
     /*
      * First, pick the core that should run the stack. We don't want to assign
@@ -39,8 +39,10 @@ queue_distribute(const std::vector<model::port_info>& port_info)
     unsigned lcore_id = 0;
     RTE_LCORE_FOREACH_SLAVE(lcore_id) {
         /* No other cores should be running anything */
-        assert(rte_eal_get_lcore_state(lcore_id) == WAIT);
-        if (lcore_id == stack_lcore) continue;
+        if (!single_core) {
+            assert(rte_eal_get_lcore_state(lcore_id) == WAIT);
+            if (lcore_id == stack_lcore) continue;
+        }
 
         nodes[rte_lcore_to_socket_id(lcore_id)].push_back(lcore_id);
     }

--- a/src/modules/packetio/drivers/dpdk/topology_utils.h
+++ b/src/modules/packetio/drivers/dpdk/topology_utils.h
@@ -24,7 +24,7 @@ unsigned get_stack_lcore_id();
  * port locality.
  */
 std::vector<queue::descriptor>
-queue_distribute(const std::vector<model::port_info>& port_info);
+queue_distribute(const std::vector<model::port_info>& port_info, bool single_core);
 
 /**
  * Determine the most common NUMA node connected to the most ports

--- a/src/modules/packetio/drivers/dpdk/worker_api.h
+++ b/src/modules/packetio/drivers/dpdk/worker_api.h
@@ -100,7 +100,9 @@ struct args {
 };
 
 int main(void*);
-
+void proxy_stash_config_data(const void* cntxt,
+                             const std::vector<descriptor>& dscrptrs,
+                             const std::shared_ptr<vif_map<netif>>& vif);
 }
 }
 }


### PR DESCRIPTION
Lower the minimum number of CPUs from three to
two so AAT data-plane tests can execute in the
Jenkins and circleCI environments.
The primary change was not starting
the "worker" thread and make the "tcpip"
thread act as a proxy for this thread.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirentorion/inception-core/102)
<!-- Reviewable:end -->
