### PR TITLE
modules/packetio: improve get_worker_{rx,tx}_ids()

### DIFF
--- a/src/modules/packetio/forwarding_table.h
+++ b/src/modules/packetio/forwarding_table.h
@@ -40,6 +40,8 @@ public:
     sink_vector* insert_sink(uint16_t port_idx, Sink sink);
     sink_vector* remove_sink(uint16_t port_idx, Sink sink);
 
+    Interface* find_interface(std::string_view id) const;
+
     Interface* find_interface(uint16_t port_idx, const net::mac_address& mac) const;
     Interface* find_interface(uint16_t port_idx, const uint8_t octets[mac_address_length]) const;
 

--- a/src/modules/packetio/generic_workers.h
+++ b/src/modules/packetio/generic_workers.h
@@ -4,6 +4,7 @@
 #include <any>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "tl/expected.hpp"
@@ -32,14 +33,14 @@ public:
         : m_self(std::make_unique<workers_model<Workers>>(std::move(s)))
     {}
 
-    std::vector<unsigned> get_rx_worker_ids() const
+    std::vector<unsigned> get_rx_worker_ids(std::optional<std::string_view> obj_id = std::nullopt) const
     {
-        return (m_self->get_rx_worker_ids());
+        return (m_self->get_rx_worker_ids(obj_id));
     }
 
-    std::vector<unsigned> get_tx_worker_ids() const
+    std::vector<unsigned> get_tx_worker_ids(std::optional<std::string_view> obj_id = std::nullopt) const
     {
-        return (m_self->get_tx_worker_ids());
+        return (m_self->get_tx_worker_ids(obj_id));
     }
 
     transmit_function get_transmit_function(std::string_view port_id) const
