### PR TITLE
enhanced SO_BINDTODEVICE to support user-defined interface names

### DIFF
--- a/src/modules/packetio/stack/dpdk/module.mk
+++ b/src/modules/packetio/stack/dpdk/module.mk
@@ -4,6 +4,7 @@ PIO_STACK_SOURCES += \
 	lwip.cpp \
 	gso_utils.cpp \
 	net_interface.cpp \
+	netif_utils.cpp \
 	netif_wrapper.cpp \
 	offload_utils.cpp \
 	stack.cpp \

--- a/src/modules/packetio/stack/dpdk/netif_utils.cpp
+++ b/src/modules/packetio/stack/dpdk/netif_utils.cpp
@@ -1,0 +1,19 @@
+#include "lwip/netifapi.h"
+#include "packetio/stack/dpdk/net_interface.h"
+
+using namespace icp::packetio::dpdk;
+
+uint8_t netif_id_match(std::string_view id_str)
+{
+    for (auto i = 1; i <= UINT8_MAX; i++) {
+        auto n = netif_get_by_index(i);
+        if (n != nullptr) {
+            auto *ifp =
+                reinterpret_cast<icp::packetio::dpdk::net_interface*>(n->state);
+            if (ifp->id() == id_str) {
+                return netif_get_index(n);
+            }
+        }
+    }
+    return (NETIF_NO_INDEX);
+}

--- a/src/modules/packetio/stack/netif_utils.h
+++ b/src/modules/packetio/stack/netif_utils.h
@@ -1,0 +1,6 @@
+#ifndef _ICP_PACKETIO_STACK_NETIF_UTILS_H_
+#define _ICP_PACKETIO_STACK_NETIF_UTILS_H_
+
+uint8_t netif_id_match(std::string_view id_str);
+
+#endif /* _ICP_PACKETIO_STACK_NETIF_UTILS_H_ */


### PR DESCRIPTION
SO_BINDTODEVICE walks list of lwip interfaces to see if
string in ICP_BINDTODEVICE envvar is valid

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirentorion/inception-core/105)
<!-- Reviewable:end -->
