### PR TITLE
Fix AAT Block error: name "time" is not defined

### DIFF
--- a/tests/aat/spec/block_spec.py
+++ b/tests/aat/spec/block_spec.py
@@ -1,4 +1,5 @@
 import os
+import time
 import client.api
 import client.models
 


### PR DESCRIPTION
AAT tests fails with errors like this:
```
Failure/Error: spec/block_spec.py wait_for_file_initialization_done(self.api, file.id, 1)
    NameError: name 'time' is not defined
        
File "spec/block_spec.py", line 74, in wait_for_file_initialization_done
    time.sleep(.1)
File "spec/block_spec.py", line 283, in before_each
    wait_for_file_initialization_done(self.api, file.id, 1)
``` 

Fix AAT tests block specification by importing the `time` module.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/328)
<!-- Reviewable:end -->