@@ -106,8 +107,8 @@ public:
 private:
     struct workers_concept {
         virtual ~workers_concept() = default;
-        virtual std::vector<unsigned> get_rx_worker_ids() const = 0;
-        virtual std::vector<unsigned> get_tx_worker_ids() const = 0;
+        virtual std::vector<unsigned> get_rx_worker_ids(std::optional<std::string_view> obj_id) const = 0;
+        virtual std::vector<unsigned> get_tx_worker_ids(std::optional<std::string_view> obj_id) const = 0;
         virtual transmit_function get_transmit_function(std::string_view port_id) const = 0;
         virtual void add_interface(std::string_view port_id, std::any interface) = 0;
         virtual void del_interface(std::string_view port_id, std::any interface) = 0;
@@ -132,14 +133,14 @@ private:
             : m_workers(std::move(s))
         {}
 
-        std::vector<unsigned> get_rx_worker_ids() const override
+        std::vector<unsigned> get_rx_worker_ids(std::optional<std::string_view> obj_id) const override
         {
-            return (m_workers.get_rx_worker_ids());
+            return (m_workers.get_rx_worker_ids(obj_id));
         }
 
-        std::vector<unsigned> get_tx_worker_ids() const override
+        std::vector<unsigned> get_tx_worker_ids(std::optional<std::string_view> obj_id) const override
         {
-            return (m_workers.get_tx_worker_ids());
+            return (m_workers.get_tx_worker_ids(obj_id));
         }
 
         transmit_function get_transmit_function(std::string_view port_id) const override

--- a/src/modules/packetio/internal_api.h
+++ b/src/modules/packetio/internal_api.h
@@ -61,8 +61,13 @@ struct request_task_del {
     std::string task_id;
 };
 
-struct request_worker_rx_ids {};
-struct request_worker_tx_ids {};
+struct request_worker_rx_ids {
+    std::optional<std::string> object_id = std::nullopt;
+};
+
+struct request_worker_tx_ids {
+    std::optional<std::string> object_id = std::nullopt;
+};
 
 struct reply_task_add {
     std::string task_id;

--- a/src/modules/packetio/internal_client.cpp
+++ b/src/modules/packetio/internal_client.cpp
@@ -31,9 +31,15 @@ client& client::operator=(client&& other)
     return (*this);
 }
 
-tl::expected<std::vector<unsigned>, int> client::get_worker_rx_ids()
+tl::expected<std::vector<unsigned>, int>
+client::get_worker_rx_ids(std::optional<std::string_view> obj_id)
 {
-    auto reply = do_request(m_socket.get(), request_worker_rx_ids{});
+    auto request = request_worker_rx_ids{};
+    if (obj_id) {
+        request.object_id = std::string(*obj_id);
+    }
+
+    auto reply = do_request(m_socket.get(), request);
     if (!reply) {
         return (tl::make_unexpected(reply.error()));
     }
@@ -41,9 +47,15 @@ tl::expected<std::vector<unsigned>, int> client::get_worker_rx_ids()
     return (std::get<reply_worker_ids>(reply.value()).worker_ids);
 }
 
-tl::expected<std::vector<unsigned>, int> client::get_worker_tx_ids()
+tl::expected<std::vector<unsigned>, int>
+client::get_worker_tx_ids(std::optional<std::string_view> obj_id)
 {
-    auto reply = do_request(m_socket.get(), request_worker_tx_ids{});
+    auto request = request_worker_tx_ids{};
+    if (obj_id) {
+        request.object_id = std::string(*obj_id);
+    }
+
+    auto reply = do_request(m_socket.get(), request);
     if (!reply) {
         return (tl::make_unexpected(reply.error()));
     }

--- a/src/modules/packetio/internal_client.h
+++ b/src/modules/packetio/internal_client.h
@@ -29,8 +29,10 @@ public:
     client(client&& other);
     client& operator=(client&& other);
 
-    tl::expected<std::vector<unsigned>, int> get_worker_rx_ids();
-    tl::expected<std::vector<unsigned>, int> get_worker_tx_ids();
+    tl::expected<std::vector<unsigned>, int>
+    get_worker_rx_ids(std::optional<std::string_view> obj_id = std::nullopt);
+    tl::expected<std::vector<unsigned>, int>
+    get_worker_tx_ids(std::optional<std::string_view> obj_id = std::nullopt);
 
     tl::expected<void, int> add_sink(std::string_view src_id,
                                      packets::generic_sink sink);

--- a/src/modules/packetio/internal_server.cpp
+++ b/src/modules/packetio/internal_server.cpp
@@ -87,15 +87,15 @@ reply_msg handle_request(workers::generic_workers& workers,
 }
 
 reply_msg handle_request(workers::generic_workers& workers,
-                         const request_worker_rx_ids&)
+                         const request_worker_rx_ids& rx_ids)
 {
-    return (reply_worker_ids{workers.get_rx_worker_ids()});
+    return (reply_worker_ids{workers.get_rx_worker_ids(rx_ids.object_id)});
 }
 
 reply_msg handle_request(workers::generic_workers& workers,
-                         const request_worker_tx_ids&)
+                         const request_worker_tx_ids& tx_ids)
 {
-    return (reply_worker_ids{workers.get_tx_worker_ids()});
+    return (reply_worker_ids{workers.get_tx_worker_ids(tx_ids.object_id)});
 }
 
 static std::string to_string(request_msg& request)
@@ -123,11 +123,13 @@ static std::string to_string(request_msg& request)
                            [](const request_task_del& msg) {
                                return ("delete task " + std::string(msg.task_id));
                            },
-                           [](const request_worker_rx_ids&) {
-                               return (std::string("get worker RX ids"));
+                           [](const request_worker_rx_ids& rx_ids) {
+                               return ("get worker RX ids for "
+                                       + (rx_ids.object_id ? *rx_ids.object_id : std::string("ALL")));
                            },
-                           [](const request_worker_tx_ids&) {
-                               return (std::string("get worker TX ids"));
+                           [](const request_worker_tx_ids& tx_ids) {
+                               return ("get worker TX ids for "
+                                       + (tx_ids.object_id ? *tx_ids.object_id : std::string("ALL")));
                            }),
                        request));
 }

--- a/src/modules/packetio/stack/dpdk/net_interface.cpp
+++ b/src/modules/packetio/stack/dpdk/net_interface.cpp
@@ -433,6 +433,11 @@ interface::config_data net_interface::config() const
     return (m_config);
 }
 
