### PR TITLE
modules/socket: be more explicit with types

### DIFF
--- a/src/modules/socket/api.h
+++ b/src/modules/socket/api.h
@@ -188,10 +188,10 @@ std::string client_socket(const std::string_view id);
 
 std::string server_socket();
 
-std::optional<socket_fd_pair> get_message_fds(const api::reply_msg&);
-void set_message_fds(api::reply_msg&, const socket_fd_pair& fd_pair);
+std::optional<api::socket_fd_pair> get_message_fds(const api::reply_msg&);
+void set_message_fds(api::reply_msg&, const api::socket_fd_pair& fd_pair);
 
-io_channel_ptr to_pointer(io_channel_offset offset, const void* base);
+api::io_channel_ptr to_pointer(api::io_channel_offset offset, const void* base);
 
 }
 }

--- a/src/modules/socket/common.cpp
+++ b/src/modules/socket/common.cpp
@@ -32,7 +32,7 @@ std::string server_socket()
     return (std::string("/tmp/.").append(key).append("/server"));
 }
 
-std::optional<socket_fd_pair> get_message_fds(const reply_msg& reply)
+std::optional<api::socket_fd_pair> get_message_fds(const api::reply_msg& reply)
 {
     if (!reply) {
         return (std::nullopt);
@@ -60,7 +60,7 @@ std::optional<socket_fd_pair> get_message_fds(const reply_msg& reply)
                        *reply));
 }
 
-void set_message_fds(reply_msg& reply, const socket_fd_pair& fd_pair)
+void set_message_fds(api::reply_msg& reply, const api::socket_fd_pair& fd_pair)
 {
     if (!reply) {
         return;
@@ -88,7 +88,7 @@ void set_message_fds(reply_msg& reply, const socket_fd_pair& fd_pair)
                *reply);
 }
 
-io_channel_ptr to_pointer(io_channel_offset offset, const void* base)
+api::io_channel_ptr to_pointer(api::io_channel_offset offset, const void* base)
 {
     return (std::visit(overloaded_visitor(
                            [&](dgram_channel_offset dgram) -> io_channel_ptr {


### PR DESCRIPTION
There appears to be an issue with some llvm toolchains where
underspecified(?) variant types can cause runtime errors, e.g.
bad_variant_access.

This change fixes dataplane AAT failures observed on Ubuntu 18.04.3
using the clang-7 toolchain.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirentorion/inception-core/144)
<!-- Reviewable:end -->
