### PR TITLE
Analyzer functionality, part 2

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -54,6 +54,7 @@
                                      (concat root "deps/pistache/include")
                                      (concat root "src/")
                                      (concat root "src/framework")
+                                     (concat root "src/lib")
                                      (concat root "src/modules")
                                      (concat root "src/modules/packetio/stack/include")
                                      )))))))

--- a/src/framework/core/op_uuid.hpp
+++ b/src/framework/core/op_uuid.hpp
@@ -11,7 +11,10 @@ namespace openperf::core {
 
 class uuid
 {
-    alignas(8) uint8_t m_octets[16];
+    alignas(8) std::array<uint8_t, 16> m_octets;
+
+    friend bool operator<(const uuid&, const uuid&);
+    friend bool operator==(const uuid&, const uuid&);
 
 public:
     static uuid random() /* constructor for random uuid */
@@ -81,7 +84,7 @@ public:
         }
     }
 
-    uuid(const uint8_t data[15])
+    uuid(const uint8_t data[16])
         : m_octets{data[0],
                    data[1],
                    data[2],
@@ -120,16 +123,18 @@ public:
     }
 
     const uint8_t* data() const { return (&m_octets[0]); }
+
+    uint8_t* data() { return (&m_octets[0]); }
 };
 
 inline bool operator==(const uuid& lhs, const uuid& rhs)
 {
-    return (lhs[0] == rhs[0] && lhs[1] == rhs[1] && lhs[2] == rhs[2]
-            && lhs[3] == rhs[3] && lhs[4] == rhs[4] && lhs[5] == rhs[5]
-            && lhs[6] == rhs[6] && lhs[7] == rhs[7] && lhs[8] == rhs[8]
-            && lhs[9] == rhs[9] && lhs[10] == rhs[10] && lhs[11] == rhs[11]
-            && lhs[12] == rhs[12] && lhs[13] == rhs[13] && lhs[14] == rhs[14]
-            && lhs[15] == rhs[15]);
+    return (lhs.m_octets == rhs.m_octets);
+}
+
+inline bool operator<(const uuid& lhs, const uuid& rhs)
+{
+    return (lhs.m_octets < rhs.m_octets);
 }
 
 inline std::string to_string(const uuid& uuid)

--- a/src/framework/utils/flat_memoize.hpp
+++ b/src/framework/utils/flat_memoize.hpp
@@ -1,0 +1,220 @@
+/*
+ * @file
+ *
+ * Generic memoization implementation.  The template magic required to memoize
+ * generic functions is taken from Jim Porter's memo library at
+ * https://github.com/jimporter/memo.
+ *
+ * However, the internal data structures have been changed from a std::map
+ * to a set of fixed size arrays as the intent of this code is to speed
+ * up associate array look-ups on critical code paths, e.g. we want to
+ * turn an inexpensive hash table lookup into a really inexpensive
+ * index into an array.  At least for the common case; caveat utilitor!
+ */
+
+/*
+ * Copyright (c) 2014-2020, Jim Porter
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _OP_UTILS_MEMOIZE_HPP_
+#define _OP_UTILS_MEMOIZE_HPP_
+
+#include <array>
+#include <bitset>
+#include <functional>
+#include <optional>
+#include <tuple>
+#include <type_traits>
+
+#include "utils/hash_combine.hpp"
+
+namespace openperf::utils {
+
+namespace impl {
+
+/* Equivalent to remove_cvref from C++20 */
+template <typename T> struct remove_cvref
+{
+    using type = std::remove_cv_t<std::remove_reference_t<T>>;
+};
+
+template <typename T> using remove_cvref_t = typename remove_cvref<T>::type;
+
+template <typename T, typename U>
+struct is_same_underlying_type
+    : std::is_same<remove_cvref_t<T>, remove_cvref_t<U>>
+{};
+
+template <typename T, typename U>
+inline constexpr bool is_same_underlying_type_v =
+    is_same_underlying_type<T, U>::value;
+
+/*
+ * These templates translate various function signatures into something
+ * we can recognize.
+ */
+template <typename T, typename Enable = void> struct function_signature
+{};
+
+template <typename T>
+struct function_signature<T,
+                          std::enable_if_t<std::is_class_v<remove_cvref_t<T>>>>
+    : function_signature<decltype(&remove_cvref_t<T>::operator())>
+{};
+
+template <typename Object, typename Ret, typename... Args>
+struct function_signature<Ret (Object::*)(Args...)>
+{
+    using type = Ret(Args...);
+};
+
+template <typename Object, typename Ret, typename... Args>
+struct function_signature<Ret (Object::*)(Args...) const>
+{
+    using type = Ret(Args...);
+};
+
+template <typename Ret, typename... Args>
+struct function_signature<Ret(Args...)>
+{
+    using type = Ret(Args...);
+};
+
+template <typename Ret, typename... Args>
+struct function_signature<Ret (&)(Args...)>
+{
+    using type = Ret(Args...);
+};
+
+template <typename Ret, typename... Args>
+struct function_signature<Ret (*)(Args...)>
+{
+    using type = Ret(Args...);
+};
+
+template <typename T>
+using function_signature_t = typename function_signature<T>::type;
+
+} // namespace impl
+
+template <size_t Size, typename Signature, typename Function>
+class flat_memoizer;
+
+template <size_t Size, typename Ret, typename... Args, typename Function>
+class flat_memoizer<Size, Ret(Args...), Function>
+{
+public:
+    using function_type = Function;
+    using function_signature = Ret(Args...);
+    using tuple_type = std::tuple<std::remove_reference_t<Args>...>;
+    using return_type = Ret;
+    using return_reference = const return_type&;
+
+    static_assert((Size & (Size - 1)) == 0); /* Size must be a power of two */
+    static constexpr size_t mask = Size - 1;
+
+    flat_memoizer(const function_type& f)
+        : f_(f)
+    {}
+
+    template <typename... CallArgs>
+    inline return_reference operator()(CallArgs&&... args)
+    {
+        return (call<std::conditional_t<
+                    impl::is_same_underlying_type_v<CallArgs, Args>,
+                    CallArgs&&,
+                    impl::remove_cvref_t<Args>&&>...>(
+            std::forward<CallArgs>(args)...));
+    }
+
+    template <typename... CallArgs>
+    inline return_reference retry(CallArgs&&... args)
+    {
+        return (call_again<std::conditional_t<
+                    impl::is_same_underlying_type_v<CallArgs, Args>,
+                    CallArgs&&,
+                    impl::remove_cvref_t<Args>&&>...>(
+            std::forward<CallArgs>(args)...));
+    }
+
+private:
+    template <typename... CallArgs>
+    inline return_reference call(CallArgs... args)
+    {
+        auto key = std::forward_as_tuple(std::forward<CallArgs>(args)...);
+        auto idx =
+            std::hash<tuple_type>{}({std::forward<CallArgs>(args)...}) & mask;
+
+        if (!flags_.test(idx) || keys_[idx] != key) {
+            keys_[idx] = std::move(key);
+            values_[idx] = f_(std::forward<decltype(args)>(args)...);
+            flags_.set(idx);
+        }
+
+        return (values_[idx]);
+    }
+
+    template <typename... CallArgs>
+    inline return_reference call_again(CallArgs... args)
+    {
+        auto key = std::forward_as_tuple(std::forward<CallArgs>(args)...);
+        auto idx =
+            std::hash<tuple_type>{}({std::forward<CallArgs>(args)...}) & mask;
+
+        keys_[idx] = std::move(key);
+        values_[idx] = f_(std::forward<decltype(args)>(args)...);
+        flags_.set(idx);
+
+        return (values_[idx]);
+    }
+
+    std::bitset<Size> flags_;              /* indicates if function has been
+                                            * evaluated with the matching args */
+    std::array<tuple_type, Size> keys_;    /* arguments used for function */
+    std::array<return_type, Size> values_; /* value returned for function */
+    function_type f_;                      /* function to call */
+};
+
+template <size_t Size, typename Signature, typename Function>
+inline auto flat_memoize(Function&& f)
+{
+    return (
+        flat_memoizer<Size, Signature, Function>(std::forward<Function>(f)));
+}
+
+template <size_t Size, typename Function> inline auto flat_memoize(Function&& f)
+{
+    return (flat_memoizer<Size, impl::function_signature_t<Function>, Function>(
+        std::forward<Function>(f)));
+}
+
+} // namespace openperf::utils
+
+#endif /* _OP_UTILS_MEMOIZE_HPP_ */

--- a/src/framework/utils/recycle.hpp
+++ b/src/framework/utils/recycle.hpp
@@ -1,12 +1,13 @@
-#ifndef _OP_PACKETIO_RECYCLE_HPP_
-#define _OP_PACKETIO_RECYCLE_HPP_
+#ifndef _OP_UTILS_RECYCLE_HPP_
+#define _OP_UTILS_RECYCLE_HPP_
 
+#include <array>
 #include <atomic>
 #include <bitset>
 #include <functional>
 #include <map>
 
