### PR TITLE
api: add timesync spec

### DIFF
--- a/api/schema/v1/openperf.yaml
+++ b/api/schema/v1/openperf.yaml
@@ -398,7 +398,7 @@ paths:
         - TimeSources
       summary: List reference clocks
       description: |
-        The `time-sources` endpoint returns all network clock sources
+        The `time-sources` endpoint returns all time sources
         that are used for syncing the local time.
       responses:
         200:
@@ -412,7 +412,9 @@ paths:
       tags:
         - TimeSources
       summary: Register a time source for time syncing.
-      description: Registers a new time source for time syncing.
+      description: |
+        Registers a new time source for time syncing. Time sources are
+        immutable.
       parameters:
         - name: timesource
           in: body
@@ -975,55 +977,59 @@ definitions:
       priority:
         type: integer
         description: |
-          Priority to determine which counter to use in situations where
-          there is more than one (higher number = higher priority)
+          Priority determines which counter to use in situations where
+          there is more than one counter available (higher number = higher priority).
+          Priority is always positive.
         format: int32
     required:
       - id
       - name
       - frequency
-      - quality
+      - priority
 
-  TimeKeeperInfo:
+  TimeKeeperState:
     type: object
     description: TimeKeeper internal state information
     properties:
       frequency:
         type: number
         description: |
-          The TimeCounter frequency as measured by the interval between the
-          two best timestamp exchanges with the TimeSource over the past two
-          hours, in hz.
+          The time counter frequency as measured by the interval between the
+          two best timestamp exchanges with the time source over the past two
+          hours, in Hz.
         format: int64
       frequency_error:
         type: number
-        description: The estimated error in the TimeCounter frequency measurement, in hz.
+        description: The estimated error of the time counter frequency measurement, in Hz.
         format: int64
       local_frequency:
         type: number
         description: |
-          The TimeCounter frequency as measured by the interval between the
-          two best timestamp exchanges with the TimeSource over the past hour,
-          in hz. This value is used to help determine TimeCounter drift.
+          The time counter frequency as measured by the interval between the
+          two best timestamp exchanges with the time source over the past hour,
+          in Hz. This value is used to help determine time stamp error due to
+          time counter frequency drift.
         format: int64
       local_frequency_error:
         type: number
-        description: The estimated error in the local TimeCounter frequency measurement, in hz.
+        description: The estimated error of the local time counter frequency measurement, in Hz.
         format: int64
       offset:
         type: number
         description: |
-          The offset applied to TimeCounter derived timestamp values,
+          The offset applied to time counter derived timestamp values,
           in seconds.  This value comes from the system host clock.
         format: double
       synced:
         type: boolean
-        description: Indicates if the clock is synchronized to the source
+        description: |
+          The time keeper is considered to be synced to the time source if a clock
+          offset, theta, has been calculated and applied within the past 20 minutes.
       theta:
         type: number
         description: |
           The calculated correction to apply to the offset, based on the
-          measured TimeCounter frequency and TimeSource timestamps.
+          measured time counter frequency and time source timestamps.
         format: double
     required:
       - offset
@@ -1091,7 +1097,10 @@ definitions:
         format: int64
       timestamps:
         type: number
-        description: The number of timestamps in the current working set of timestamps.
+        description: |
+          The number of timestamps in the current working set of timestamps.
+          Old timestamps are dropped from the history of timestamps as they
+          become irrelevant.
         format: int64
     required:
       - frequency_accept
@@ -1106,11 +1115,11 @@ definitions:
   TimeKeeper:
     type: object
     description: |
-      A combination of a TimeSource and a TimeCounter used to measure
+      A combination of a time source and a time counter used to measure
       the passage of time, aka a clock
     properties:
-      info:
-        $ref: "#/definitions/TimeKeeperInfo"
+      state:
+        $ref: "#/definitions/TimeKeeperState"
       stats:
         $ref: "#/definitions/TimeKeeperStats"
       time:
@@ -1119,12 +1128,12 @@ definitions:
         format: date-time
       time_counter_id:
         type: string
-        description: Time counter used for measuring time intervals
+        description: time counter used for measuring time intervals
       time_source_id:
         type: string
-        description: Time source used for wall-clock synchronization
+        description: time source used for wall-clock synchronization
     required:
-      - info
+      - state
       - stats
       - time
       - time_counter_id
@@ -1141,10 +1150,10 @@ definitions:
           hostname:
             type: string
             description: network hostname or address for server
-          service:
+          port:
             type: string
             default: "ntp"
-            description: server port
+            description: service name or port for server
         required:
           - hostname
 
@@ -1164,9 +1173,15 @@ definitions:
             type: integer
             description: Transmitted packets
             format: int64
+          stratum:
+            type: integer
+            description: |
+              Time source distance from a NTP reference clock, in network hops.
+            format: int32
         required:
           - rx_packets
           - tx_packets
+          - stratum
 
   TimeSource:
     type: object

