### PR TITLE
modules/cpu: Fix requirement for "method" property

### DIFF
--- a/api/schema/v1/modules/cpu.yaml
+++ b/api/schema/v1/modules/cpu.yaml
@@ -354,8 +354,8 @@ definitions:
         minItems: 1
         items:
           $ref: "#/definitions/CpuGeneratorCoreConfig"
-      required:
-        - method
+    required:
+      - method
 
   CpuGeneratorCoreConfig:
     title: CpuGeneratorCoreConfig
@@ -370,6 +370,8 @@ definitions:
         maximum: 100
       targets:
         type: array
+        description: Instruction set targets (operations)
+        minItems: 1
         items:
           type: object
           properties:
@@ -377,20 +379,20 @@ definitions:
               type: string
               description: CPU load instruction set
               enum:
-              - scalar
-              - sse2
-              - sse4
-              - avx
-              - avx2
-              - avx512
+                - scalar
+                - sse2
+                - sse4
+                - avx
+                - avx2
+                - avx512
             data_type:
               type: string
               description: CPU load target operation data type, actual for chosen instruction set
               enum:
-              - int32
-              - int64
-              - float32
-              - float64
+                - int32
+                - int64
+                - float32
+                - float64
             weight:
               type: integer
               description: Targeted load ratio
@@ -399,8 +401,6 @@ definitions:
             - instruction_set
             - data_type
             - weight
-        description: Instruction set targets (operations)
-        minItems: 1
     required:
       - utilization
       - targets

--- a/src/modules/cpu/api_converters.cpp
+++ b/src/modules/cpu/api_converters.cpp
@@ -39,9 +39,7 @@ is_valid(const swagger::CpuGeneratorConfig& config)
     auto errors = std::vector<std::string>();
 
     auto method = config.getMethod();
-    if (!config.methodIsSet() || method.empty()) {
-        errors.emplace_back("Parameter 'method' is required.");
-    } else if (method == "system") {
+    if (method == "system") {
         auto utilizaton = config.getSystem()->getUtilization();
         if (utilizaton <= 0.0) {
             errors.emplace_back("System utilization value '"

--- a/src/swagger/v1/model/CpuGeneratorConfig.cpp
+++ b/src/swagger/v1/model/CpuGeneratorConfig.cpp
@@ -20,7 +20,6 @@ namespace model {
 CpuGeneratorConfig::CpuGeneratorConfig()
 {
     m_Method = "";
-    m_MethodIsSet = false;
     m_SystemIsSet = false;
     m_CoresIsSet = false;
     
@@ -39,10 +38,7 @@ nlohmann::json CpuGeneratorConfig::toJson() const
 {
     nlohmann::json val = nlohmann::json::object();
 
-    if(m_MethodIsSet)
-    {
-        val["method"] = ModelBase::toJson(m_Method);
-    }
+    val["method"] = ModelBase::toJson(m_Method);
     if(m_SystemIsSet)
     {
         val["system"] = ModelBase::toJson(m_System);
@@ -66,11 +62,7 @@ nlohmann::json CpuGeneratorConfig::toJson() const
 
 void CpuGeneratorConfig::fromJson(nlohmann::json& val)
 {
-    if(val.find("method") != val.end())
-    {
-        setMethod(val.at("method"));
-        
-    }
+    setMethod(val.at("method"));
     if(val.find("system") != val.end())
     {
         if(!val["system"].is_null())
@@ -114,15 +106,7 @@ std::string CpuGeneratorConfig::getMethod() const
 void CpuGeneratorConfig::setMethod(std::string value)
 {
     m_Method = value;
-    m_MethodIsSet = true;
-}
-bool CpuGeneratorConfig::methodIsSet() const
-{
-    return m_MethodIsSet;
-}
-void CpuGeneratorConfig::unsetMethod()
-{
-    m_MethodIsSet = false;
+    
 }
 std::shared_ptr<CpuGeneratorSystemConfig> CpuGeneratorConfig::getSystem() const
 {

--- a/src/swagger/v1/model/CpuGeneratorConfig.h
+++ b/src/swagger/v1/model/CpuGeneratorConfig.h
@@ -56,9 +56,7 @@ public:
     /// </summary>
     std::string getMethod() const;
     void setMethod(std::string value);
-    bool methodIsSet() const;
-    void unsetMethod();
-    /// <summary>
+        /// <summary>
     /// 
     /// </summary>
     std::shared_ptr<CpuGeneratorSystemConfig> getSystem() const;
@@ -74,7 +72,7 @@ public:
 
 protected:
     std::string m_Method;
-    bool m_MethodIsSet;
+
     std::shared_ptr<CpuGeneratorSystemConfig> m_System;
     bool m_SystemIsSet;
     std::vector<std::shared_ptr<CpuGeneratorCoreConfig>> m_Cores;

--- a/tests/aat/api/v1/client/models/cpu_generator_config.py
+++ b/tests/aat/api/v1/client/models/cpu_generator_config.py
@@ -50,8 +50,7 @@ class CpuGeneratorConfig(object):
         self._cores = None
         self.discriminator = None
 
-        if method is not None:
-            self.method = method
+        self.method = method
         if system is not None:
             self.system = system
         if cores is not None:

--- a/tests/aat/api/v1/docs/CpuGeneratorConfig.md
+++ b/tests/aat/api/v1/docs/CpuGeneratorConfig.md
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**method** | **str** | Configuration method | [optional] 
+**method** | **str** | Configuration method | 
 **system** | [**CpuGeneratorSystemConfig**](CpuGeneratorSystemConfig.md) |  | [optional] 
 **cores** | [**list[CpuGeneratorCoreConfig]**](CpuGeneratorCoreConfig.md) | Per CPU core load configuration | [optional] 
 


### PR DESCRIPTION
Fixes the indent of `require` property in CPU Generator API specification to pass the Swagger API checks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/356)
<!-- Reviewable:end -->
