### PR TITLE
Feature toggles

### DIFF
--- a/api/schema/v1/modules/packet/analyzer.yaml
+++ b/api/schema/v1/modules/packet/analyzer.yaml
@@ -91,6 +91,30 @@ paths:
         204:
           description: No Content
 
+  /analyzers/{id}/reset:
+    post:
+      operationId: ResetPacketAnalyzer
+      tags:
+        - PacketAnalyzers
+      summary: Reset a running analyzer.
+      description: |
+        Used to generate a new result for a running analyzer. This
+        method effective resets all analyzer counters to zero. Note
+        that the new analyzer result will not contain any flow results
+        until packets are received after the reset event. Creates a
+        new analyzer result on success.
+      parameters:
+        - $ref: "#/parameters/id"
+      responses:
+        201:
+          description: Created
+          headers:
+            Location:
+              description: URI to created analyzer result object
+              type: string
+          schema:
+            $ref: "#/definitions/PacketAnalyzerResult"
+
   /analyzers/{id}/start:
     post:
       operationId: StartPacketAnalyzer

--- a/api/schema/v1/openperf.yaml
+++ b/api/schema/v1/openperf.yaml
@@ -117,6 +117,9 @@ paths:
   /packet/analyzers/{id}:
     $ref: ./modules/packet/analyzer.yaml#/paths/~1analyzers~1{id}
 
+  /packet/analyzers/{id}/reset:
+    $ref: ./modules/packet/analyzer.yaml#/paths/~1analyzers~1{id}~1reset
+
   /packet/analyzers/{id}/start:
     $ref: ./modules/packet/analyzer.yaml#/paths/~1analyzers~1{id}~1start
 

--- a/src/modules/packet/analyzer/api.hpp
+++ b/src/modules/packet/analyzer/api.hpp
@@ -127,6 +127,11 @@ struct request_delete_analyzer
     std::string id;
 };
 
+struct request_reset_analyzer
+{
+    std::string id;
+};
+
 struct request_start_analyzer
 {
     std::string id;
@@ -185,6 +190,7 @@ using request_msg = std::variant<request_list_analyzers,
                                  request_delete_analyzers,
                                  request_get_analyzer,
                                  request_delete_analyzer,
+                                 request_reset_analyzer,
                                  request_start_analyzer,
                                  request_stop_analyzer,
                                  request_list_analyzer_results,
@@ -259,4 +265,4 @@ namespace swagger::v1::model {
 void from_json(const nlohmann::json&, swagger::v1::model::PacketAnalyzer&);
 } // namespace swagger::v1::model
 
-#endif
+#endif /* _OP_PACKET_ANALYZER_API_HPP_ */

--- a/src/modules/packet/analyzer/api_transmogrify.cpp
+++ b/src/modules/packet/analyzer/api_transmogrify.cpp
@@ -135,6 +135,11 @@ serialized_msg serialize_request(request_msg&& msg)
                                                     request.id.data(),
                                                     request.id.length()));
                            },
