### PR TITLE
Switch Pistache client to IPv4 only

### DIFF
--- a/src/modules/api/api_utils.cpp
+++ b/src/modules/api/api_utils.cpp
@@ -23,7 +23,11 @@ static constexpr unsigned int max_poll_count = 6;
 // Is the API port open?
 static tl::expected<void, std::string> check_api_port()
 {
-    struct addrinfo hints = {.ai_family = AF_UNSPEC, .ai_socktype = SOCK_STREAM}, *result;
+    /*
+     * XXX: Pistache currently can only support one address family per server.
+     * Until this is fixed, we're using IPv4 only.
+     */
+    struct addrinfo hints = {.ai_family = AF_INET, .ai_socktype = SOCK_STREAM}, *result;
 
     int res = getaddrinfo(api_server_host.c_str(),
                           to_string(icp::api::api_get_service_port()).c_str(), &hints, &result);


### PR DESCRIPTION
Pistache appears to only support one address family per server instance,
e.g. IPv4 OR IPv6, but not both.  Until that can be addressed, switch
the API client to use IPv4 only to match the Pistache server.
    
This fixes inception AAT's on dual-stack hosts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirentorion/inception-core/106)
<!-- Reviewable:end -->