+const net_interface& to_interface(netif* ifp)
+{
+    return *(reinterpret_cast<net_interface*>(ifp->state));
+}
+
 }
 }
 }

--- a/src/modules/packetio/stack/dpdk/net_interface.h
+++ b/src/modules/packetio/stack/dpdk/net_interface.h
@@ -56,6 +56,8 @@ private:
     netif m_netif;
 };
 
+const net_interface& to_interface(netif*);
+
 }
 }
 }

--- a/src/modules/packetio/workers/dpdk/forwarding_table_impl.cpp
+++ b/src/modules/packetio/workers/dpdk/forwarding_table_impl.cpp
@@ -1,4 +1,5 @@
 #include "packetio/drivers/dpdk/dpdk.h"
+#include "packetio/stack/dpdk/net_interface.h"
 #include "packetio/forwarding_table.tcc"
 #include "packetio/generic_sink.h"
 
@@ -9,5 +10,15 @@ namespace icp::packetio {
 template class forwarding_table<netif,
                                 packets::generic_sink,
                                 RTE_MAX_ETHPORTS>;
+
+/*
+ * Provide a template specialization for the forwarding table so that it
+ * can retrieve the opaque string id from an interface.
+ */
+template<>
+std::string get_interface_id(netif* ifp)
+{
+    return (dpdk::to_interface(ifp).id());
+}
 
 }

--- a/src/modules/packetio/workers/dpdk/worker_controller.h
+++ b/src/modules/packetio/workers/dpdk/worker_controller.h
@@ -36,8 +36,8 @@ public:
     worker_controller(const worker_controller&) = delete;
     worker_controller& operator=(const worker_controller&&) = delete;
 
-    std::vector<unsigned> get_rx_worker_ids() const;
-    std::vector<unsigned> get_tx_worker_ids() const;
+    std::vector<unsigned> get_rx_worker_ids(std::optional<std::string_view> obj_id = std::nullopt) const;
+    std::vector<unsigned> get_tx_worker_ids(std::optional<std::string_view> obj_id = std::nullopt) const;
 
     workers::transmit_function get_transmit_function(std::string_view port_id) const;
 

--- a/tests/unit/modules/packetio/test_forwarding_table.cpp
+++ b/tests/unit/modules/packetio/test_forwarding_table.cpp
@@ -27,6 +27,12 @@ template class icp::packetio::forwarding_table<test_interface,
                                                test_sink,
                                                max_ports>;
 
+template <>
+std::string icp::packetio::get_interface_id(test_interface* ifp)
+{
+    return (ifp->id);
+}
+
 using forwarding_table = icp::packetio::forwarding_table<test_interface,
                                                          test_sink,
                                                          max_ports>;
@@ -48,6 +54,10 @@ TEST_CASE("forwarding table functionality", "[forwarding table]")
             auto ptr = table.find_interface(port1, mac1);
             REQUIRE(ptr == std::addressof(ifp1));
             REQUIRE(ptr->id == ifp1.id);
+
+            auto ptr2 = table.find_interface(ifp1.id);
+            REQUIRE(ptr2 == std::addressof(ifp1));
+            REQUIRE(ptr2->id == ifp1.id);
 
             SECTION("remove interface, ") {
                 to_delete = table.remove_interface(port1, mac1);
@@ -118,6 +128,9 @@ TEST_CASE("forwarding table functionality", "[forwarding table]")
             for(const auto& [key, value] : interfaces) {
                 auto ptr = table.find_interface(key.first, key.second);
                 REQUIRE(ptr->id == value.id);
+
+                auto ptr2 = table.find_interface(value.id);
+                REQUIRE(ptr2->id == value.id);
 
                 auto& map = table.get_interfaces(key.first);
                 REQUIRE(map.size() == many_interfaces / many_ports);


### PR DESCRIPTION
Add an optional id parameter to the get_worker_{rx,tx}_ids() functions so
that callers can just retrieve the set of workers responsible for servicing
the specified id instead of all worker ids.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirentorion/inception-core/159)
<!-- Reviewable:end -->