-namespace openperf::packetio::recycle {
+namespace openperf::utils::recycle {
 
 /**
  * The depot contains all the logic and machinery necessary to implement
@@ -73,6 +74,6 @@ public:
     ~guard();
 };
 
-} // namespace openperf::packetio::recycle
+} // namespace openperf::utils::recycle
 
-#endif /* _OP_PACKETIO_RECYCLE_HPP_ */
+#endif /* _OP_UTILS_RECYCLE_HPP_ */

--- a/src/framework/utils/recycle.hpp
+++ b/src/framework/utils/recycle.hpp
@@ -33,7 +33,7 @@ template <int NumReaders> class depot
      */
     struct alignas(cache_line_size) reader_state
     {
-        std::atomic_size_t version;
+        mutable std::atomic_size_t version;
     };
     alignas(
         cache_line_size) std::array<reader_state, NumReaders> m_reader_states;
@@ -56,8 +56,8 @@ public:
     /**
      * Thread safe reader functions
      **/
-    void reader_checkpoint(size_t reader_id);
-    void reader_idle(size_t reader_id);
+    void reader_checkpoint(size_t reader_id) const;
+    void reader_idle(size_t reader_id) const;
 };
 
 /**
@@ -66,11 +66,11 @@ public:
  **/
 template <int NumReaders> class guard
 {
-    depot<NumReaders>& m_depot;
+    const depot<NumReaders>& m_depot;
     size_t m_id;
 
 public:
-    guard(depot<NumReaders>& depot, size_t reader_id);
+    guard(const depot<NumReaders>& depot, size_t reader_id);
     ~guard();
 };
 

--- a/src/framework/utils/recycle.tcc
+++ b/src/framework/utils/recycle.tcc
@@ -1,7 +1,7 @@
 #include "core/op_log.h"
-#include "packetio/recycle.hpp"
+#include "utils/recycle.hpp"
 
-namespace openperf::packetio::recycle {
+namespace openperf::utils::recycle {
 
 template <int NumReaders>
 depot<NumReaders>::depot()
@@ -113,4 +113,4 @@ template <int NumReaders> guard<NumReaders>::~guard()
     m_depot.reader_idle(m_id);
 }
 
-} // namespace openperf::packetio::recycle
+} // namespace openperf::utils::recycle

--- a/src/framework/utils/recycle.tcc
+++ b/src/framework/utils/recycle.tcc
@@ -88,20 +88,21 @@ template <int NumReaders> void depot<NumReaders>::writer_process_gc_callbacks()
 }
 
 template <int NumReaders>
-void depot<NumReaders>::reader_checkpoint(size_t reader_id)
+void depot<NumReaders>::reader_checkpoint(size_t reader_id) const
 {
     auto v = m_writer_version.load(std::memory_order_consume);
     m_reader_states[reader_id].version.store(v, std::memory_order_release);
 }
 
-template <int NumReaders> void depot<NumReaders>::reader_idle(size_t reader_id)
+template <int NumReaders>
+void depot<NumReaders>::reader_idle(size_t reader_id) const
 {
     m_reader_states[reader_id].version.store(idle_version,
                                              std::memory_order_release);
 }
 
 template <int NumReaders>
-guard<NumReaders>::guard(depot<NumReaders>& depot, size_t reader_id)
+guard<NumReaders>::guard(const depot<NumReaders>& depot, size_t reader_id)
     : m_depot(depot)
     , m_id(reader_id)
 {

--- a/src/framework/utils/soa_container.hpp
+++ b/src/framework/utils/soa_container.hpp
@@ -1,0 +1,233 @@
+#include <cstddef>
+#include <functional>
+#include <iostream>
+#include <utility>
+#include <vector>
+
+namespace openperf::utils {
+
+template <template <typename...> typename Container, typename Item>
+struct soa_container_adapter
+{};
+
+template <template <typename...> typename Container,
+          template <typename...>
+          typename Item,
+          typename... Types>
+struct soa_container_adapter<Container, Item<Types...>>
+{
+    using container_type = std::tuple<Container<Types>...>;
+    using value_type = Item<Types...>;
+
+    static constexpr value_type get(container_type& container, size_t idx)
+    {
+        return (get_impl(
+            container, idx, std::make_index_sequence<sizeof...(Types)>()));
+    }
+
+    static constexpr void resize(container_type& container, size_t size)
+    {
+        resize_impl(
+            container, size, std::make_index_sequence<sizeof...(Types)>());
+    }
+
+    static constexpr void push_back(container_type& container,
+                                    value_type&& value)
+    {
+        push_back_impl(container,
+                       std::forward<value_type>(value),
+                       std::make_index_sequence<sizeof...(Types)>());
+    }
+
+    static constexpr bool empty(const container_type& container)
+    {
+        return (std::get<0>(container).empty());
+    }
+
+    static constexpr size_t size(const container_type& container)
+    {
+        return (std::get<0>(container).size());
+    }
+
+    static constexpr size_t max_size(const container_type& container)
+    {
+        return (std::get<0>(container).max_size());
+    }
+
+    template <size_t Idx>
+    static constexpr typename std::tuple_element_t<Idx, std::tuple<Types...>>*
+    data(container_type& container)
+    {
+        return (std::get<Idx>(container).data());
+    }
+
+    friend bool operator==(const container_type& left,
+                           const container_type& right)
+    {
+        return (equals_impl(
+            left, right, std::make_index_sequence<sizeof...(Types)>()));
+    }
+
+private:
+    template <size_t... Indexes>
+    static constexpr auto get_impl(container_type& container,
+                                   size_t idx,
+                                   std::index_sequence<Indexes...>)
+    {
+        return (value_type{
+            std::reference_wrapper(std::get<Indexes>(container)[idx])...});
+    }
+
+    template <size_t... Indexes>
+    static constexpr void resize_impl(container_type& container,
+                                      size_t size,
+                                      std::index_sequence<Indexes...>)
+    {
+        (std::get<Indexes>(container).resize(size), ...);
+    }
+
+    template <size_t... Indexes>
+    static constexpr void push_back_impl(container_type& container,
+                                         value_type&& value,
+                                         std::index_sequence<Indexes...>)
+    {
+        (std::get<Indexes>(container).push_back(
+             std::get<Indexes>(std::forward<value_type>(value))),
+         ...);
+    }
+
+    template <size_t... Indexes>
+    static constexpr bool equals_impl(const container_type& left,
+                                      const container_type& right,
+                                      std::index_sequence<Indexes...>)
+    {
+        return ((std::get<Indexes>(left) == std::get<Indexes>(right)) && ...);
+    }
+};
+
+template <typename Container> class soa_container_iterator
+{
+    static constexpr size_t invalid_idx = std::numeric_limits<size_t>::max();
+    Container* m_container = nullptr;
+    size_t m_idx = invalid_idx;
+
+public:
+    using adapter = typename Container::adapter;
+    using difference_type = std::ptrdiff_t;
+    using value_type = typename adapter::value_type;
+    using reference = value_type&;
+    using iterator_category = std::bidirectional_iterator_tag;
+
+    soa_container_iterator(Container* container, size_t idx = 0)
+        : m_container(container)
+        , m_idx(idx)
+    {}
+
+    soa_container_iterator(const Container* container, size_t idx = 0)
+        : m_container(const_cast<Container*>(container))
+        , m_idx(idx)
+    {}
+
+    soa_container_iterator& operator=(soa_container_iterator const& other)
+    {
+        m_container = other.m_container;
+        m_idx = other.m_idx;
+    }
+
+    soa_container_iterator& operator=(std::nullptr_t const&)
+    {
+        m_container = nullptr;
+        m_idx = invalid_idx;
+    }
+
+    friend bool operator==(soa_container_iterator const& left,
+                           soa_container_iterator const& right)
+    {
+        return (left.m_container == right.m_container
+                && left.m_idx == right.m_idx);
+    }
+
+    friend bool operator!=(soa_container_iterator const& left,
+                           soa_container_iterator const& right)
+    {
+        return (!(left == right));
+    }
+
+    template <typename T>
+    typename std::enable_if_t<std::is_integral_v<T>> operator+=(T incr)
+    {
+        m_idx += incr;
+    }
+
+    template <typename T>
+    typename std::enable_if_t<std::is_integral_v<T>> operator-=(T decr)
+    {
+        m_idx -= decr;
+    }
+
+    void operator++() { operator+=(1); }
+    void operator--() { operator-=(1); }
+    operator bool() const
+    {
+        return (m_container && m_idx >= m_container->size());
+    }
+
+    value_type operator*() { return ((*m_container)[m_idx]); }
+};
+
+template <template <typename...> typename Container, typename Item>
+struct soa_container
+{
+    using adapter = soa_container_adapter<Container, Item>;
+    using iterator = soa_container_iterator<soa_container<Container, Item>>;
+    using const_iterator = const iterator;
+    using difference_type = std::ptrdiff_t;
+    using value_type = typename adapter::value_type;
+    using reference_type = value_type&;
+    using size_type = size_t;
+
+    void push_back(value_type&& value)
+    {
+        adapter::push_back(m_adapter, std::forward<value_type>(value));
+    }
+
+    bool empty() const { return (adapter::empty(m_adapter)); }
+
+    size_t size() const { return (adapter::size(m_adapter)); }
+
+    size_t max_size() const { return (adapter::max_size(m_adapter)); }
+
+    value_type operator[](size_t idx) { return (adapter::get(m_adapter, idx)); }
+
+    void resize(size_t size) { adapter::resize(m_adapter, size); }
+
+    template <size_t Idx> std::tuple_element_t<Idx, value_type>* data()
+    {
+        return (adapter::template data<Idx>(m_adapter));
+    }
+
+    iterator begin() { return (iterator(this)); }
+    const_iterator begin() const { return iterator((this)); }
+    const_iterator cbegin() const { return (begin()); }
+
+    iterator end() { return (iterator(this, size())); }
+    const_iterator end() const { return (iterator(this, size())); }
+    const_iterator cend() const { return (end()); }
+
+    friend bool operator==(const soa_container& left,
+                           const soa_container& right)
+    {
+        return (left.m_adapter == right.m_adapter);
+    }
+
+    friend bool operator!=(const soa_container& left,
+                           const soa_container& right)
+    {
+        return (!(left.m_adapter == right.m_adapter));
+    }
+
+private:
+    typename adapter::container_type m_adapter;
+}; // namespace openperf::utils
+
+} // namespace openperf::utils

--- a/src/modules/packetio/drivers/dpdk/directory.mk
+++ b/src/modules/packetio/drivers/dpdk/directory.mk
@@ -10,6 +10,7 @@ PIO_DRIVER_SOURCES += \
 	mbuf_signature.cpp \
 	port_filter.cpp \
 	port_signature_decoder.cpp \
+	port_signature_decoder_utils.cpp \
 	port_timestamper.cpp \
 	queue_utils.cpp \
 	topology_utils.cpp \

--- a/src/modules/packetio/drivers/dpdk/directory.mk
+++ b/src/modules/packetio/drivers/dpdk/directory.mk
@@ -1,4 +1,4 @@
-PIO_DEPENDS += dpdk
+PIO_DEPENDS += dpdk timesync
 
 PIO_DRIVER_SOURCES += \
 	arg_parser.cpp \
@@ -8,6 +8,7 @@ PIO_DRIVER_SOURCES += \
 	flow_filter.cpp \
 	mac_filter.cpp \
 	port_filter.cpp \
+	port_timestamper.cpp \
 	queue_utils.cpp \
 	topology_utils.cpp \
 	model/physical_port.cpp \

--- a/src/modules/packetio/drivers/dpdk/directory.mk
+++ b/src/modules/packetio/drivers/dpdk/directory.mk
@@ -1,4 +1,4 @@
-PIO_DEPENDS += dpdk timesync
+PIO_DEPENDS += dpdk timesync spirent_pga
 
 PIO_DRIVER_SOURCES += \
 	arg_parser.cpp \
@@ -7,9 +7,14 @@ PIO_DRIVER_SOURCES += \
 	eal.cpp \
 	flow_filter.cpp \
 	mac_filter.cpp \
+	mbuf_signature.cpp \
 	port_filter.cpp \
+	port_signature_decoder.cpp \
 	port_timestamper.cpp \
 	queue_utils.cpp \
 	topology_utils.cpp \
 	model/physical_port.cpp \
 	model/port_info.cpp
+
+# Needed to use the "experimental" API for DPDK's dynamic mbufs
+$(PIO_OBJ_DIR)/drivers/dpdk/mbuf_signature.o: OP_CPPFLAGS += -Wno-deprecated-declarations

--- a/src/modules/packetio/drivers/dpdk/eal.cpp
+++ b/src/modules/packetio/drivers/dpdk/eal.cpp
@@ -11,6 +11,7 @@
 
 #include "packetio/drivers/dpdk/dpdk.h"
 #include "packetio/drivers/dpdk/eal.hpp"
+#include "packetio/drivers/dpdk/mbuf_signature.hpp"
 #include "packetio/drivers/dpdk/topology_utils.hpp"
 #include "packetio/drivers/dpdk/model/physical_port.hpp"
 #include "packetio/generic_port.hpp"
@@ -280,6 +281,9 @@ eal::eal(std::vector<std::string> args,
                parsed_or_err,
                eal_args.size() - 2);
     }
