### PR TITLE
Support string ID for /stacks resources

### DIFF
--- a/src/modules/packetio/generic_stack.h
+++ b/src/modules/packetio/generic_stack.h
@@ -68,7 +68,7 @@ public:
         : m_self(std::make_shared<stack_model<Stack>>(std::move(s)))
     {}
 
-    int id() const
+    std::string id() const
     {
         return m_self->id();
     }
@@ -121,7 +121,7 @@ public:
 private:
     struct stack_concept {
         virtual ~stack_concept() = default;
-        virtual int id() const = 0;
+        virtual std::string id() const = 0;
         virtual std::vector<std::string> interface_ids() const = 0;
         virtual std::optional<interface::generic_interface> interface(std::string_view id) const = 0;
         virtual tl::expected<std::string, std::string> create_interface(const interface::config_data& config) = 0;
@@ -139,7 +139,7 @@ private:
             : m_stack(std::move(s))
         {}
 
-        int id() const override
+        std::string id() const override
         {
             return m_stack.id();
         }

--- a/src/modules/packetio/stack/dpdk/lwip.h
+++ b/src/modules/packetio/stack/dpdk/lwip.h
@@ -50,7 +50,7 @@ public:
     lwip(const lwip&) = delete;
     lwip& operator=(const lwip&&) = delete;
 
-    int id() const { return 0; }  /* only 1 stack for now */
+    std::string id() const { return "stack0"; }  /* only 1 stack for now */
     std::vector<std::string> interface_ids() const;
     std::optional<interface::generic_interface> interface(std::string_view id) const;
     tl::expected<std::string, std::string> create_interface(const interface::config_data& config);

--- a/src/modules/packetio/stack_server.cpp
+++ b/src/modules/packetio/stack_server.cpp
@@ -62,8 +62,8 @@ static void handle_list_stacks_request(generic_stack& stack,
 
 static void handle_get_stack_request(generic_stack& stack, json& request, json& reply)
 {
-    int id = request["id"].get<int>();
-    if (id == 0) {
+    auto id = request["id"].get<std::string>();
+    if (id == stack.id()) {
         reply["code"] = reply_code::OK;
         reply["data"] = make_swagger_stack(stack)->toJson().dump();
     } else {

--- a/src/modules/packetio/stack_utils.cpp
+++ b/src/modules/packetio/stack_utils.cpp
@@ -132,7 +132,7 @@ std::shared_ptr<Stack> make_swagger_stack(const generic_stack& in_stack)
 {
     auto out_stack = std::make_shared<Stack>();
 
-    out_stack->setId(std::to_string(in_stack.id()));
+    out_stack->setId(in_stack.id());
     out_stack->setStats(make_swagger_stack_stats(in_stack));
 
     return (out_stack);

--- a/tests/aat/spec/stacks_spec.py
+++ b/tests/aat/spec/stacks_spec.py
@@ -32,7 +32,7 @@ with description('Stacks,') as self:
     with description('get,'):
         with description('known existing stack,'):
             with it('succeeds'):
-                expect(self.api.get_stack('0')).to(be_valid_stack)
+                expect(self.api.get_stack('stack0')).to(be_valid_stack)
 
         with description('non-existent stack,'):
             with it('returns 404'):


### PR DESCRIPTION
With only a single stack in the system, its name is hard coded as "stack0". For now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirentorion/inception-core/108)
<!-- Reviewable:end -->
