### PR TITLE
Change makefile to generate ISO-8601 build timestamps

### DIFF
--- a/mk/versions.mk
+++ b/mk/versions.mk
@@ -24,8 +24,9 @@ ifeq ($(BUILD_NUMBER),)
   endif
 endif
 
-#Generate current timestamp per organizational requirements.
-TIMESTAMP := $(shell date -u +%Y-%m-%dT%H:%M:%S%Z)
+#Generate current timestamp per organizational requirements (ISO 8601).
+#This is the portable version of GNU date's --iso-8601 option.
+TIMESTAMP := $(shell date +%Y-%m-%dT%H:%M:%S%z | sed 's@^.\{22\}@&:@')
 
 # This dummy target allows us to treat versions as a standard dependency
 .PHONY: versions


### PR DESCRIPTION
Swagger requires RFC-3339/ISO-8601 format for
date-time values. Prior to this change the /modules
endpoint was returning build timestamps that were not
fully Swagger compliant.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/183)
<!-- Reviewable:end -->
