### PR TITLE
Update AnalyzerResult resource to not require any existing flows

### DIFF
--- a/api/schema/v1/modules/packet/analyzer.yaml
+++ b/api/schema/v1/modules/packet/analyzer.yaml
@@ -485,7 +485,6 @@ definitions:
       - active
       - protocol_counters
       - flow_counters
-      - flows
 
   AnalyzerProtocolCounters:
     type: object
@@ -986,7 +985,7 @@ definitions:
         format: date-time
       timestamp_last:
         type: string
-        description: Timestamp of last received packed
+        description: Timestamp of last received packet
         format: date-time
     required:
       - frame_count

--- a/src/swagger/v1/model/AnalyzerFlowCounters.h
+++ b/src/swagger/v1/model/AnalyzerFlowCounters.h
@@ -109,7 +109,7 @@ public:
     bool timestampFirstIsSet() const;
     void unsetTimestamp_first();
     /// <summary>
-    /// Timestamp of last received packed
+    /// Timestamp of last received packet
     /// </summary>
     std::string getTimestampLast() const;
     void setTimestampLast(std::string value);

--- a/src/swagger/v1/model/AnalyzerResult.cpp
+++ b/src/swagger/v1/model/AnalyzerResult.cpp
@@ -23,6 +23,7 @@ AnalyzerResult::AnalyzerResult()
     m_Analyzer_id = "";
     m_Analyzer_idIsSet = false;
     m_Active = false;
+    m_FlowsIsSet = false;
     
 }
 
@@ -53,8 +54,12 @@ nlohmann::json AnalyzerResult::toJson() const
         {
             jsonArray.push_back(ModelBase::toJson(item));
         }
-        val["flows"] = jsonArray;
-            }
+        
+        if(jsonArray.size() > 0)
+        {
+            val["flows"] = jsonArray;
+        }
+    }
     
 
     return val;
@@ -72,10 +77,13 @@ void AnalyzerResult::fromJson(nlohmann::json& val)
     {
         m_Flows.clear();
         nlohmann::json jsonArray;
-                for( auto& item : val["flows"] )
+        if(val.find("flows") != val.end())
+        {
+        for( auto& item : val["flows"] )
         {
             m_Flows.push_back(item);
             
+        }
         }
     }
     
@@ -138,6 +146,14 @@ void AnalyzerResult::setFlowCounters(std::shared_ptr<AnalyzerFlowCounters> value
 std::vector<std::string>& AnalyzerResult::getFlows()
 {
     return m_Flows;
+}
+bool AnalyzerResult::flowsIsSet() const
+{
+    return m_FlowsIsSet;
+}
+void AnalyzerResult::unsetFlows()
+{
+    m_FlowsIsSet = false;
 }
 
 }

--- a/src/swagger/v1/model/AnalyzerResult.h
+++ b/src/swagger/v1/model/AnalyzerResult.h
@@ -82,7 +82,9 @@ public:
     /// List of unique flow ids included in stats. Individual flow statistics may be queried via the &#x60;rx-flows&#x60; endpoint. 
     /// </summary>
     std::vector<std::string>& getFlows();
-    
+    bool flowsIsSet() const;
+    void unsetFlows();
+
 protected:
     std::string m_Id;
 
@@ -95,7 +97,7 @@ protected:
     std::shared_ptr<AnalyzerFlowCounters> m_Flow_counters;
 
     std::vector<std::string> m_Flows;
-
+    bool m_FlowsIsSet;
 };
 
 }

--- a/tests/aat/api/v1/client/models/analyzer_flow_counters.py
+++ b/tests/aat/api/v1/client/models/analyzer_flow_counters.py
@@ -254,7 +254,7 @@ class AnalyzerFlowCounters(object):
     def timestamp_last(self):
         """Gets the timestamp_last of this AnalyzerFlowCounters.  # noqa: E501
 
-        Timestamp of last received packed  # noqa: E501
+        Timestamp of last received packet  # noqa: E501
 
         :return: The timestamp_last of this AnalyzerFlowCounters.  # noqa: E501
         :rtype: datetime
@@ -265,7 +265,7 @@ class AnalyzerFlowCounters(object):
     def timestamp_last(self, timestamp_last):
         """Sets the timestamp_last of this AnalyzerFlowCounters.
 
-        Timestamp of last received packed  # noqa: E501
+        Timestamp of last received packet  # noqa: E501
 
         :param timestamp_last: The timestamp_last of this AnalyzerFlowCounters.  # noqa: E501
         :type: datetime

--- a/tests/aat/api/v1/client/models/analyzer_result.py
+++ b/tests/aat/api/v1/client/models/analyzer_result.py
@@ -65,7 +65,8 @@ class AnalyzerResult(object):
         self.active = active
         self.protocol_counters = protocol_counters
         self.flow_counters = flow_counters
-        self.flows = flows
+        if flows is not None:
+            self.flows = flows
 
     @property
     def id(self):

--- a/tests/aat/api/v1/docs/AnalyzerFlowCounters.md
+++ b/tests/aat/api/v1/docs/AnalyzerFlowCounters.md
@@ -11,7 +11,7 @@ Name | Type | Description | Notes
 **sequence** | [**AnalyzerFlowCountersSequence**](AnalyzerFlowCountersSequence.md) |  | [optional] 
 **frame_count** | **int** | Number of received packets | 
 **timestamp_first** | **datetime** | Timestamp of first received packet | [optional] 
-**timestamp_last** | **datetime** | Timestamp of last received packed | [optional] 
+**timestamp_last** | **datetime** | Timestamp of last received packet | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/tests/aat/api/v1/docs/AnalyzerResult.md
+++ b/tests/aat/api/v1/docs/AnalyzerResult.md
@@ -8,7 +8,7 @@ Name | Type | Description | Notes
 **active** | **bool** | Indicates whether the result is currently receiving updates | 
 **protocol_counters** | [**AnalyzerProtocolCounters**](AnalyzerProtocolCounters.md) |  | 
 **flow_counters** | [**AnalyzerFlowCounters**](AnalyzerFlowCounters.md) |  | 
-**flows** | **list[str]** | List of unique flow ids included in stats. Individual flow statistics may be queried via the &#x60;rx-flows&#x60; endpoint.  | 
+**flows** | **list[str]** | List of unique flow ids included in stats. Individual flow statistics may be queried via the &#x60;rx-flows&#x60; endpoint.  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 


### PR DESCRIPTION
* If Flows is set to required it can break some JSON decoders when
  no flows exist.
* With the property set to required, JSON decoders assume the
  property will be specified and non-null. In this case when an
  empty array is passed, the JSON encoder encodes that to NULL
  rather than an empty array.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/239)
<!-- Reviewable:end -->