--- a/api/schema/v1/openperf.yaml
+++ b/api/schema/v1/openperf.yaml
@@ -39,6 +39,9 @@ tags:
   - name: Modules
   - name: Ports
   - name: Stacks
+  - name: TimeCounters
+  - name: TimeKeeper
+  - name: TimeSources
 
 basePath: /
 
@@ -341,6 +344,114 @@ paths:
           description: Success
           schema:
             $ref: "#/definitions/Stack"
+
+  /time-counters:
+    get:
+      operationId: ListTimeCounters
+      tags:
+        - TimeCounters
+      summary: List time counters
+      description: |
+        The `time-counters` endpoint returns all local time counters
+        that are available for measuring the passage of time.  This
+        list is for informational purposes only.
+      responses:
+        200:
+          description: Success
+          schema:
+            type: array
+            items:
+              $ref: "#/definitions/TimeCounter"
+
+  /time-counters/{id}:
+    get:
+      operationId: GetTimeCounter
+      tags:
+        - TimeCounters
+      summary: Get a time counter
+      description: Returns a time counter, by id.
+      parameters:
+        - $ref: "#/parameters/id"
+      responses:
+        200:
+          description: Success
+          schema:
+            $ref: "#/definitions/TimeCounter"
+
+  /time-keeper:
+    get:
+      operationId: GetTimeKeeper
+      tags:
+        - TimeKeeper
+      summary: Get a time keeper.
+      description: Returns the system time keeper, aka clock.
+      responses:
+        200:
+          description: Success
+          schema:
+            $ref: "#/definitions/TimeKeeper"
+
+  /time-sources:
+    get:
+      operationId: ListTimeSources
+      tags:
+        - TimeSources
+      summary: List reference clocks
+      description: |
+        The `time-sources` endpoint returns all network clock sources
+        that are used for syncing the local time.
+      responses:
+        200:
+          description: Success
+          schema:
+            type: array
+            items:
+              $ref: "#/definitions/TimeSource"
+    post:
+      operationId: CreateTimeSource
+      tags:
+        - TimeSources
+      summary: Register a time source for time syncing.
+      description: Registers a new time source for time syncing.
+      parameters:
+        - name: timesource
+          in: body
+          description: New time source
+          required: true
+          schema:
+            $ref: "#/definitions/TimeSource"
+      responses:
+        201:
+          description: Success
+          schema:
+            $ref: "#/definitions/TimeSource"
+
+  /time-sources/{id}:
+    get:
+      operationId: GetTimeSource
+      tags:
+        - TimeSources
+      summary: Get a time source
+      description: Get a time source, by id.
+      parameters:
+        - $ref: "#/parameters/id"
+      responses:
+        200:
+          description: Success
+          schema:
+            $ref: "#/definitions/TimeSource"
+    delete:
+      operationId: DeleteTimeSource
+      tags:
+        - TimeSources
+      summary: Delete a time source
+      description: Deletes an existing time source. Idempotent.
+      parameters:
+        - $ref: "#/parameters/id"
+      responses:
+        204:
+          description: No Content
+
 
 definitions:
   Interface:
@@ -846,3 +957,235 @@ definitions:
       - sems
       - mutexes
       - mboxes
