### PR TITLE
block: Fix intermittent file permission errors

### DIFF
--- a/src/modules/block/file_stack.cpp
+++ b/src/modules/block/file_stack.cpp
@@ -26,7 +26,8 @@ tl::expected<int, int> file::vopen()
 {
     if (m_fd >= 0) return m_fd;
 
-    if ((m_fd = open(get_path().c_str(), O_RDWR | O_CREAT)) < 0) {
+    if ((m_fd = open(get_path().c_str(), O_RDWR | O_CREAT,
+                     S_IRUSR | S_IWUSR)) < 0) {
         return tl::make_unexpected(errno);
     }
 


### PR DESCRIPTION
mode parameter is required when O_CREAT flag is used

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/216)
<!-- Reviewable:end -->
