### PR TITLE
Increase Http Response/Request size up to 1Mb

### DIFF
--- a/src/modules/api/api_init.cpp
+++ b/src/modules/api/api_init.cpp
@@ -110,8 +110,11 @@ public:
         op_thread_setname("op_api");
 
         Address addr(IP::any(Ipv6::supported()), Port(port));
-        auto opts =
-            Http::Endpoint::options().threads(1).flags(Tcp::Options::ReuseAddr);
+        auto opts = Http::Endpoint::options()
+                        .maxRequestSize(1024 * 1024)
+                        .maxResponseSize(1024 * 1024)
+                        .threads(1)
+                        .flags(Tcp::Options::ReuseAddr);
 
         m_server = std::make_unique<Http::Endpoint>(addr);
         m_server->init(opts);


### PR DESCRIPTION
Increase HTTP Response and Request size up to 1Mb for large queries.
Needed for large generators configurations and particular for TVLP profiles.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/322)
<!-- Reviewable:end -->
