### PR TITLE
deps/libpcap: Don't link with netlink library

### DIFF
--- a/mk/libpcap.mk
+++ b/mk/libpcap.mk
@@ -24,7 +24,8 @@ LIBPCAP_CONFIG_OPTS += \
 	--enable-bluetooth=no \
 	--enable-dbus=no \
 	--enable-rdma=no \
-	--enable-shared=no
+	--enable-shared=no \
+	--without-libnl
 
 ###
 # Build rules


### PR DESCRIPTION
openperf only uses libpcap for bpf string parsing so it
doesn't need support for netlink.

the netlink library dependency was causing issues with
cross compile using a different sysroot.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/306)
<!-- Reviewable:end -->
