### PR TITLE
Update ISPC verison and link in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,10 @@ RUN apt-get clean && \
     lld-${LLVM_VERSION} bear
 
 # Install Intel SPMD Program Compiler (ISPC)
-ENV ISPC_VERSION 1.12.0
-RUN wget -q -O - https://sourceforge.net/projects/ispcmirror/files/v${ISPC_VERSION}/ispc-v${ISPC_VERSION}-linux.tar.gz \
+ENV ISPC_VERSION 1.13.0
+RUN wget -q -O - https://github.com/ispc/ispc/releases/download/v${ISPC_VERSION}/ispc-v${ISPC_VERSION}-linux.tar.gz \
     | tar -C /opt -xvz && \
+    chown -R root:root /opt/ispc-v${ISPC_VERSION}-linux/bin/ispc && \
     ln -s /opt/ispc-v${ISPC_VERSION}-linux/bin/ispc /usr/local/bin/ispc
 
 # Fix up toolchain names


### PR DESCRIPTION
ISPC binaries can now be directly downloaded from github, so do so.
Also, bump the version while here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/220)
<!-- Reviewable:end -->
