### PR TITLE
modules/api: don't block startup

### DIFF
--- a/src/modules/api/api_config_file_resources.cpp
+++ b/src/modules/api/api_config_file_resources.cpp
@@ -31,6 +31,9 @@ tl::expected<void, std::string> op_config_file_process_resources()
     for (auto&& resource : root_node["resources"]) {
         auto [path, id] = op_config_split_path_id(resource.first.Scalar());
 
+        auto ready = utils::check_api_path_ready(path);
+        if (!ready) return (ready);
+
         // Verify we have a valid id.
         auto valid_id = openperf::config::op_config_validate_id_string(id);
         if (!valid_id)

--- a/src/modules/api/api_utils.cpp
+++ b/src/modules/api/api_utils.cpp
@@ -64,14 +64,13 @@ static tl::expected<void, std::string> check_api_port()
 }
 
 // Is the API able to retrieve a resource?
-static tl::expected<void, std::string> check_api_resource()
+tl::expected<void, std::string> check_api_path_ready(std::string_view path)
 {
     unsigned int poll_count = 0;
     bool done = false;
 
     for (; (poll_count < max_poll_count) && !done; poll_count++) {
-        auto [code, body] =
-            openperf::api::client::internal_api_get(api_check_resource);
+        auto [code, body] = openperf::api::client::internal_api_get(path);
         if (code == Pistache::Http::Code::Ok) {
             done = true;
             break;
@@ -84,7 +83,7 @@ static tl::expected<void, std::string> check_api_resource()
     if (!done) {
         return (tl::make_unexpected("Error starting up internal API client. "
                                     "Could not retrieve resource: "
-                                    + std::string(api_check_resource)));
+                                    + std::string(path)));
     }
 
     return {};
@@ -95,7 +94,7 @@ tl::expected<void, std::string> check_api_module_running()
     auto result = check_api_port();
     if (!result) return (result);
 
-    result = check_api_resource();
+    result = check_api_path_ready(api_check_resource);
     if (!result) return (result);
 
     return {};

--- a/src/modules/api/api_utils.hpp
+++ b/src/modules/api/api_utils.hpp
@@ -1,12 +1,16 @@
 #ifndef _OP_API_UTILS_HPP_
 #define _OP_API_UTILS_HPP_
 
+#include <string>
+
 #include "tl/expected.hpp"
 
 namespace openperf::api::utils {
 
 // Verify API module is up and running.
 tl::expected<void, std::string> check_api_module_running();
+
+tl::expected<void, std::string> check_api_path_ready(std::string_view path);
 
 } // namespace openperf::api::utils
 #endif


### PR DESCRIPTION
When started with a configuration file, the API startup function
attempts to populate the REST API with the contents of the file.
Previously, this was done in the main thread, which caused a
potential ordering issue when the API module was started before a
module it needed to configure. Fix the issue by spawning a separate
configuration thread to do the configuration so that other modules
aren't blocked during startup.

Also, verify that resource paths are ready before attempting to use
them. This avoids a race between the API config thread and other
modules.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/236)
<!-- Reviewable:end -->
