### PR TITLE
modules/block: improve startup logging

### DIFF
--- a/src/modules/block/device_stack.hpp
+++ b/src/modules/block/device_stack.hpp
@@ -33,7 +33,6 @@ private:
     void init_device_stack();
     uint64_t get_block_device_size(std::string_view id);
     std::optional<std::string> get_block_device_info(std::string_view id);
-    int is_block_device_usable(std::string_view id);
     bool is_raw_device(std::string_view id);
 
 public:


### PR DESCRIPTION
On startup, the block module attempts to query various devices for block
load testing. If the user lacks permission to access a block device,
then just skip the device instead of logging an error.  Also, only log
block device size errors once. There's no need to repeat the same error
twice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/227)
<!-- Reviewable:end -->
