### PR TITLE
Set poller timeout to avoid 100% core usage by packetio dpdk worker

### DIFF
--- a/src/modules/packetio/workers/dpdk/worker.cpp
+++ b/src/modules/packetio/workers/dpdk/worker.cpp
@@ -857,7 +857,7 @@ static void run_spinning(run_args&& args)
         rte_pause();
 
         /* All queues are idle; check callbacks */
-        for (auto& event : poller.poll(0)) {
+        for (auto& event : poller.poll(1)) {
             service_event(args.loop, args.fib, event);
         }
 


### PR DESCRIPTION
Packetio dpdk worker generates full usage for one core.
![Screenshot 2020-09-24 at 15 10 17](https://user-images.githubusercontent.com/60749064/94120860-d3bc0000-fe7a-11ea-93ad-9d7ea2f8c95e.png)
That makes affect on all generators.
The delay allows to avoid core usage by packetio dpdk worker
![Screenshot 2020-09-24 at 15 14 08](https://user-images.githubusercontent.com/60749064/94120870-d74f8700-fe7a-11ea-8d19-e03652708431.png)



Signed-off-by: Artem Belov <artem.belov@spirent.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/340)
<!-- Reviewable:end -->
