### PR TITLE
Assign only available cores to cpu generator workers

### DIFF
--- a/src/framework/core/op_cpuset.c
+++ b/src/framework/core/op_cpuset.c
@@ -15,6 +15,16 @@ extern op_cpuset_t op_cpuset_create_from_string(const char* str);
 extern int op_cpuset_get_first(op_cpuset_t cpuset, size_t* cpu);
 extern int op_cpuset_get_next(op_cpuset_t cpuset, size_t* cpu);
 
+op_cpuset_t op_cpuset_all(void)
+{
+    op_cpuset_t cpuset = op_cpuset_create();
+    for (uint16_t core = 0; core < op_get_cpu_count(); core++) {
+        op_cpuset_set(cpuset, core, true);
+    }
+
+    return cpuset;
+}
+
 uint64_t op_cpuset_get_uint64(op_cpuset_t cpuset, size_t off, size_t len)
 {
     uint64_t val = 0;

--- a/src/framework/core/op_cpuset.h
+++ b/src/framework/core/op_cpuset.h
@@ -4,9 +4,15 @@
 #include <stddef.h>
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef void* op_cpuset_t;
 
 op_cpuset_t op_cpuset_create(void);
+
+op_cpuset_t op_cpuset_all(void);
 
 int op_cpuset_from_string(op_cpuset_t cpuset, const char* str);
 
@@ -124,5 +130,9 @@ inline int op_cpuset_get_next(op_cpuset_t cpuset, size_t* cpu)
  *   The number of cpus or 0 if fail.
  */
 size_t op_get_cpu_count(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _OP_CPUSET_H_ */

--- a/src/modules/cpu/cpu.hpp
+++ b/src/modules/cpu/cpu.hpp
@@ -58,7 +58,6 @@ struct utilization_time
 utilization_time cpu_thread_time();
 std::chrono::nanoseconds cpu_steal_time();
 
-uint16_t cpu_cores();
 uint16_t cpu_cache_line_size();
 std::string cpu_architecture();
 

--- a/src/modules/cpu/cpu_linux.cpp
+++ b/src/modules/cpu/cpu_linux.cpp
@@ -85,8 +85,6 @@ utilization_time cpu_thread_time()
                             .utilization = time_user + time_system};
 }
 
-uint16_t cpu_cores() { return sysconf(_SC_NPROCESSORS_CONF); }
-
 uint16_t cpu_cache_line_size() { return sysconf(_SC_LEVEL1_DCACHE_LINESIZE); }
 
 std::string cpu_architecture()

--- a/src/modules/cpu/generator.cpp
+++ b/src/modules/cpu/generator.cpp
@@ -101,6 +101,10 @@ generator::~generator()
 
 std::vector<uint16_t> detect_cores()
 {
+    // It is required to change thread affinity in order to be able to detect
+    // available cores. Affinity of the current thread could be already set and
+    // we should not touch it therefore this will be performed in a separate
+    // thread.
     auto f = std::async(std::launch::async, [] {
         std::vector<uint16_t> result;
 

--- a/src/modules/cpu/generator.cpp
+++ b/src/modules/cpu/generator.cpp
@@ -109,13 +109,13 @@ std::vector<uint16_t> detect_cores()
         std::vector<uint16_t> result;
 
         auto cpuset = op_cpuset_all();
-        int s = op_thread_set_affinity_mask(&cpuset);
+        int s = op_thread_set_affinity_mask(cpuset);
         if (s != 0) {
             OP_LOG(OP_LOG_ERROR, "Failed to set affinity");
             return result;
         }
 
-        s = op_thread_get_affinity_mask(&cpuset);
+        s = op_thread_get_affinity_mask(cpuset);
         if (s != 0) {
             OP_LOG(OP_LOG_ERROR, "Failed to get affinity");
             return result;

--- a/src/modules/cpu/server.cpp
+++ b/src/modules/cpu/server.cpp
@@ -248,7 +248,7 @@ reply_msg server::handle_request(const request_cpu_info&)
 {
     auto info = std::make_unique<cpu_info_t>();
     info->architecture = cpu_architecture();
-    info->cores = cpu_cores();
+    info->cores = op_get_cpu_count();
     info->cache_line_size = cpu_cache_line_size();
 
     return reply_cpu_info{.info = std::move(info)};


### PR DESCRIPTION
Fixes #333 
Cpu generator is trying to assing workers thread to cored by sequential number. But kubernetes can assign random cores to the pod. So we have to find available cores to use by CPU generator.

Signed-off-by: Artem Belov <artem.belov@spirent.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/335)
<!-- Reviewable:end -->