+
+    /* Find some space for Spirent test signatures */
+    mbuf_signature_init();
 
     if (test_portpairs > 0) { create_test_portpairs(test_portpairs); }
 

--- a/src/modules/packetio/drivers/dpdk/mbuf_signature.cpp
+++ b/src/modules/packetio/drivers/dpdk/mbuf_signature.cpp
@@ -1,0 +1,50 @@
+#include <stdexcept>
+#include <string>
+
+#include "core/op_log.h"
+#include "packetio/drivers/dpdk/dpdk.h"
+#include "packetio/drivers/dpdk/mbuf_signature.hpp"
+
+namespace openperf::packetio::dpdk {
+
+size_t mbuf_signature_offset = 0;
+uint64_t mbuf_signature_flag = 0;
+
+void mbuf_signature_init()
+{
+    static constexpr auto mbuf_dynfield_signature =
+        rte_mbuf_dynfield{.name = "packetio_dynfield_signature",
+                          .size = sizeof(mbuf_signature),
+                          .align = __alignof(uint64_t),
+                          .flags = 0};
+
+    auto offset = rte_mbuf_dynfield_register(&mbuf_dynfield_signature);
+    if (offset < 0) {
+        throw std::runtime_error(
+            "Could not register dynamic field for signature: "
+            + std::string(rte_strerror(rte_errno)));
+    }
+
+    mbuf_signature_offset = offset;
+
+    static constexpr auto mbuf_dynflag_signature =
+        rte_mbuf_dynflag{.name = "packetio_dynflag_signature", .flags = 0};
+
+    /* Register the signature flag for any available bit */
+    auto bitnum =
+        rte_mbuf_dynflag_register_bitnum(&mbuf_dynflag_signature, UINT_MAX);
+    if (bitnum < 0) {
+        throw std::runtime_error(
+            "Could not register dynamic bit number for signature: "
+            + std::string(rte_strerror(rte_errno)));
+    }
+
+    mbuf_signature_flag = (1ULL << bitnum);
+
+    OP_LOG(OP_LOG_DEBUG,
+           "Dynamic signature field registered: offset = %d, bitflag = %d\n",
+           offset,
+           bitnum);
+};
+
+} // namespace openperf::packetio::dpdk

--- a/src/modules/packetio/drivers/dpdk/mbuf_signature.hpp
+++ b/src/modules/packetio/drivers/dpdk/mbuf_signature.hpp
@@ -14,8 +14,14 @@ struct mbuf_signature
     uint32_t sig_stream_id;
     uint32_t sig_seq_num;
 
-    static constexpr auto flag_shift = 48U;
-    static constexpr auto timestamp_mask = 0xffffffffffffULL;
+    /*
+     * We use the upper 2 bits of the timestamp to store the flags.
+     * The lower 62 bits contain the wall-clock time in nanoseconds
+     * since the start of the UNIX epoch, e.g. 1970.  The 62 bit counter
+     * will roll over sometime in 2116.
+     */
+    static constexpr auto flag_shift = 62U;
+    static constexpr auto timestamp_mask = 0x3fffffffffffffffULL;
     uint64_t sig_timestamp_flags;
 };
 

--- a/src/modules/packetio/drivers/dpdk/mbuf_signature.hpp
+++ b/src/modules/packetio/drivers/dpdk/mbuf_signature.hpp
@@ -1,0 +1,78 @@
+#ifndef _OP_PACKETIO_DPDK_MBUF_SIGNATURE_HPP_
+#define _OP_PACKETIO_DPDK_MBUF_SIGNATURE_HPP_
+
+#include <cstdint>
+#include <cstddef>
+#include <tuple>
+
+#include "packetio/drivers/dpdk/dpdk.h"
+
+namespace openperf::packetio::dpdk {
+
+struct mbuf_signature
+{
+    uint32_t sig_stream_id;
+    uint32_t sig_seq_num;
+
+    static constexpr auto flag_shift = 48U;
+    static constexpr auto timestamp_mask = 0xffffffffffffULL;
+    uint64_t sig_timestamp_flags;
+};
+
+extern size_t mbuf_signature_offset;
+extern uint64_t mbuf_signature_flag;
+
+void mbuf_signature_init();
+
+inline void mbuf_signature_set(rte_mbuf* mbuf,
+                               uint32_t stream_id,
+                               uint32_t seq_num,
+                               uint64_t timestamp,
+                               int flags)
+{
+    mbuf->ol_flags |= mbuf_signature_flag;
+    *(RTE_MBUF_DYNFIELD(mbuf, mbuf_signature_offset, mbuf_signature*)) =
+        mbuf_signature{
+            .sig_stream_id = stream_id,
+            .sig_seq_num = seq_num,
+            .sig_timestamp_flags =
+                ((static_cast<uint64_t>(flags) << mbuf_signature::flag_shift)
+                 | (timestamp & mbuf_signature::timestamp_mask))};
+}
+
+inline bool mbuf_signature_avail(const rte_mbuf* mbuf)
+{
+    return (mbuf->ol_flags & mbuf_signature_flag);
+}
+
+inline const mbuf_signature& mbuf_signature_get(const rte_mbuf* mbuf)
+{
+    return (*(
+        RTE_MBUF_DYNFIELD(mbuf, mbuf_signature_offset, const mbuf_signature*)));
+}
+
+inline uint32_t mbuf_signature_stream_id_get(const rte_mbuf* mbuf)
+{
+    return (mbuf_signature_get(mbuf).sig_stream_id);
+}
+
+inline uint32_t mbuf_signature_seq_num_get(const rte_mbuf* mbuf)
+{
+    return (mbuf_signature_get(mbuf).sig_seq_num);
+}
+
+inline uint64_t mbuf_signature_timestamp_get(const rte_mbuf* mbuf)
+{
+    return (mbuf_signature_get(mbuf).sig_timestamp_flags
+            & mbuf_signature::timestamp_mask);
+}
+
+inline int mbuf_signature_flags_get(const rte_mbuf* mbuf)
+{
+    return (mbuf_signature_get(mbuf).sig_timestamp_flags
+            >> mbuf_signature::flag_shift);
+}
+
+} // namespace openperf::packetio::dpdk
+
+#endif /* _OP_PACKETIO_DPDK_MUBF_SIGNATURE_HPP_ */

