### PR TITLE
Fix minor typo in TimeKeeperState swagger spec

### DIFF
--- a/api/schema/v1/openperf.yaml
+++ b/api/schema/v1/openperf.yaml
@@ -1033,7 +1033,7 @@ definitions:
         format: double
     required:
       - offset
-      - boolean
+      - synced
 
   TimeKeeperStats:
     type: object

--- a/src/swagger/v1/model/TimeKeeperState.cpp
+++ b/src/swagger/v1/model/TimeKeeperState.cpp
@@ -29,7 +29,6 @@ TimeKeeperState::TimeKeeperState()
     m_Local_frequency_errorIsSet = false;
     m_Offset = 0.0;
     m_Synced = false;
-    m_SyncedIsSet = false;
     m_Theta = 0.0;
     m_ThetaIsSet = false;
     
@@ -65,10 +64,7 @@ nlohmann::json TimeKeeperState::toJson() const
         val["local_frequency_error"] = m_Local_frequency_error;
     }
     val["offset"] = m_Offset;
-    if(m_SyncedIsSet)
-    {
-        val["synced"] = m_Synced;
-    }
+    val["synced"] = m_Synced;
     if(m_ThetaIsSet)
     {
         val["theta"] = m_Theta;
@@ -97,10 +93,7 @@ void TimeKeeperState::fromJson(nlohmann::json& val)
         setLocalFrequencyError(val.at("local_frequency_error"));
     }
     setOffset(val.at("offset"));
-    if(val.find("synced") != val.end())
-    {
-        setSynced(val.at("synced"));
-    }
+    setSynced(val.at("synced"));
     if(val.find("theta") != val.end())
     {
         setTheta(val.at("theta"));
@@ -193,15 +186,7 @@ bool TimeKeeperState::isSynced() const
 void TimeKeeperState::setSynced(bool value)
 {
     m_Synced = value;
-    m_SyncedIsSet = true;
-}
-bool TimeKeeperState::syncedIsSet() const
-{
-    return m_SyncedIsSet;
-}
-void TimeKeeperState::unsetSynced()
-{
-    m_SyncedIsSet = false;
+    
 }
 double TimeKeeperState::getTheta() const
 {

--- a/src/swagger/v1/model/TimeKeeperState.h
+++ b/src/swagger/v1/model/TimeKeeperState.h
@@ -85,9 +85,7 @@ public:
     /// </summary>
     bool isSynced() const;
     void setSynced(bool value);
-    bool syncedIsSet() const;
-    void unsetSynced();
-    /// <summary>
+        /// <summary>
     /// The calculated correction to apply to the offset, based on the measured time counter frequency and time source timestamps. 
     /// </summary>
     double getTheta() const;
@@ -107,7 +105,7 @@ protected:
     double m_Offset;
 
     bool m_Synced;
-    bool m_SyncedIsSet;
+
     double m_Theta;
     bool m_ThetaIsSet;
 };

--- a/tests/aat/api/v1/client/models/time_keeper_state.py
+++ b/tests/aat/api/v1/client/models/time_keeper_state.py
@@ -71,8 +71,7 @@ class TimeKeeperState(object):
         if local_frequency_error is not None:
             self.local_frequency_error = local_frequency_error
         self.offset = offset
-        if synced is not None:
-            self.synced = synced
+        self.synced = synced
         if theta is not None:
             self.theta = theta
 

--- a/tests/aat/api/v1/docs/TimeKeeperState.md
+++ b/tests/aat/api/v1/docs/TimeKeeperState.md
@@ -8,7 +8,7 @@ Name | Type | Description | Notes
 **local_frequency** | **float** | The time counter frequency as measured by the interval between the two best timestamp exchanges with the time source over the past hour, in Hz. This value is used to help determine time stamp error due to time counter frequency drift.  | [optional] 
 **local_frequency_error** | **float** | The estimated error of the local time counter frequency measurement, in Hz. | [optional] 
 **offset** | **float** | The offset applied to time counter derived timestamp values, in seconds.  This value comes from the system host clock.  | 
-**synced** | **bool** | The time keeper is considered to be synced to the time source if a clock offset, theta, has been calculated and applied within the past 20 minutes.  | [optional] 
+**synced** | **bool** | The time keeper is considered to be synced to the time source if a clock offset, theta, has been calculated and applied within the past 20 minutes.  | 
 **theta** | **float** | The calculated correction to apply to the offset, based on the measured time counter frequency and time source timestamps.  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)


### PR DESCRIPTION
"required" parameter was listed by type instead of by name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/180)
<!-- Reviewable:end -->