+                           [&](request_reset_analyzer& request) {
+                               return (zmq_msg_init(&serialized.data,
+                                                    request.id.data(),
+                                                    request.id.length()));
+                           },
                            [&](request_start_analyzer& request) {
                                return (zmq_msg_init(&serialized.data,
                                                     request.id.data(),
@@ -232,6 +237,11 @@ tl::expected<request_msg, int> deserialize_request(const serialized_msg& msg)
         auto id = std::string(zmq_msg_data<char*>(&msg.data),
                               zmq_msg_size(&msg.data));
         return (request_delete_analyzer{std::move(id)});
+    }
+    case utils::variant_index<request_msg, request_reset_analyzer>(): {
+        auto id = std::string(zmq_msg_data<char*>(&msg.data),
+                              zmq_msg_size(&msg.data));
+        return (request_reset_analyzer{std::move(id)});
     }
     case utils::variant_index<request_msg, request_start_analyzer>(): {
         auto id = std::string(zmq_msg_data<char*>(&msg.data),

--- a/src/modules/packet/analyzer/server.hpp
+++ b/src/modules/packet/analyzer/server.hpp
@@ -48,6 +48,7 @@ public:
     reply_msg handle_request(const request_get_analyzer&);
     reply_msg handle_request(const request_delete_analyzer&);
 
+    reply_msg handle_request(const request_reset_analyzer&);
     reply_msg handle_request(const request_start_analyzer&);
     reply_msg handle_request(const request_stop_analyzer&);
 

--- a/src/modules/packet/analyzer/sink.cpp
+++ b/src/modules/packet/analyzer/sink.cpp
@@ -123,6 +123,14 @@ api::flow_counters_config sink::flow_counters() const
 
 size_t sink::worker_count() const { return (m_indexes.size()); }
 
+sink_result* sink::reset(sink_result* results)
+{
+    results->start();
+    auto stopped = m_results.exchange(results, std::memory_order_acq_rel);
+    stopped->stop();
+    return (stopped);
+}
+
 void sink::start(sink_result* results)
 {
     results->start();

--- a/src/modules/packet/analyzer/sink.hpp
+++ b/src/modules/packet/analyzer/sink.hpp
@@ -75,6 +75,7 @@ public:
     api::protocol_counters_config protocol_counters() const;
     api::flow_counters_config flow_counters() const;
 
+    sink_result* reset(sink_result* results);
     void start(sink_result* results);
     void stop();
 

--- a/src/modules/packet/generator/api.hpp
+++ b/src/modules/packet/generator/api.hpp
@@ -174,6 +174,11 @@ struct request_stop_generator
     std::string id;
 };
 
+struct request_toggle_generator
+{
+    std::unique_ptr<std::pair<std::string, std::string>> ids;
+};
+
 struct request_list_generator_results
 {
     filter_map_ptr filter;
@@ -224,6 +229,7 @@ using request_msg = std::variant<request_list_generators,
                                  request_delete_generator,
                                  request_start_generator,
                                  request_stop_generator,
+                                 request_toggle_generator,
                                  request_list_generator_results,
                                  request_delete_generator_results,
                                  request_get_generator_result,

--- a/src/modules/packet/generator/server.hpp
+++ b/src/modules/packet/generator/server.hpp
@@ -13,30 +13,6 @@ namespace openperf::packet::generator::api {
 
 class server
 {
-    core::event_loop& m_loop;
-    packetio::internal::api::client m_client;
-    std::unique_ptr<void, op_socket_deleter> m_socket;
-
-    /*
-     * Source's know their own id's, so we don't need to store
-     * them in a map.  Just use a (sorted) vector so we don't
-     * store id's twice.
-     */
-    using source_value_type = packetio::packet::generic_source;
-    std::vector<source_value_type> m_sources;
-
-    /*
-     * Results don't know their id's, so we store them in an associative
-     * container with the id as the key. Futhermore, we (the server)
-     * own the results.  We just let the source borrow them for a while.
-     */
-    using result_value_type = source_result;
-    using result_value_ptr = std::unique_ptr<result_value_type>;
-    using result_map = std::map<core::uuid, result_value_ptr>;
-
-    /* result id --> result */
-    result_map m_results;
-
 public:
     server(void* context, core::event_loop& loop);
 
@@ -50,6 +26,8 @@ public:
     reply_msg handle_request(const request_start_generator&);
     reply_msg handle_request(const request_stop_generator&);
 
+    reply_msg handle_request(const request_toggle_generator&);
+
     reply_msg handle_request(const request_list_generator_results&);
     reply_msg handle_request(const request_delete_generator_results&);
     reply_msg handle_request(const request_get_generator_result&);
@@ -57,6 +35,34 @@ public:
 
     reply_msg handle_request(const request_list_tx_flows&);
     reply_msg handle_request(const request_get_tx_flow&);
+
+    /*
+     * Source's know their own id's, so we don't need to store
+     * them in a map.  Just use a (sorted) vector so we don't
+     * store id's twice.
+     */
+    enum source_state { none = 0, idle, active };
+    using source_value_type = packetio::packet::generic_source;
+    using source_item = std::pair<source_value_type, source_state>;
+
+    /*
+     * Results don't know their id's, so we store them in an associative
+     * container with the id as the key. Futhermore, we (the server)
+     * own the results.  We just let the source borrow them for a while.
+     */
+    using result_value_type = source_result;
+    using result_value_ptr = std::unique_ptr<result_value_type>;
+    using result_map = std::map<core::uuid, result_value_ptr>;
+
+private:
+    core::event_loop& m_loop;
+    packetio::internal::api::client m_client;
+    std::unique_ptr<void, op_socket_deleter> m_socket;
+
+    std::vector<source_item> m_sources;
+
+    /* result id --> result */
+    result_map m_results;
 };
 
 } // namespace openperf::packet::generator::api

--- a/src/modules/packet/generator/source.cpp
+++ b/src/modules/packet/generator/source.cpp
@@ -1,11 +1,45 @@
 #include "packet/generator/api.hpp"
 #include "packet/generator/source.hpp"
 #include "packetio/packet_buffer.hpp"
+#include "swagger/v1/model/PacketGeneratorConfig.h"
 #include "utils/memcpy.hpp"
 
 namespace openperf::packet::generator {
 
 using packets_per_hour = packetio::packet::packets_per_hour;
+
+/*
+ * Convenient RAII wrappers for using an atomic_flag for notification
+ * purposes. Our generator has a worker thread that does actual work
+ * and a controller thread that needs to be able to tell if the worker
+ * thread is busy.  The worker thread uses the notification struct
+ * to atomically set/clear the flag. The controller thread uses the lock
+ * struct to verify that the flag is cleared before proceeding.
+ */
+struct flag_notify
+{
+    std::atomic_flag& flag_;
+    flag_notify(std::atomic_flag& flag)
+        : flag_(flag)
+    {
+        flag_.test_and_set(std::memory_order_acquire);
+    }
+
+    ~flag_notify() { flag_.clear(std::memory_order_release); }
+};
+
+struct flag_lock
+{
+    std::atomic_flag& flag_;
+    flag_lock(std::atomic_flag& flag)
+        : flag_(flag)
+    {
+        while (flag_.test_and_set(std::memory_order_acquire))
+            ;
+    }
+
+    ~flag_lock() { flag_.clear(std::memory_order_release); }
+};
 
 source_result::source_result(const source& src)
     : m_parent(src)
@@ -121,15 +155,46 @@ packetio::packet::packets_per_hour source::packet_rate() const
 void source::start(source_result* results)
 {
     m_tx_idx = 0;
+    m_offsets.resize(m_sequence.flow_count()); /* no offsets */
     results->start(m_sequence.flow_count());
     m_results.store(results, std::memory_order_release);
 }
 
-void source::stop()
+void source::start(
+    source_result* results,
+    const std::map<uint32_t, traffic::stat_t>& sig_stream_offsets)
+{
+    using sig_config_type = std::optional<traffic::signature_config>;
+
+    m_tx_idx = 0;
+    m_offsets.resize(m_sequence.flow_count());
+
+    /* Merge incoming offset data */
+    std::for_each(
+        std::begin(m_sequence),
+        std::end(m_sequence),
+        [&](const auto& flow_tuple) {
+            const auto& sig_config = std::get<sig_config_type>(flow_tuple);
+            if (sig_config && sig_stream_offsets.count(sig_config->stream_id)) {
+                m_offsets[std::get<0>(flow_tuple)] =
+                    sig_stream_offsets.at(sig_config->stream_id);
+            }
+        });
+
+    start(results);
+    results->start(m_sequence.flow_count());
+    m_results.store(results, std::memory_order_release);
+}
+
+source_result* source::stop()
 {
     auto* results = m_results.exchange(nullptr, std::memory_order_acq_rel);
+
+    /* Spin until the generator has finished transmitting any last packets */
+    auto lock = flag_lock(m_busy);
+
     results->stop();
-    /* somebody else owns the pointer; we don't need to do anything with it */
+    return (results);
 }
 
 static size_t to_send_diff(size_t tx_count, size_t tx_limit)
@@ -151,6 +216,8 @@ uint16_t source::transform(packetio::packet::packet_buffer* input[],
                            uint16_t input_length,
                            packetio::packet::packet_buffer* output[]) const
 {
+    auto notify = flag_notify(m_busy);
+
     auto results = m_results.load(std::memory_order_consume);
     if (!results) { return (0); }
 
@@ -180,8 +247,11 @@ uint16_t source::transform(packetio::packet::packet_buffer* input[],
             std::begin(m_packet_scratch),
             output + start,
             [&](auto buffer, auto&& pkt_data) {
-                auto
-                    && [flow_idx, hdr_ptr, hdr_lens, hdr_flags, sig_config,
+                auto&& [flow_idx,
+                        hdr_ptr,
+                        hdr_lens,
+                        hdr_flags,
+                        sig_config,
                         pkt_len] = pkt_data;
 
                 auto pkt = packetio::packet::to_data<uint8_t>(buffer);
@@ -204,7 +274,8 @@ uint16_t source::transform(packetio::packet::packet_buffer* input[],
                      */
                     packetio::packet::signature(buffer,
                                                 sig_config->stream_id,
-                                                flow_counters.packet,
+                                                m_offsets[flow_idx]
+                                                    + flow_counters.packet,
                                                 sig_config->flags);
                 }
 

--- a/src/modules/packetio/internal_api.hpp
+++ b/src/modules/packetio/internal_api.hpp
@@ -50,6 +50,19 @@ struct request_source_del
     source_data data;
 };
 
+struct source_swap_data
+{
+    char dst_id[name_length_max];
+    packet::generic_source outgoing;
+    packet::generic_source incoming;
+    std::optional<workers::source_swap_function> action;
+};
+
+struct request_source_swap
+{
+    source_swap_data data;
+};
+
 struct task_data
 {
     char name[name_length_max];
@@ -102,6 +115,7 @@ using request_msg = std::variant<request_sink_add,
                                  request_sink_del,
                                  request_source_add,
                                  request_source_del,
+                                 request_source_swap,
                                  request_task_add,
                                  request_task_del,
                                  request_worker_rx_ids,

--- a/src/modules/packetio/internal_client.hpp
+++ b/src/modules/packetio/internal_client.hpp
@@ -10,6 +10,7 @@
 #include "packetio/generic_sink.hpp"
 #include "packetio/generic_source.hpp"
 #include "packetio/generic_workers.hpp"
+#include "packetio/internal_api.hpp"
 
 namespace openperf::packetio::internal::api {
 
@@ -24,6 +25,12 @@ class client
                   event_loop::event_handler&& on_event,
                   std::optional<event_loop::delete_handler>&& on_delete,
                   std::any&& arg);
+
+    tl::expected<void, int> swap_source_impl(
+        std::string_view dst_id,
+        packet::generic_source&& outgoing,
+        packet::generic_source&& incoming,
+        std::optional<workers::source_swap_function>&& swap_function);
 
 public:
     client(void* context);
@@ -40,10 +47,19 @@ public:
                                      packet::generic_sink sink);
     tl::expected<void, int> del_sink(std::string_view src_id,
                                      packet::generic_sink sink);
+
     tl::expected<void, int> add_source(std::string_view dst_id,
                                        packet::generic_source source);
     tl::expected<void, int> del_source(std::string_view dst_id,
                                        packet::generic_source source);
+    tl::expected<void, int> swap_source(std::string_view dst_id,
+                                        packet::generic_source outgoing,
+                                        packet::generic_source incoming);
+    tl::expected<void, int>
+    swap_source(std::string_view dst_id,
+                packet::generic_source outgoing,
+                packet::generic_source incoming,
+                workers::source_swap_function&& swap_function);
 
     tl::expected<std::string, int> add_task(workers::context ctx,
                                             std::string_view name,

--- a/src/modules/packetio/internal_transmogrify.cpp
+++ b/src/modules/packetio/internal_transmogrify.cpp
@@ -44,6 +44,12 @@ serialized_msg serialize_request(const request_msg& msg)
                                                std::addressof(source_del.data),
                                                sizeof(source_del.data)));
                  },
+                 [&](const request_source_swap& source_swap) {
+                     return (
+                         message::zmq_msg_init(&serialized.data,
+                                               std::addressof(source_swap.data),
+                                               sizeof(source_swap.data)));
+                 },
                  [&](const request_task_add& task_add) {
                      return (
                          message::zmq_msg_init(&serialized.data,
@@ -129,6 +135,9 @@ tl::expected<request_msg, int> deserialize_request(const serialized_msg& msg)
     case utils::variant_index<request_msg, request_source_del>():
         return (request_source_del{
             *(message::zmq_msg_data<source_data*>(&msg.data))});
+    case utils::variant_index<request_msg, request_source_swap>():
+        return (request_source_swap{
+            *(message::zmq_msg_data<source_swap_data*>(&msg.data))});
     case utils::variant_index<request_msg, request_task_add>():
         return (
             request_task_add{*(message::zmq_msg_data<task_data*>(&msg.data))});

--- a/src/modules/packetio/workers/dpdk/tx_scheduler.cpp
+++ b/src/modules/packetio/workers/dpdk/tx_scheduler.cpp
@@ -8,8 +8,8 @@ namespace openperf::packetio::dpdk {
 
 using namespace std::literals::chrono_literals;
 static constexpr auto block_poll = 100ns;
-static constexpr auto idle_poll = 1s;
-static constexpr auto link_poll = 100ms;
+static constexpr auto idle_poll = 100ms;
+static constexpr auto link_poll = 100us;
 static constexpr auto min_poll = 1ns;
 static constexpr auto schedule_poll = idle_poll;
 

--- a/src/modules/packetio/workers/dpdk/worker_controller.hpp
+++ b/src/modules/packetio/workers/dpdk/worker_controller.hpp
@@ -67,6 +67,11 @@ public:
                                        packet::generic_source source);
     void del_source(std::string_view dst_id,
                     const packet::generic_source& source);
+    tl::expected<void, int>
+    swap_source(std::string_view dst_id,
+                const packet::generic_source& outgoing,
+                packet::generic_source incoming,
+                std::optional<workers::source_swap_function>&& swap_action);
 
     tl::expected<std::string, int>
     add_task(workers::context ctx,

--- a/tests/aat/api/v1/client/api/packet_analyzers_api.py
+++ b/tests/aat/api/v1/client/api/packet_analyzers_api.py
@@ -1498,6 +1498,105 @@ class PacketAnalyzersApi(object):
             _request_timeout=params.get('_request_timeout'),
             collection_formats=collection_formats)
 
+    def reset_packet_analyzer(self, id, **kwargs):  # noqa: E501
+        """Reset a running analyzer.  # noqa: E501
+
+        Used to generate a new result for a running analyzer. This method effective resets all analyzer counters to zero. Note that the new analyzer result will not contain any flow results until packets are received after the reset event. Creates a new analyzer result on success.   # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.reset_packet_analyzer(id, async_req=True)
+        >>> result = thread.get()
+
+        :param async_req bool
+        :param str id: Unique resource identifier (required)
+        :return: PacketAnalyzerResult
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+        kwargs['_return_http_data_only'] = True
+        if kwargs.get('async_req'):
+            return self.reset_packet_analyzer_with_http_info(id, **kwargs)  # noqa: E501
+        else:
+            (data) = self.reset_packet_analyzer_with_http_info(id, **kwargs)  # noqa: E501
+            return data
+
+    def reset_packet_analyzer_with_http_info(self, id, **kwargs):  # noqa: E501
+        """Reset a running analyzer.  # noqa: E501
+
+        Used to generate a new result for a running analyzer. This method effective resets all analyzer counters to zero. Note that the new analyzer result will not contain any flow results until packets are received after the reset event. Creates a new analyzer result on success.   # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.reset_packet_analyzer_with_http_info(id, async_req=True)
+        >>> result = thread.get()
+
+        :param async_req bool
+        :param str id: Unique resource identifier (required)
+        :return: PacketAnalyzerResult
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+
+        all_params = ['id']  # noqa: E501
+        all_params.append('async_req')
+        all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
+        all_params.append('_request_timeout')
+
+        params = locals()
+        for key, val in six.iteritems(params['kwargs']):
+            if key not in all_params:
+                raise TypeError(
+                    "Got an unexpected keyword argument '%s'"
+                    " to method reset_packet_analyzer" % key
+                )
+            params[key] = val
+        del params['kwargs']
+        # verify the required parameter 'id' is set
+        if ('id' not in params or
+                params['id'] is None):
+            raise ValueError("Missing the required parameter `id` when calling `reset_packet_analyzer`")  # noqa: E501
+
+        collection_formats = {}
+
+        path_params = {}
+        if 'id' in params:
+            path_params['id'] = params['id']  # noqa: E501
+
+        query_params = []
+
+        header_params = {}
+
+        form_params = []
+        local_var_files = {}
+
+        body_params = None
+        # HTTP header `Accept`
+        header_params['Accept'] = self.api_client.select_header_accept(
+            ['application/json'])  # noqa: E501
+
+        # HTTP header `Content-Type`
+        header_params['Content-Type'] = self.api_client.select_header_content_type(  # noqa: E501
+            ['application/json'])  # noqa: E501
+
+        # Authentication setting
+        auth_settings = []  # noqa: E501
+
+        return self.api_client.call_api(
+            '/packet/analyzers/{id}/reset', 'POST',
+            path_params,
+            query_params,
+            header_params,
+            body=body_params,
+            post_params=form_params,
+            files=local_var_files,
+            response_type='PacketAnalyzerResult',  # noqa: E501
+            auth_settings=auth_settings,
+            async_req=params.get('async_req'),
+            _return_http_data_only=params.get('_return_http_data_only'),
+            _preload_content=params.get('_preload_content', True),
+            _request_timeout=params.get('_request_timeout'),
+            collection_formats=collection_formats)
+
     def start_packet_analyzer(self, id, **kwargs):  # noqa: E501
         """Start analyzing and collecting packet statistics.  # noqa: E501
 

--- a/tests/aat/api/v1/docs/PacketAnalyzersApi.md
+++ b/tests/aat/api/v1/docs/PacketAnalyzersApi.md
@@ -19,6 +19,7 @@ Method | HTTP request | Description
 [**list_packet_analyzer_results**](PacketAnalyzersApi.md#list_packet_analyzer_results) | **GET** /packet/analyzer-results | List analyzer results
 [**list_packet_analyzers**](PacketAnalyzersApi.md#list_packet_analyzers) | **GET** /packet/analyzers | List packet analyzers
 [**list_rx_flows**](PacketAnalyzersApi.md#list_rx_flows) | **GET** /packet/rx-flows | List received packet flows
+[**reset_packet_analyzer**](PacketAnalyzersApi.md#reset_packet_analyzer) | **POST** /packet/analyzers/{id}/reset | Reset a running analyzer.
 [**start_packet_analyzer**](PacketAnalyzersApi.md#start_packet_analyzer) | **POST** /packet/analyzers/{id}/start | Start analyzing and collecting packet statistics.
 [**stop_packet_analyzer**](PacketAnalyzersApi.md#stop_packet_analyzer) | **POST** /packet/analyzers/{id}/stop | Stop analyzing and collecting packet statistics
 
@@ -721,6 +722,54 @@ Name | Type | Description  | Notes
 ### Return type
 
 [**list[RxFlow]**](RxFlow.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **reset_packet_analyzer**
+> PacketAnalyzerResult reset_packet_analyzer(id)
+
+Reset a running analyzer.
+
+Used to generate a new result for a running analyzer. This method effective resets all analyzer counters to zero. Note that the new analyzer result will not contain any flow results until packets are received after the reset event. Creates a new analyzer result on success. 
+
+### Example
+```python
+from __future__ import print_function
+import time
+import client
+from client.rest import ApiException
+from pprint import pprint
+
+# create an instance of the API class
+api_instance = client.PacketAnalyzersApi()
+id = 'id_example' # str | Unique resource identifier
+
+try:
+    # Reset a running analyzer.
+    api_response = api_instance.reset_packet_analyzer(id)
+    pprint(api_response)
+except ApiException as e:
+    print("Exception when calling PacketAnalyzersApi->reset_packet_analyzer: %s\n" % e)
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **id** | **str**| Unique resource identifier | 
+
+### Return type
+
+[**PacketAnalyzerResult**](PacketAnalyzerResult.md)
 
 ### Authorization
 


### PR DESCRIPTION
Add some neat tricks:

1. Allow analyzer "resets" - Replace an analyzer result with a new one so that clients can "reset" their analyzer counters.
2. Allow generator "swapping" - Replace a running generator with an idle one to simulate a generator reconfiguration. The swapping operation extracts the number of signature frames generated by the outgoing generator and adds them to the new generator so that there are no gaps or resets in the signature sequence.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/265)
<!-- Reviewable:end -->