--- a/src/modules/packetio/drivers/dpdk/model/physical_port.cpp
+++ b/src/modules/packetio/drivers/dpdk/model/physical_port.cpp
@@ -126,12 +126,12 @@ static __attribute__((const)) uint64_t filter_tx_offloads(uint64_t tx_capa)
                | DEV_TX_OFFLOAD_MULTI_SEGS));
 }
 
-static rte_eth_conf make_rte_eth_conf(port_info& info, bool use_rss)
+static rte_eth_conf make_rte_eth_conf(port_info& info)
 {
     return {.link_speeds = ETH_LINK_SPEED_AUTONEG,
             .rxmode =
                 {
-                    .mq_mode = use_rss ? ETH_MQ_RX_RSS : ETH_MQ_RX_NONE,
+                    .mq_mode = ETH_MQ_RX_RSS,
                     .max_rx_pkt_len = info.max_rx_pktlen(),
                     .offloads = filter_rx_offloads(info.rx_offloads()),
                 },
@@ -165,7 +165,7 @@ physical_port::config(const port::config_data& c)
     /* Acquire some useful data about our port... */
     auto info = port_info(m_idx);
 
-    rte_eth_conf port_conf = make_rte_eth_conf(info, info.rx_queue_count() > 1);
+    rte_eth_conf port_conf = make_rte_eth_conf(info);
 
     /* Auto-negotiation is the default config. */
     if (dpdk_config.auto_negotiation) {
@@ -336,7 +336,7 @@ physical_port::low_level_config(uint16_t nb_rxqs, uint16_t nb_txqs)
 {
     auto info = port_info(m_idx);
 
-    rte_eth_conf port_conf = make_rte_eth_conf(info, nb_rxqs > 1);
+    rte_eth_conf port_conf = make_rte_eth_conf(info);
 
     auto result = apply_port_config(info, port_conf, nb_rxqs, nb_txqs);
     if (!result) { return (result); }

--- a/src/modules/packetio/drivers/dpdk/port_feature_toggle.hpp
+++ b/src/modules/packetio/drivers/dpdk/port_feature_toggle.hpp
@@ -1,0 +1,70 @@
+#ifndef _OP_PACKETIO_DPDK_PORT_FEATURE_TOGGLE_HPP_
+#define _OP_PACKETIO_DPDK_PORT_FEATURE_TOGGLE_HPP_
+
+#include <cstdint>
+#include <variant>
+
+namespace openperf::packetio::dpdk::port {
+
+class null_feature
+{
+public:
+    null_feature(uint16_t port_id)
+        : m_port(port_id)
+    {}
+
+    uint16_t port_id() const { return (m_port); }
+
+    void enable(){};
+    void disable(){};
+
+private:
+    uint16_t m_port;
+};
+
+template <typename Derived, typename... Feature> class port_feature_toggle
+{
+public:
+    using variant_type = std::variant<Feature...>;
+
+    uint16_t port_id() const
+    {
+        auto id_visitor = [](auto& s) { return (s.port_id()); };
+        return (std::visit(id_visitor, get_feature()));
+    }
+
+    void enable()
+    {
+        if (!m_enabled) {
+            auto enable_visitor = [](auto& s) { s.enable(); };
+            std::visit(enable_visitor, get_feature());
+            m_enabled = true;
+        }
+    }
+
+    void disable()
+    {
+        if (m_enabled) {
+            auto disable_visitor = [](auto& s) { s.disable(); };
+            std::visit(disable_visitor, get_feature());
+            m_enabled = false;
+        }
+    }
+
+protected:
+    const variant_type& get_feature() const
+    {
+        return (static_cast<const Derived&>(*this).feature);
+    }
+
+    variant_type& get_feature()
+    {
+        return (static_cast<Derived&>(*this).feature);
+    }
+
+    bool m_enabled = false;
+};
+
+} // namespace openperf::packetio::dpdk::port
+
+#endif /* _OP_PACKETIO_DPDK_PORT_FEATURE_TOGGLE_HPP_ */

--- a/src/modules/packetio/drivers/dpdk/port_signature_decoder.cpp
+++ b/src/modules/packetio/drivers/dpdk/port_signature_decoder.cpp
@@ -1,0 +1,160 @@
+#include <algorithm>
+
+#include "core/op_log.h"
+#include "packetio/drivers/dpdk/dpdk.h"
+#include "packetio/drivers/dpdk/model/port_info.hpp"
+#include "packetio/drivers/dpdk/mbuf_signature.hpp"
+#include "packetio/drivers/dpdk/port_signature_decoder.hpp"
+#include "spirent_pga/api.h"
+#include "utils/soa_container.hpp"
+
+namespace openperf::packetio::dpdk::port {
+
+static constexpr auto chunk_size = 32U;
+static constexpr auto signature_size = 20U;
+
+template <typename T> using chunk_array = std::array<T, chunk_size>;
+
+static uint16_t detect_signatures([[maybe_unused]] uint16_t port_id,
+                                  [[maybe_unused]] uint16_t queue_id,
+                                  rte_mbuf* packets[],
+                                  uint16_t nb_packets,
+                                  [[maybe_unused]] uint16_t max_packets,
+                                  [[maybe_unused]] void* user_param)
+{
+    using payload_container =
+        utils::soa_container<chunk_array,
+                             std::tuple<const uint8_t*, std::byte[20]>>;
+    using sig_container =
+        utils::soa_container<chunk_array,
+                             std::tuple<uint32_t, uint32_t, uint64_t, int>>;
+
+    payload_container payloads;
+    sig_container signatures;
+    auto crc_matches = std::array<int, chunk_size>{};
+
+    auto start = 0U;
+    while (start < nb_packets) {
+        auto end = start + std::min(chunk_size, nb_packets - start);
+        auto count = end - start;
+
+        /*
+         * The spirent signature should start 20 bytes before the end of the
+         * packet, so generate an array of expected locations to check.
+         */
+        std::transform(packets + start,
+                       packets + end,
+                       payloads.data<1>(), /* storage */
+                       payloads.data<0>(), /* pointer */
+                       [&](const auto& mbuf, auto& storage) {
+                           return (static_cast<const uint8_t*>(rte_pktmbuf_read(
+                               mbuf,
+                               rte_pktmbuf_pkt_len(mbuf) - signature_size,
+                               signature_size,
+                               storage)));
+                       });
+
+        /* Look for signature candidates */
+        if (pga_signatures_crc_filter(
+                payloads.data<0>(), count, crc_matches.data())) {
+
+            /* Matches found; decode signatures */
+            pga_signatures_decode(payloads.data<0>(),
+                                  count,
+                                  signatures.data<0>(),  /* stream id */
+                                  signatures.data<1>(),  /* sequence num */
+                                  signatures.data<2>(),  /* timestamp */
+                                  signatures.data<3>()); /* flags */
+
+            /* Write valid signature data to the associated mbuf */
+            for (auto idx = 0U; idx < count; idx++) {
+                const auto& sig = signatures[idx];
+                if (crc_matches[idx]
+                    && (pga_status_flag(std::get<3>(sig))
+                        == pga_signature_status::valid)) {
+                    mbuf_signature_set(packets[start + idx],
+                                       std::get<0>(sig),
+                                       std::get<1>(sig),
+                                       std::get<2>(sig),
+                                       std::get<3>(sig));
+                }
+            }
+        }
+
+        start = end;
+    }
+
+    return (nb_packets);
+}
+
+callback_signature_decoder::callback_signature_decoder(uint16_t port_id)
+    : m_port(port_id)
+{}
+
+callback_signature_decoder::~callback_signature_decoder()
+{
+    if (m_callbacks.empty()) return;
+
+    std::for_each(
+        std::begin(m_callbacks), std::end(m_callbacks), [&](auto& item) {
+            rte_eth_remove_rx_callback(port_id(), item.first, item.second);
+        });
+}
+
+callback_signature_decoder::callback_signature_decoder(
+    callback_signature_decoder&& other)
+    : m_callbacks(std::move(other.m_callbacks))
+    , m_port(other.m_port)
+{}
+
+callback_signature_decoder&
+callback_signature_decoder::operator=(callback_signature_decoder&& other)
+{
+    if (this != &other) {
+        m_callbacks = std::move(other.m_callbacks);
+        m_port = other.m_port;
+    }
+
+    return (*this);
+}
+
+uint16_t callback_signature_decoder::port_id() const { return (m_port); }
+
+void callback_signature_decoder::enable()
+{
+    OP_LOG(OP_LOG_INFO,
+           "Enabling software Spirent signature detection on port %u\n",
+           m_port);
+
+    for (auto q = 0U; q < model::port_info(port_id()).rx_queue_count(); q++) {
+        auto cb =
+            rte_eth_add_rx_callback(port_id(), q, detect_signatures, nullptr);
+        if (!cb) {
+            throw std::runtime_error("Could not add timestamp callback");
+        }
+        m_callbacks.emplace(q, cb);
+    }
+}
+
+void callback_signature_decoder::disable()
+{
+    OP_LOG(OP_LOG_INFO,
+           "Disabling software Spirent signature detection on port %u\n",
+           m_port);
+
+    std::for_each(
+        std::begin(m_callbacks), std::end(m_callbacks), [&](auto& item) {
+            rte_eth_remove_rx_callback(port_id(), item.first, item.second);
+        });
+}
+
+static signature_decoder::variant_type make_signature_decoder(uint16_t port_id)
+{
+    return (callback_signature_decoder(port_id));
+}
+
+signature_decoder::signature_decoder(uint16_t port_id)
+    : feature(make_signature_decoder(port_id))
+{}
+
+} // namespace openperf::packetio::dpdk::port

--- a/src/modules/packetio/drivers/dpdk/port_signature_decoder.hpp
+++ b/src/modules/packetio/drivers/dpdk/port_signature_decoder.hpp
@@ -1,0 +1,44 @@
+#ifndef _OP_PACKETIO_DPDK_PORT_SIGNATURE_DECODER_HPP_
+#define _OP_PACKETIO_DPDK_PORT_SIGNATURE_DECODER_HPP_
+
+#include <map>
+
+#include "packetio/drivers/dpdk/port_feature_toggle.hpp"
+
+struct rte_eth_rxtx_callback;
+
+namespace openperf::packetio::dpdk::port {
+
+class callback_signature_decoder
+{
+public:
+    callback_signature_decoder(uint16_t port_id);
+    ~callback_signature_decoder();
+
+    callback_signature_decoder(callback_signature_decoder&&);
+    callback_signature_decoder& operator=(callback_signature_decoder&&);
+
+    uint16_t port_id() const;
+
+    void enable();
+    void disable();
+
+    using callback_map = std::map<uint16_t, const rte_eth_rxtx_callback*>;
+
+private:
+    callback_map m_callbacks;
+    uint16_t m_port;
+};
+
+struct signature_decoder
+    : port_feature_toggle<signature_decoder,
+                          callback_signature_decoder,
+                          null_feature>
+{
+    variant_type feature;
+    signature_decoder(uint16_t port_id);
+};
+
+} // namespace openperf::packetio::dpdk::port
+
+#endif /* _OP_PACKETIO_DPDK_PORT_SIGNATURE_DECODER_HPP_ */

--- a/src/modules/packetio/drivers/dpdk/port_signature_decoder.hpp
+++ b/src/modules/packetio/drivers/dpdk/port_signature_decoder.hpp
@@ -39,6 +39,17 @@ struct signature_decoder
     signature_decoder(uint16_t port_id);
 };
 
+namespace utils {
+
+/*
+ * Spirent signature fields use timestamps epochs that begin with
+ * the current year.  This function calculates the proper offset
+ * from the UNIX epoch.
+ */
+time_t get_timestamp_epoch_offset();
+
+} // namespace utils
+
 } // namespace openperf::packetio::dpdk::port
 
 #endif /* _OP_PACKETIO_DPDK_PORT_SIGNATURE_DECODER_HPP_ */

--- a/src/modules/packetio/drivers/dpdk/port_signature_decoder_utils.cpp
+++ b/src/modules/packetio/drivers/dpdk/port_signature_decoder_utils.cpp
@@ -1,0 +1,164 @@
+/*
+ *----------------------------------------------------------------------
+ * Copyright © 2005-2014 Rich Felker, et al.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * ----------------------------------------------------------------------
+ */
+
+#include <limits.h>
+#include <sys/time.h>
+
+#include "timesync/chrono.hpp"
+
+namespace openperf::packetio::dpdk::port::utils {
+
+namespace impl {
+
+/* 2000-03-01 (mod 400 year, immediately after feb29 */
+#define LEAPOCH (946684800LL + 86400 * (31 + 29))
+
+#define DAYS_PER_400Y (365 * 400 + 97)
+#define DAYS_PER_100Y (365 * 100 + 24)
+#define DAYS_PER_4Y (365 * 4 + 1)
+
+int seconds_to_year(time_t t)
+{
+    static const char days_in_month[] = {
+        31, 30, 31, 30, 31, 31, 30, 31, 30, 31, 31, 29};
+
+    /* Reject time_t values whose year would overflow int */
+    if (t < INT_MIN * 31622400LL || t > INT_MAX * 31622400LL) return -1;
+
+    auto secs = t - LEAPOCH;
+    auto days = secs / 86400;
+    auto remsecs = secs % 86400;
+    if (remsecs < 0) { days--; }
+
+    auto qc_cycles = days / DAYS_PER_400Y;
+    auto remdays = days % DAYS_PER_400Y;
+    if (remdays < 0) {
+        remdays += DAYS_PER_400Y;
+        qc_cycles--;
+    }
+
+    auto c_cycles = remdays / DAYS_PER_100Y;
+    if (c_cycles == 4) c_cycles--;
+    remdays -= c_cycles * DAYS_PER_100Y;
+
+    auto q_cycles = remdays / DAYS_PER_4Y;
+    if (q_cycles == 25) q_cycles--;
+    remdays -= q_cycles * DAYS_PER_4Y;
+
+    auto remyears = remdays / 365;
+    if (remyears == 4) remyears--;
+    remdays -= remyears * 365;
+
+    auto years = remyears + 4 * q_cycles + 100 * c_cycles + 400 * qc_cycles;
+
+    auto months = 0;
+    for (; days_in_month[months] <= remdays; months++)
+        remdays -= days_in_month[months];
+
+    if (years + 100 > INT_MAX || years + 100 < INT_MIN) return -1;
+
+    /*
+     * Need to account for using February as the last month in this
+     * calculation.
+     */
+    return (static_cast<int>(years + 100 + (months + 2 >= 12 ? 1 : 0)));
+}
+
+time_t year_to_seconds(int year)
+{
+    bool is_leap = false;
+    if (year - 2ULL <= 136) {
+        int y = year;
+        int leaps = (y - 68) >> 2;
+        if (!((y - 68) & 3)) { leaps--; }
+        return 31536000 * (y - 70) + 86400 * leaps;
+    }
+
+    int cycles, centuries, leaps, rem;
+
+    cycles = (year - 100) / 400;
+    rem = (year - 100) % 400;
+    if (rem < 0) {
+        cycles--;
+        rem += 400;
+    }
+    if (!rem) {
+        is_leap = true;
+        centuries = 0;
+        leaps = 0;
+    } else {
+        if (rem >= 200) {
+            if (rem >= 300)
+                centuries = 3, rem -= 300;
+            else
+                centuries = 2, rem -= 200;
+        } else {
+            if (rem >= 100)
+                centuries = 1, rem -= 100;
+            else
+                centuries = 0;
+        }
+        if (!rem) {
+            is_leap = false;
+            leaps = 0;
+        } else {
+            leaps = rem / 4;
+            rem %= 4;
+            is_leap = !rem;
+        }
+    }
+
+    leaps += 97 * cycles + 24 * centuries - (is_leap ? 1 : 0);
+
+    return (year - 100) * 31536000LL + leaps * 86400LL + 946684800 + 86400;
+}
+
+} // namespace impl
+
+/*
+ * Both of the utility functions above were intended for use with
+ * `tm structs` as used by the standard C library.  Hence, we need
+ * to offset the year by 1900.
+ */
+static constexpr auto impl_offset = 1900;
+
+static int seconds_to_year(time_t seconds)
+{
+    return (impl::seconds_to_year(seconds) + impl_offset);
+}
+
+static time_t year_to_seconds(int year)
+{
+    return (impl::year_to_seconds(year - impl_offset));
+}
+
+time_t get_timestamp_epoch_offset()
+{
+    using clock = timesync::chrono::realtime;
+
+    return (year_to_seconds(seconds_to_year(clock::to_time_t(clock::now()))));
+}
+
+} // namespace openperf::packetio::dpdk::port::utils

--- a/src/modules/packetio/drivers/dpdk/port_timestamper.cpp
+++ b/src/modules/packetio/drivers/dpdk/port_timestamper.cpp
@@ -1,0 +1,159 @@
+#include <chrono>
+
+#include "core/op_log.h"
+#include "packetio/drivers/dpdk/dpdk.h"
+#include "packetio/drivers/dpdk/model/port_info.hpp"
+#include "packetio/drivers/dpdk/port_timestamper.hpp"
+#include "timesync/chrono.hpp"
+#include "units/data-rates.hpp"
+
+namespace openperf::packetio::dpdk::port {
+
+static uint16_t timestamp_packets(uint16_t port_id,
+                                  [[maybe_unused]] uint16_t queue_id,
+                                  rte_mbuf* packets[],
+                                  uint16_t nb_packets,
+                                  [[maybe_unused]] uint16_t max_packets,
+                                  [[maybe_unused]] void* user_param)
+{
+    using namespace openperf::units;
+    using clock = openperf::timesync::chrono::realtime;
+
+    static constexpr auto ethernet_bytes = 8U;
+    static constexpr auto ethernet_overhead = 20U;
+    static constexpr auto ethernet_quanta = 64U;
+
+    /* Find the current link speed */
+    struct rte_eth_link link;
+    rte_eth_link_get_nowait(port_id, &link);
+
+    /*
+     * Calculate nanoseconds per quanta;
+     * nanoseconds per byte is less than 1 nanosecond at 100G speeds!
+     * (and hence, too small for us to use)
+     */
+    using bps = rate<uint64_t>;
+    using mbps = rate<uint64_t, megabits>;
+
+    auto ns_per_quanta = to_duration<std::chrono::nanoseconds>(
+        rate_cast<bps>(mbps(link.link_speed))
+        / (ethernet_bytes * ethernet_quanta));
+
+    /*
+     * Iterate through the packet array in reverse order.  For each packet,
+     * increase the offset by the transmit time for that packet.
+     * This allows us to calculate the maximum realistic receive timestamp
+     * for each packet.
+     */
+    auto now = clock::now().time_since_epoch();
+    auto offset = clock::duration::zero();
+
+    std::for_each(std::make_reverse_iterator(packets + nb_packets),
+                  std::make_reverse_iterator(packets),
+                  [&](auto& m) {
+                      m->timestamp = (now - offset).count();
+                      offset += ns_per_quanta
+                                * (rte_pktmbuf_pkt_len(m) + ethernet_overhead)
+                                / ethernet_quanta;
+                  });
+
+    return (nb_packets);
+}
+
+callback_timestamper::callback_timestamper(uint16_t port_id)
+    : m_port(port_id)
+{}
+
+callback_timestamper::~callback_timestamper()
+{
+    if (m_callbacks.empty()) return;
+
+    std::for_each(
+        std::begin(m_callbacks), std::end(m_callbacks), [&](auto& item) {
+            rte_eth_remove_rx_callback(port_id(), item.first, item.second);
+        });
+}
+
+callback_timestamper::callback_timestamper(callback_timestamper&& other)
+    : m_callbacks(std::move(other.m_callbacks))
+    , m_port(other.m_port)
+{}
+
+callback_timestamper&
+callback_timestamper::operator=(callback_timestamper&& other)
+{
+    if (this != &other) {
+        m_callbacks = std::move(other.m_callbacks);
+        m_port = other.m_port;
+    }
+
+    return (*this);
+}
+
+uint16_t callback_timestamper::port_id() const { return (m_port); }
+
+void callback_timestamper::enable()
+{
+    OP_LOG(OP_LOG_INFO,
+           "Enabling software packet timestamps on port %u\n",
+           m_port);
+
+    for (auto q = 0U; q < model::port_info(port_id()).rx_queue_count(); q++) {
+        auto cb = rte_eth_add_first_rx_callback(
+            port_id(), q, timestamp_packets, nullptr);
+        if (!cb) {
+            throw std::runtime_error("Could not add timestamp callback");
+        }
+        m_callbacks.emplace(q, cb);
+    }
+}
+
+void callback_timestamper::disable()
+{
+    OP_LOG(OP_LOG_INFO,
+           "Disabling software packet timestamps on port %u\n",
+           m_port);
+
+    std::for_each(
+        std::begin(m_callbacks), std::end(m_callbacks), [&](auto& item) {
+            rte_eth_remove_rx_callback(port_id(), item.first, item.second);
+        });
+}
+
+null_timestamper::null_timestamper(uint16_t port_id)
+    : m_port(port_id)
+{}
+
+uint16_t null_timestamper::port_id() const { return (m_port); }
+
+void null_timestamper::enable() {}
+void null_timestamper::disable() {}
+
+static timestamper::timestamper_strategy make_timestamper(uint16_t port_id)
+{
+    return (callback_timestamper(port_id));
+}
+
+timestamper::timestamper(uint16_t port_id)
+    : m_timestamper(make_timestamper(port_id))
+{}
+
+uint16_t timestamper::port_id() const
+{
+    auto id_visitor = [](auto& stamper) { return stamper.port_id(); };
+    return (std::visit(id_visitor, m_timestamper));
+}
+
+void timestamper::enable()
+{
+    auto enable_visitor = [](auto& stamper) { return stamper.enable(); };
+    std::visit(enable_visitor, m_timestamper);
+}
+
+void timestamper::disable()
+{
+    auto disable_visitor = [](auto& stamper) { return stamper.disable(); };
+    std::visit(disable_visitor, m_timestamper);
+}
+
+} // namespace openperf::packetio::dpdk::port

--- a/src/modules/packetio/drivers/dpdk/port_timestamper.hpp
+++ b/src/modules/packetio/drivers/dpdk/port_timestamper.hpp
@@ -1,0 +1,65 @@
+#ifndef _OP_PACKETIO_DPDK_PORT_TIMESTAMPER_HPP_
+#define _OP_PACKETIO_DPDK_PORT_TIMESTAMPER_HPP_
+
+#include <map>
+#include <variant>
+
+struct rte_eth_rxtx_callback;
+
+namespace openperf::packetio::dpdk::port {
+
+class callback_timestamper
+{
+public:
+    callback_timestamper(uint16_t port_id);
+    ~callback_timestamper();
+
+    callback_timestamper(callback_timestamper&&);
+    callback_timestamper& operator=(callback_timestamper&&);
+
+    uint16_t port_id() const;
+
+    void enable();
+    void disable();
+
+    using callback_map = std::map<uint16_t, const rte_eth_rxtx_callback*>;
+
+private:
+    callback_map m_callbacks;
+    uint16_t m_port;
+};
+
+class null_timestamper
+{
+public:
+    null_timestamper(uint16_t port_id);
+
+    uint16_t port_id() const;
+
+    void enable();
+    void disable();
+
+private:
+    uint16_t m_port;
+};
+
+class timestamper
+{
+public:
+    timestamper(uint16_t port_id);
+
+    uint16_t port_id() const;
+
+    void enable();
+    void disable();
+
+    using timestamper_strategy =
+        std::variant<callback_timestamper, null_timestamper>;
+
+private:
+    timestamper_strategy m_timestamper;
+};
+
+} // namespace openperf::packetio::dpdk::port
+
+#endif /* _OP_PACKETIO_DPDK_PORT_TIMESTAMPER_HPP_ */

--- a/src/modules/packetio/drivers/dpdk/port_timestamper.hpp
+++ b/src/modules/packetio/drivers/dpdk/port_timestamper.hpp
@@ -2,7 +2,8 @@
 #define _OP_PACKETIO_DPDK_PORT_TIMESTAMPER_HPP_
 
 #include <map>
-#include <variant>
+
+#include "packetio/drivers/dpdk/port_feature_toggle.hpp"
 
 struct rte_eth_rxtx_callback;
 
@@ -29,35 +30,11 @@ private:
     uint16_t m_port;
 };
 
-class null_timestamper
+struct timestamper
+    : port_feature_toggle<timestamper, callback_timestamper, null_feature>
 {
-public:
-    null_timestamper(uint16_t port_id);
-
-    uint16_t port_id() const;
-
-    void enable();
-    void disable();
-
-private:
-    uint16_t m_port;
-};
-
-class timestamper
-{
-public:
+    variant_type feature;
     timestamper(uint16_t port_id);
-
-    uint16_t port_id() const;
-
-    void enable();
-    void disable();
-
-    using timestamper_strategy =
-        std::variant<callback_timestamper, null_timestamper>;
-
-private:
-    timestamper_strategy m_timestamper;
 };
 
 } // namespace openperf::packetio::dpdk::port