+
+  TimeCounter:
+    type: object
+    description: A source of clock ticks
+    properties:
+      id:
+        type: string
+        description: Unique time counter identifier
+      name:
+        type: string
+        description: Time counter name
+      frequency:
+        type: integer
+        description: Tick rate of the counter, in Hz.
+        format: int64
+      priority:
+        type: integer
+        description: |
+          Priority to determine which counter to use in situations where
+          there is more than one (higher number = higher priority)
+        format: int32
+    required:
+      - id
+      - name
+      - frequency
+      - quality
+
+  TimeKeeperInfo:
+    type: object
+    description: TimeKeeper internal state information
+    properties:
+      frequency:
+        type: number
+        description: |
+          The TimeCounter frequency as measured by the interval between the
+          two best timestamp exchanges with the TimeSource over the past two
+          hours, in hz.
+        format: int64
+      frequency_error:
+        type: number
+        description: The estimated error in the TimeCounter frequency measurement, in hz.
+        format: int64
+      local_frequency:
+        type: number
+        description: |
+          The TimeCounter frequency as measured by the interval between the
+          two best timestamp exchanges with the TimeSource over the past hour,
+          in hz. This value is used to help determine TimeCounter drift.
+        format: int64
+      local_frequency_error:
+        type: number
+        description: The estimated error in the local TimeCounter frequency measurement, in hz.
+        format: int64
+      offset:
+        type: number
+        description: |
+          The offset applied to TimeCounter derived timestamp values,
+          in seconds.  This value comes from the system host clock.
+        format: double
+      synced:
+        type: boolean
+        description: Indicates if the clock is synchronized to the source
+      theta:
+        type: number
+        description: |
+          The calculated correction to apply to the offset, based on the
+          measured TimeCounter frequency and TimeSource timestamps.
+        format: double
+    required:
+      - offset
+      - boolean
+
+  TimeKeeperStats:
+    type: object
+    description: TimeKeeper statistics
+    properties:
+      frequency_accept:
+        type: number
+        description: The number of times the frequency calculation has been updated.
+        format: int64
+      frequency_reject:
+        type: number
+        description: |
+          The number of times the frequency calculation has been rejected due
+          to an excessive delta between old and new values.
+        format: int64
+      local_frequency_accept:
+        type: number
+        description: The number of times the local frequency calculation has been updated.
+        format: int64
+      local_frequency_reject:
+        type: number
+        description: |
+          The number of times the local frequency calculation has been rejected
+          due to an excessive delta between old and new values.
+        format: int64
+      round_trip_times:
+        type: object
+        description: |
+          The round trip time measures the total elapsed time to make a timestamp
+          exchange with the remote time source.  The TimeKeeper stores RTT data so
+          that the least delayed clock exchanges can be given extra weight when
+          calculating the current clock offset.
+        properties:
+          avg:
+            type: number
+            description: the average round trip time, in seconds.
+            format: double
+          max:
+            type: number
+            description: The maximum round trip time, in seconds.
+            format: double
+          min:
+            type: number
+            description: The minimum round trip time, in seconds.
+            format: double
+          size:
+            type: number
+            description: The number of round trip times in the data set.
+            format: int64
+        required:
+          - size
+      theta_accept:
+        type: number
+        description: The number of times the theta calculation has been updated.
+        format: int64
+      theta_reject:
+        type: number
+        description: |
+          Then umber of times the theta calculation has been rejected due to
+          excessive delta between old and new values.
+        format: int64
+      timestamps:
+        type: number
+        description: The number of timestamps in the current working set of timestamps.
+        format: int64
+    required:
+      - frequency_accept
+      - frequency_reject
+      - local_frequency_accept
+      - local_frequency_reject
+      - round_trip_times
+      - theta_accept
+      - theta_reject
+      - timestamps
+
+  TimeKeeper:
+    type: object
+    description: |
+      A combination of a TimeSource and a TimeCounter used to measure
+      the passage of time, aka a clock
+    properties:
+      info:
+        $ref: "#/definitions/TimeKeeperInfo"
+      stats:
+        $ref: "#/definitions/TimeKeeperStats"
+      time:
+        type: string
+        description: The current time and date in ISO8601 format
+        format: date-time
+      time_counter_id:
+        type: string
+        description: Time counter used for measuring time intervals
+      time_source_id:
+        type: string
+        description: Time source used for wall-clock synchronization
+    required:
+      - info
+      - stats
+      - time
+      - time_counter_id
+      - time_source_id
+
+  TimeSourceConfig:
+    type: object
+    description: time source configuration
+    properties:
+      ntp:
+        type: object
+        description: Network Time Protocol Server
+        properties:
+          hostname:
+            type: string
+            description: network hostname or address for server
+          service:
+            type: string
+            default: "ntp"
+            description: server port
+        required:
+          - hostname
+
+  TimeSourceStats:
+    type: object
+    description: time source statistics
+    properties:
+      ntp:
+        type: object
+        description: NTP statistics
+        properties:
+          rx_packets:
+            type: integer
+            description: Received packets
+            format: int64
+          tx_packets:
+            type: integer
+            description: Transmitted packets
+            format: int64
+        required:
+          - rx_packets
+          - tx_packets
+
+  TimeSource:
+    type: object
+    description: A reference time source
+    properties:
+      id:
+        type: string
+        description: Unique time source identifier
+      kind:
+        type: string
+        description: time source kind
+        enum:
+          - ntp
+      config:
+        $ref: "#/definitions/TimeSourceConfig"
+      stats:
+        $ref: "#/definitions/TimeSourceStats"
+    required:
+      - id
+      - kind
+      - config
+      - stats


### PR DESCRIPTION
This is the current version of the time sync spec with some information and statistics added.  I tried to explain the various meanings as thoroughly as possible.

Once this is approved, I'll create a final pull request for the code.  It's pretty big, but a good portion of it is auto generated, swagger code.

Example time-keeper GET reply...
```{
  "info": {
    "frequency": 3493339386,
    "frequency_error": 998,
    "offset": 1578404236.507593,
    "synced": true,
    "theta": 1.177635398
  },
  "stats": {
    "frequency_accept": 6,
    "frequency_reject": 0,
    "local_frequency_accept": 0,
    "local_frequency_reject": 0,
    "round_trip_times": {
      "avg": 0.000187127,
      "max": 0.000308604,
      "min": 0.000118351,
      "size": 8
    },
    "theta_accept": 6,
    "theta_reject": 0,
    "timestamps": 8
  },
  "time": "2020-01-10T15:16:14.753306Z",
  "time_counter_id": "18d29f23-74e2-4935-79d1-8a7fa8872a5e",
  "time_source_id": "b96d3b79-5eff-4876-770d-2b34a6952ae8"
}
```
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/173)
<!-- Reviewable:end -->
