### PR TITLE
Add CPU Dynamic target.operations support

### DIFF
--- a/src/modules/cpu/cpu_stat.cpp
+++ b/src/modules/cpu/cpu_stat.cpp
@@ -10,6 +10,8 @@ task_cpu_stat::task_cpu_stat(size_t targets_number)
 
 task_cpu_stat& task_cpu_stat::operator+=(const task_cpu_stat& other)
 {
+    assert(targets.size() == other.targets.size());
+
     available += other.available;
     utilization += other.utilization;
     system += other.system;
@@ -17,7 +19,6 @@ task_cpu_stat& task_cpu_stat::operator+=(const task_cpu_stat& other)
     steal += other.steal;
     error += other.error;
 
-    targets.resize(std::max(targets.size(), other.targets.size()));
     for (size_t i = 0; i < targets.size(); i++) {
         targets[i].operations += other.targets[i].operations;
         targets[i].runtime += other.targets[i].runtime;
@@ -30,6 +31,18 @@ task_cpu_stat task_cpu_stat::operator+(const task_cpu_stat& other) const
 {
     auto copy = *this;
     return copy += other;
+}
+
+void task_cpu_stat::clear()
+{
+    available = 0ns;
+    utilization = 0ns;
+    system = 0ns;
+    user = 0ns;
+    steal = 0ns;
+    error = 0ns;
+
+    for (auto&& target : targets) target = {};
 }
 
 cpu_stat::cpu_stat(size_t cores_number)
@@ -56,6 +69,18 @@ cpu_stat cpu_stat::operator+(const task_cpu_stat& task) const
 {
     auto stat = *this;
     return stat += task;
+}
+
+void cpu_stat::clear()
+{
+    available = 0ns;
+    utilization = 0ns;
+    system = 0ns;
+    user = 0ns;
+    steal = 0ns;
+    error = 0ns;
+
+    for (auto&& core : cores) core.clear();
 }
 
 } // namespace openperf::cpu

--- a/src/modules/cpu/cpu_stat.hpp
+++ b/src/modules/cpu/cpu_stat.hpp
@@ -23,8 +23,8 @@ struct task_cpu_stat : public common_stat
 {
     struct target_cpu_stat
     {
-        uint64_t operations;
-        std::chrono::nanoseconds runtime;
+        uint64_t operations = 0;
+        std::chrono::nanoseconds runtime = 0ns;
     };
 
     double load = 0.0;
@@ -34,6 +34,8 @@ struct task_cpu_stat : public common_stat
     task_cpu_stat(size_t targets = 0);
     task_cpu_stat& operator+=(const task_cpu_stat&);
     task_cpu_stat operator+(const task_cpu_stat&) const;
+
+    void clear();
 };
 
 struct cpu_stat : public common_stat
@@ -43,6 +45,8 @@ struct cpu_stat : public common_stat
     cpu_stat(size_t cores = 0);
     cpu_stat& operator+=(const task_cpu_stat&);
     cpu_stat operator+(const task_cpu_stat&) const;
+
+    void clear();
 };
 
 } // namespace openperf::cpu


### PR DESCRIPTION
Add support of the `cores[N].targets[N].operations` field for the CPU dynamic result.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/315)
<!-- Reviewable:end -->