--- a/src/modules/packetio/generic_sink.hpp
+++ b/src/modules/packetio/generic_sink.hpp
@@ -5,9 +5,17 @@
 #include <memory>
 #include <string>
 
+#include "utils/enum_flags.hpp"
+
 namespace openperf::packetio::packets {
 
 struct packet_buffer;
+
+enum class sink_feature_flags {
+    none = 0,
+    rx_timestamp = (1 << 0),
+    spirent_signature_decode = (1 << 1),
+};
 
 class generic_sink
 {
@@ -22,6 +30,11 @@ public:
     uint16_t push(packet_buffer* const packets[], uint16_t length) const
     {
         return (m_self->push(packets, length));
+    }
+
+    bool uses_feature(enum sink_feature_flags flags) const
+    {
+        return (m_self->uses_feature(flags));
     }
 
     bool operator==(const generic_sink& other) const
@@ -39,6 +52,7 @@ private:
     {
         virtual ~sink_concept() = default;
         virtual std::string id() const = 0;
+        virtual bool uses_feature(enum sink_feature_flags) const = 0;
         virtual uint16_t push(packet_buffer* const packets[],
                               uint16_t length) = 0;
         virtual std::any get_pointer() noexcept = 0;
@@ -51,6 +65,11 @@ private:
         {}
 
         std::string id() const override { return (m_sink.id()); }
+
+        bool uses_feature(enum sink_feature_flags flags) const override
+        {
+            return (m_sink.uses_feature(flags));
+        }
 
         uint16_t push(packet_buffer* const packets[], uint16_t length) override
         {
@@ -69,5 +88,7 @@ private:
 };
 
 } // namespace openperf::packetio::packets
+
+declare_enum_flags(openperf::packetio::packets::sink_feature_flags);
 
 #endif /* _OP_PACKETIO_GENERIC_SINK_HPP_ */

--- a/src/modules/packetio/generic_sink.hpp
+++ b/src/modules/packetio/generic_sink.hpp
@@ -27,6 +27,8 @@ public:
 
     std::string id() const { return (m_self->id()); }
 
+    bool active() const { return (m_self->active()); }
+
     uint16_t push(packet_buffer* const packets[], uint16_t length) const
     {
         return (m_self->push(packets, length));
@@ -52,6 +54,7 @@ private:
     {
         virtual ~sink_concept() = default;
         virtual std::string id() const = 0;
+        virtual bool active() const = 0;
         virtual bool uses_feature(enum sink_feature_flags) const = 0;
         virtual uint16_t push(packet_buffer* const packets[],
                               uint16_t length) = 0;
@@ -65,6 +68,8 @@ private:
         {}
 
         std::string id() const override { return (m_sink.id()); }
+
+        bool active() const override { return (m_sink.active()); }
 
         bool uses_feature(enum sink_feature_flags flags) const override
         {

--- a/src/modules/packetio/memory/dpdk/packet_buffer.cpp
+++ b/src/modules/packetio/memory/dpdk/packet_buffer.cpp
@@ -21,6 +21,12 @@ uint16_t length(const packet_buffer* buffer)
     return (rte_pktmbuf_pkt_len(buffer));
 }
 
+timesync::chrono::realtime::time_point timestamp(const packet_buffer* buffer)
+{
+    using clock = openperf::timesync::chrono::realtime;
+    return (clock::time_point{clock::duration{buffer->timestamp}});
+}
+
 void length(packet_buffer* buffer, uint16_t size)
 {
     rte_pktmbuf_data_len(buffer) = size;

--- a/src/modules/packetio/memory/dpdk/packet_buffer.cpp
+++ b/src/modules/packetio/memory/dpdk/packet_buffer.cpp
@@ -27,6 +27,8 @@ timesync::chrono::realtime::time_point timestamp(const packet_buffer* buffer)
     return (clock::time_point{clock::duration{buffer->timestamp}});
 }
 
+uint32_t rss_hash(const packet_buffer* buffer) { return (buffer->hash.rss); }
+
 void length(packet_buffer* buffer, uint16_t size)
 {
     rte_pktmbuf_data_len(buffer) = size;

--- a/src/modules/packetio/memory/dpdk/packet_buffer.cpp
+++ b/src/modules/packetio/memory/dpdk/packet_buffer.cpp
@@ -1,4 +1,5 @@
 #include "packetio/drivers/dpdk/dpdk.h"
+#include "packetio/drivers/dpdk/mbuf_signature.hpp"
 #include "packetio/packet_buffer.hpp"
 
 namespace openperf::packetio::packets {
@@ -21,13 +22,39 @@ uint16_t length(const packet_buffer* buffer)
     return (rte_pktmbuf_pkt_len(buffer));
 }
 
-timesync::chrono::realtime::time_point timestamp(const packet_buffer* buffer)
+timesync::chrono::realtime::time_point rx_timestamp(const packet_buffer* buffer)
 {
     using clock = openperf::timesync::chrono::realtime;
     return (clock::time_point{clock::duration{buffer->timestamp}});
 }
 
 uint32_t rss_hash(const packet_buffer* buffer) { return (buffer->hash.rss); }
+
+uint32_t type(const packet_buffer* buffer) { return (buffer->packet_type); }
+
+std::optional<uint32_t> signature_stream_id(const packet_buffer* buffer)
+{
+    return (dpdk::mbuf_signature_avail(buffer)
+                ? std::make_optional(dpdk::mbuf_signature_stream_id_get(buffer))
+                : std::nullopt);
+}
+
+std::optional<uint32_t> signature_sequence_number(const packet_buffer* buffer)
+{
+    return (dpdk::mbuf_signature_avail(buffer)
+                ? std::make_optional(dpdk::mbuf_signature_seq_num_get(buffer))
+                : std::nullopt);
+}
+
+std::optional<timesync::chrono::realtime::time_point>
+signature_tx_timestamp(const packet_buffer* buffer)
+{
+    using clock = openperf::timesync::chrono::realtime;
+    return (dpdk::mbuf_signature_avail(buffer)
+                ? std::make_optional(clock::time_point{clock::duration{
+                    dpdk::mbuf_signature_timestamp_get(buffer)}})
+                : std::nullopt);
+}
 
 void length(packet_buffer* buffer, uint16_t size)
 {

--- a/src/modules/packetio/packet_buffer.hpp
+++ b/src/modules/packetio/packet_buffer.hpp
@@ -4,6 +4,8 @@
 #include <cstdint>
 #include <cstddef>
 
+#include "timesync/chrono.hpp"
+
 namespace openperf::packetio::packets {
 
 struct packet_buffer;
@@ -12,6 +14,8 @@ uint16_t max_length(const packet_buffer* buffer);
 
 uint16_t length(const packet_buffer* buffer);
 void length(packet_buffer*, uint16_t length);
+
+timesync::chrono::realtime::time_point timestamp(const packet_buffer* buffer);
 
 void* to_data(packet_buffer* buffer);
 const void* to_data(const packet_buffer* buffer);

--- a/src/modules/packetio/packet_buffer.hpp
+++ b/src/modules/packetio/packet_buffer.hpp
@@ -3,6 +3,7 @@
 
 #include <cstdint>
 #include <cstddef>
+#include <optional>
 
 #include "timesync/chrono.hpp"
 
@@ -15,9 +16,19 @@ uint16_t max_length(const packet_buffer* buffer);
 uint16_t length(const packet_buffer* buffer);
 void length(packet_buffer*, uint16_t length);
 
-timesync::chrono::realtime::time_point timestamp(const packet_buffer* buffer);
+timesync::chrono::realtime::time_point
+rx_timestamp(const packet_buffer* buffer);
 
 uint32_t rss_hash(const packet_buffer* buffer);
+
+uint32_t type(const packet_buffer* buffer);
+
+std::optional<uint32_t> signature_stream_id(const packet_buffer* buffer);
+
+std::optional<uint32_t> signature_sequence_number(const packet_buffer* buffer);
+
+std::optional<timesync::chrono::realtime::time_point>
+signature_tx_timestamp(const packet_buffer* buffer);
 
 void* to_data(packet_buffer* buffer);
 const void* to_data(const packet_buffer* buffer);

--- a/src/modules/packetio/packet_buffer.hpp
+++ b/src/modules/packetio/packet_buffer.hpp
@@ -17,6 +17,8 @@ void length(packet_buffer*, uint16_t length);
 
 timesync::chrono::realtime::time_point timestamp(const packet_buffer* buffer);
 
+uint32_t rss_hash(const packet_buffer* buffer);
+
 void* to_data(packet_buffer* buffer);
 const void* to_data(const packet_buffer* buffer);
 

--- a/src/modules/packetio/workers/dpdk/recycle_impl.cpp
+++ b/src/modules/packetio/workers/dpdk/recycle_impl.cpp
@@ -1,5 +1,5 @@
 #include "packetio/drivers/dpdk/dpdk.h"
-#include "packetio/recycle.tcc"
+#include "utils/recycle.tcc"
 
-template class openperf::packetio::recycle::depot<RTE_MAX_LCORE>;
-template class openperf::packetio::recycle::guard<RTE_MAX_LCORE>;
+template class openperf::utils::recycle::depot<RTE_MAX_LCORE>;
+template class openperf::utils::recycle::guard<RTE_MAX_LCORE>;

--- a/src/modules/packetio/workers/dpdk/worker.cpp
+++ b/src/modules/packetio/workers/dpdk/worker.cpp
@@ -433,8 +433,7 @@ static void run_pollable(run_args&& args)
     while (!messages) {
         auto& events = poller.poll();
         {
-            auto guard =
-                packetio::recycle::guard(*args.recycler, rte_lcore_id());
+            auto guard = utils::recycle::guard(*args.recycler, rte_lcore_id());
             for (auto& event : events) {
                 std::visit(
                     utils::overloaded_visitor(

--- a/src/modules/packetio/workers/dpdk/worker.cpp
+++ b/src/modules/packetio/workers/dpdk/worker.cpp
@@ -222,6 +222,8 @@ static void rx_sink_dispatch(const fib* fib,
                              uint16_t n)
 {
     for (auto& sink : fib->get_sinks(rxq->port_id())) {
+        if (!sink.active()) { continue; }
+
         OP_LOG(OP_LOG_TRACE,
                "Dispatching packets to sink %s\n",
                sink.id().c_str());

--- a/src/modules/packetio/workers/dpdk/worker_api.hpp
+++ b/src/modules/packetio/workers/dpdk/worker_api.hpp
@@ -11,9 +11,9 @@
 #include "packetio/drivers/dpdk/dpdk.h"
 #include "packetio/forwarding_table.hpp"
 #include "packetio/generic_sink.hpp"
-#include "packetio/recycle.hpp"
 #include "packetio/transmit_table.hpp"
 #include "packetio/workers/dpdk/tx_source.hpp"
+#include "utils/recycle.hpp"
 
 namespace openperf::packetio::dpdk {
 class callback;
@@ -29,7 +29,7 @@ static constexpr uint16_t pkt_burst_size = 64;
 using fib =
     packetio::forwarding_table<netif, packets::generic_sink, RTE_MAX_ETHPORTS>;
 using tib = packetio::transmit_table<dpdk::tx_source>;
-using recycler = packetio::recycle::depot<RTE_MAX_LCORE>;
+using recycler = utils::recycle::depot<RTE_MAX_LCORE>;
 
 /**
  * The types of things workers know how to deal with.

--- a/src/modules/packetio/workers/dpdk/worker_controller.hpp
+++ b/src/modules/packetio/workers/dpdk/worker_controller.hpp
@@ -11,10 +11,13 @@
 #include "packetio/generic_event_loop.hpp"
 #include "packetio/generic_workers.hpp"
 #include "packetio/drivers/dpdk/port_filter.hpp"
+#include "packetio/drivers/dpdk/port_timestamper.hpp"
 #include "packetio/workers/dpdk/callback.hpp"
 #include "packetio/workers/dpdk/tx_scheduler.hpp"
 #include "packetio/workers/dpdk/worker_api.hpp"
 #include "utils/hash_combine.hpp"
+
+struct rte_eth_rxtx_callback;
 
 namespace openperf::core {
 class event_loop;
@@ -69,11 +72,14 @@ public:
     void del_task(std::string_view task_id);
 
     using load_map = std::unordered_map<unsigned, uint64_t>;
+    using rx_callback_map =
+        std::map<std::pair<uint16_t, uint16_t>, rte_eth_rxtx_callback*>;
     using task_map = std::unordered_map<core::uuid, callback>;
     using worker_map = std::map<std::pair<uint16_t, uint16_t>, unsigned>;
 
     using txsched_ptr = std::unique_ptr<tx_scheduler>;
     using filter_ptr = std::unique_ptr<port::filter>;
+    using timestamper_ptr = std::unique_ptr<port::timestamper>;
 
 private:
     void* m_context;                              /* 0MQ context */
@@ -89,7 +95,8 @@ private:
     load_map m_tx_loads;     /* map from worker id --> worker load */
     worker_map m_tx_workers; /* map from (port id, queue id) --> worker id */
 
-    std::vector<filter_ptr> m_filters; /* Port filters */
+    std::vector<filter_ptr> m_filters;           /* Port filters */
+    std::vector<timestamper_ptr> m_timestampers; /* Port timestampers */
 };
 
 } // namespace openperf::packetio::dpdk

--- a/src/modules/packetio/workers/dpdk/worker_controller.hpp
+++ b/src/modules/packetio/workers/dpdk/worker_controller.hpp
@@ -11,6 +11,7 @@
 #include "packetio/generic_event_loop.hpp"
 #include "packetio/generic_workers.hpp"
 #include "packetio/drivers/dpdk/port_filter.hpp"
+#include "packetio/drivers/dpdk/port_signature_decoder.hpp"
 #include "packetio/drivers/dpdk/port_timestamper.hpp"
 #include "packetio/workers/dpdk/callback.hpp"
 #include "packetio/workers/dpdk/tx_scheduler.hpp"
@@ -79,9 +80,12 @@ public:
 
     using txsched_ptr = std::unique_ptr<tx_scheduler>;
     using filter_ptr = std::unique_ptr<port::filter>;
+    using sigdecoder_ptr = std::unique_ptr<port::signature_decoder>;
     using timestamper_ptr = std::unique_ptr<port::timestamper>;
 
 private:
+    void maybe_update_sink_features(size_t port_idx);
+
     void* m_context;                              /* 0MQ context */
     driver::generic_driver& m_driver;             /* generic driver reference */
     std::unique_ptr<worker::client> m_workers;    /* worker command client */
@@ -96,6 +100,7 @@ private:
     worker_map m_tx_workers; /* map from (port id, queue id) --> worker id */
 
     std::vector<filter_ptr> m_filters;           /* Port filters */
+    std::vector<sigdecoder_ptr> m_sigdecoders;   /* Port signature decoders */
     std::vector<timestamper_ptr> m_timestampers; /* Port timestampers */
 };
 

--- a/src/modules/timesync/chrono.hpp
+++ b/src/modules/timesync/chrono.hpp
@@ -99,6 +99,20 @@ struct realtime
 
         return (time_point(to_duration(bt + th->offset)));
     }
+
+    static std::time_t to_time_t(const time_point& tp) noexcept
+    {
+        return (std::time_t(std::chrono::duration_cast<std::chrono::seconds>(
+                                tp.time_since_epoch())
+                                .count()));
+    }
+
+    static time_point from_time_t(std::time_t t) noexcept
+    {
+        using from_t = std::chrono::time_point<realtime, std::chrono::seconds>;
+        return (std::chrono::time_point_cast<realtime::duration>(
+            from_t{std::chrono::seconds{t}}));
+    }
 };
 
 struct monotime

--- a/src/modules/timesync/socket.cpp
+++ b/src/modules/timesync/socket.cpp
@@ -77,7 +77,7 @@ static bintime get_clock_offset()
 
     std::generate_n(offsets.data(), offset_calc_trials, []() {
         using sys_clock = std::chrono::high_resolution_clock;
-        using ref_clock = timesync::chrono::realtime;
+        using ref_clock = timesync::chrono::monotime;
         auto x1 = sys_clock::now();
         auto x2 = ref_clock::now();
         auto y1 = ref_clock::now();
@@ -117,7 +117,7 @@ static bintime get_clock_offset()
 static counter::ticks to_ticks(const timeval& tv)
 {
     auto local_ts = to_bintime(tv) - get_clock_offset();
-    auto [ref_time, ref_ticks] = chrono::realtime_ticks();
+    auto [ref_time, ref_ticks] = chrono::monotime_ticks();
     auto delta = ref_time - local_ts;
     auto freq = counter::frequency().count();
     auto dt = freq * delta.bt_sec + ((freq * (delta.bt_frac >> 32)) >> 32);

--- a/tests/unit/framework/directory.mk
+++ b/tests/unit/framework/directory.mk
@@ -17,6 +17,7 @@ TEST_SOURCES += \
 	framework/test_ipv4_network.cpp \
 	framework/test_offset_ptr.cpp \
 	framework/test_recycle.cpp \
+	framework/test_soa_container.cpp \
 	framework/test_std_allocator.cpp \
 	framework/test_task.cpp \
 	framework/test_units_rate.cpp \

--- a/tests/unit/framework/directory.mk
+++ b/tests/unit/framework/directory.mk
@@ -16,6 +16,7 @@ TEST_SOURCES += \
 	framework/test_ipv4_address.cpp \
 	framework/test_ipv4_network.cpp \
 	framework/test_offset_ptr.cpp \
+	framework/test_recycle.cpp \
 	framework/test_std_allocator.cpp \
 	framework/test_task.cpp \
 	framework/test_units_rate.cpp \

--- a/tests/unit/framework/test_recycle.cpp
+++ b/tests/unit/framework/test_recycle.cpp
@@ -1,10 +1,10 @@
 #include "catch.hpp"
 
-#include "packetio/recycle.tcc"
+#include "utils/recycle.tcc"
 
-template class openperf::packetio::recycle::depot<2>;
+template class openperf::utils::recycle::depot<2>;
 
-using recycler = openperf::packetio::recycle::depot<2>;
+using recycler = openperf::utils::recycle::depot<2>;
 
 TEST_CASE("recycler functionality", "[recycler]")
 {
@@ -29,7 +29,7 @@ TEST_CASE("recycler functionality", "[recycler]")
 
         bool gc_fired = false;
         {
-            openperf::packetio::recycle::guard guard(depot, 0);
+            openperf::utils::recycle::guard guard(depot, 0);
             depot.writer_add_gc_callback([&]() { gc_fired = true; });
             depot.writer_process_gc_callbacks();
 

--- a/tests/unit/framework/test_soa_container.cpp
+++ b/tests/unit/framework/test_soa_container.cpp
@@ -1,0 +1,55 @@
+#include "catch.hpp"
+
+#include "utils/soa_container.hpp"
+
+TEST_CASE("soa container", "[framework]")
+{
+    using test_container =
+        openperf::utils::soa_container<std::vector, std::tuple<int, double>>;
+
+    SECTION("can store tuples, ")
+    {
+        test_container container;
+        container.push_back({1, 1.1});
+        container.push_back({2, 2.1});
+        container.push_back({3, 3.1});
+
+        REQUIRE(container.size() == 3);
+
+        SECTION("can iterate container as struct, ")
+        {
+            auto nb_items = 0;
+            for (const auto& item : container) {
+                REQUIRE_NOTHROW(std::get<0>(item));
+                REQUIRE_NOTHROW(std::get<1>(item));
+                nb_items++;
+            }
+
+            REQUIRE(nb_items == 3);
+        }
+
+        SECTION("can iterate container as array, ")
+        {
+            auto start0 = container.data<0>();
+            REQUIRE(std::accumulate(start0, start0 + container.size(), 0) == 6);
+
+            auto start1 = container.data<1>();
+            REQUIRE(std::accumulate(start1, start1 + container.size(), 0.0)
+                    == Approx(6.3));
+        }
+    }
+
+    SECTION("can compare containers, ")
+    {
+        test_container c1;
+        c1.push_back({1, 1.1});
+
+        test_container c2;
+        c2.push_back({1, 1.1});
+
+        REQUIRE(c1 == c2);
+
+        c2.push_back({2, 2.1});
+        REQUIRE(c1 != c2);
+    }
+}

--- a/tests/unit/modules/packetio/directory.mk
+++ b/tests/unit/modules/packetio/directory.mk
@@ -6,5 +6,4 @@ TEST_DEPENDS += packetio_test
 
 TEST_SOURCES += \
 	modules/packetio/test_forwarding_table.cpp \
-	modules/packetio/test_recycle.cpp \
 	modules/packetio/test_transmit_table.cpp


### PR DESCRIPTION
This PR includes all of the changes needed to allow the analyzer module to do its job.  It's a mix of new features along with bug fixes and tweaks in existing code.

New features:
* Packetio callback to timestamp received packets
* Packetio callback to detect/decode Spirent signatures (using the library from part 1)
* Ability to dynamically add/remove callbacks as needed

New utilities:
* SoA containers - syntactic sugar for tuples of vectors
* Generic memoization utility

Bug fixes:
Fix the real-time clock; it was discontinuous and shouldn't have been

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/192)
<!-- Reviewable:end -->
