### PR TITLE
Fix large replies

### DIFF
--- a/src/modules/api/api_utils.hpp
+++ b/src/modules/api/api_utils.hpp
@@ -3,6 +3,8 @@
 
 #include <string>
 
+#include "json.hpp"
+#include "pistache/http.h"
 #include "tl/expected.hpp"
 
 namespace openperf::api::utils {
@@ -11,6 +13,11 @@ namespace openperf::api::utils {
 tl::expected<void, std::string> check_api_module_running();
 
 tl::expected<void, std::string> check_api_path_ready(std::string_view path);
+
+// Efficiently send large JSON responses in chunks
+void send_chunked_response(Pistache::Http::ResponseWriter,
+                           Pistache::Http::Code,
+                           const nlohmann::json&);
 
 } // namespace openperf::api::utils
 #endif

--- a/src/modules/packet/analyzer/handler.cpp
+++ b/src/modules/packet/analyzer/handler.cpp
@@ -1,6 +1,7 @@
 #include <zmq.h>
 
 #include "api/api_route_handler.hpp"
+#include "api/api_utils.hpp"
 #include "config/op_config_utils.hpp"
 #include "core/op_core.h"
 #include "message/serialized_message.hpp"
@@ -207,15 +208,14 @@ void handler::list_analyzers(const request_type& request,
     auto api_reply = submit_request(m_socket.get(), std::move(api_request));
 
     if (auto reply = std::get_if<reply_analyzers>(&api_reply)) {
-        response.headers().add<Http::Header::ContentType>(
-            MIME(Application, Json));
         auto analyzers = nlohmann::json::array();
         std::transform(
             std::begin(reply->analyzers),
             std::end(reply->analyzers),
             std::back_inserter(analyzers),
             [](const auto& analyzer) { return (analyzer->toJson()); });
-        response.send(Http::Code::Ok, analyzers.dump());
+        openperf::api::utils::send_chunked_response(
+            std::move(response), Http::Code::Ok, analyzers);
     } else {
         handle_reply_error(api_reply, std::move(response));
     }
@@ -661,14 +661,13 @@ void handler::list_analyzer_results(const request_type& request,
     auto api_reply = submit_request(m_socket.get(), std::move(api_request));
 
     if (auto reply = std::get_if<reply_analyzer_results>(&api_reply)) {
-        response.headers().add<Http::Header::ContentType>(
-            MIME(Application, Json));
         auto analyzer_results = nlohmann::json::array();
         std::transform(std::begin(reply->analyzer_results),
                        std::end(reply->analyzer_results),
                        std::back_inserter(analyzer_results),
                        [](const auto& result) { return (result->toJson()); });
-        response.send(Http::Code::Ok, analyzer_results.dump());
+        openperf::api::utils::send_chunked_response(
+            std::move(response), Http::Code::Ok, analyzer_results);
     } else {
         handle_reply_error(api_reply, std::move(response));
     }
@@ -742,14 +741,13 @@ void handler::list_rx_flows(const request_type& request, response_type response)
     auto api_reply = submit_request(m_socket.get(), std::move(api_request));
 
     if (auto reply = std::get_if<reply_rx_flows>(&api_reply)) {
-        response.headers().add<Http::Header::ContentType>(
-            MIME(Application, Json));
         auto flows = nlohmann::json::array();
         std::transform(std::begin(reply->flows),
                        std::end(reply->flows),
                        std::back_inserter(flows),
                        [](const auto& result) { return (result->toJson()); });
-        response.send(Http::Code::Ok, flows.dump());
+        openperf::api::utils::send_chunked_response(
+            std::move(response), Http::Code::Ok, flows);
     } else {
         handle_reply_error(api_reply, std::move(response));
     }

--- a/src/modules/packet/generator/handler.cpp
+++ b/src/modules/packet/generator/handler.cpp
@@ -1,6 +1,7 @@
 #include <zmq.h>
 
 #include "api/api_route_handler.hpp"
+#include "api/api_utils.hpp"
 #include "config/op_config_utils.hpp"
 #include "core/op_core.h"
 #include "message/serialized_message.hpp"
@@ -216,15 +217,14 @@ void handler::list_generators(const request_type& request,
     auto api_reply = submit_request(m_socket.get(), std::move(api_request));
 
     if (auto reply = std::get_if<reply_generators>(&api_reply)) {
-        response.headers().add<Http::Header::ContentType>(
-            MIME(Application, Json));
         auto generators = nlohmann::json::array();
         std::transform(
             std::begin(reply->generators),
             std::end(reply->generators),
             std::back_inserter(generators),
             [](const auto& generator) { return (generator->toJson()); });
-        response.send(Http::Code::Ok, generators.dump());
+        openperf::api::utils::send_chunked_response(
+            std::move(response), Http::Code::Ok, generators);
     } else {
         handle_reply_error(api_reply, std::move(response));
     }
@@ -678,14 +678,13 @@ void handler::list_generator_results(const request_type& request,
     auto api_reply = submit_request(m_socket.get(), std::move(api_request));
 
     if (auto reply = std::get_if<reply_generator_results>(&api_reply)) {
-        response.headers().add<Http::Header::ContentType>(
-            MIME(Application, Json));
         auto generator_results = nlohmann::json::array();
         std::transform(std::begin(reply->generator_results),
                        std::end(reply->generator_results),
                        std::back_inserter(generator_results),
                        [](const auto& result) { return (result->toJson()); });
-        response.send(Http::Code::Ok, generator_results.dump());
+        openperf::api::utils::send_chunked_response(
+            std::move(response), Http::Code::Ok, generator_results);
     } else {
         handle_reply_error(api_reply, std::move(response));
     }
@@ -757,14 +756,13 @@ void handler::list_tx_flows(const request_type& request, response_type response)
     auto api_reply = submit_request(m_socket.get(), std::move(api_request));
 
     if (auto reply = std::get_if<reply_tx_flows>(&api_reply)) {
-        response.headers().add<Http::Header::ContentType>(
-            MIME(Application, Json));
         auto flows = nlohmann::json::array();
         std::transform(std::begin(reply->flows),
                        std::end(reply->flows),
                        std::back_inserter(flows),
                        [](const auto& result) { return (result->toJson()); });
-        response.send(Http::Code::Ok, flows.dump());
+        openperf::api::utils::send_chunked_response(
+            std::move(response), Http::Code::Ok, flows);
     } else {
         handle_reply_error(api_reply, std::move(response));
     }


### PR DESCRIPTION
This fixes observed issues in the generator/analyzer/capture handlers where large replies will block indefinitely due to insufficient buffer space in the Pistache code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/365)
<!-- Reviewable:end -->
