### PR TITLE
contrib/docker: Add init script

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,8 +1,5 @@
 FROM spirentorion/openperf:latest AS devimg
 
-COPY "." "/root/project/"
-WORKDIR /root/project
-
 ARG GIT_COMMIT
 ARG GIT_VERSION
 ARG BUILD_NUMBER
@@ -10,9 +7,13 @@ ENV GIT_COMMIT=${GIT_COMMIT}
 ENV GIT_VERSION=${GIT_VERSION}
 ENV BUILD_NUMBER=${BUILD_NUMBER}
 
-RUN cd targets/openperf && make
+COPY . /root/project/
+WORKDIR /root/project
 
-FROM debian:buster-slim as runtime
+# Use all available cores for making
+RUN make -j$(nproc) -C targets/openperf
+
+FROM debian:buster-slim AS runtime
 
 RUN apt-get clean && \
     apt-get update && \
@@ -21,9 +22,16 @@ RUN apt-get clean && \
 RUN mkdir -p /opt/openperf/bin
 RUN mkdir -p /opt/openperf/plugins
 
-COPY --from=devimg /root/project/build/openperf-linux-x86_64-testing/bin/openperf /opt/openperf/bin/openperf
-COPY --from=devimg /root/project/build/openperf-linux-x86_64-testing/plugins/* /opt/openperf/plugins
-COPY --from=devimg /root/project/config.yaml /etc/openperf/config.yaml
+# Environment variables for init script
+ENV EXECUTABLE=/opt/openperf/bin/openperf
+ENV OP_CONFIG=/etc/openperf/config.yaml
+ENV OP_MODULES_PLUGINS_PATH=/opt/openperf/plugins
+ENV OP_MODULES_API_PORT=9000
 
-EXPOSE 9000
-CMD /opt/openperf/bin/openperf -c /etc/openperf/config.yaml
+COPY --from=devimg /root/project/init.sh /init
+COPY --from=devimg /root/project/config.yaml ${OP_CONFIG}
+COPY --from=devimg /root/project/build/openperf-linux-x86_64-testing/plugins/* ${OP_MODULES_PLUGINS_PATH}
+COPY --from=devimg /root/project/build/openperf-linux-x86_64-testing/bin/openperf ${EXECUTABLE}
+
+EXPOSE ${OP_MODULES_API_PORT}/tcp
+ENTRYPOINT [ "/init" ]

--- a/contrib/docker/build.sh
+++ b/contrib/docker/build.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-clean_folder() {
+function clean_folder() {
     rm -rf "$ROOT/build/docker"
 }
 
@@ -19,8 +19,15 @@ cp -r "$ROOT/.circleci" \
       "$ROOT/src" \
       "$ROOT/targets" \
       "config.yaml" \
+      "init.sh" \
       "$ROOT/build/docker/"
 
-docker build -f Dockerfile -t "${DOCKER_IMAGE}" --build-arg GIT_COMMIT="${GIT_COMMIT}" --build-arg GIT_VERSION="${GIT_VERSION}" --build-arg BUILD_NUMBER="${BUILD_NUMBER}" "$ROOT/build/docker"
+docker build \
+    --file Dockerfile \
+    --tag "${DOCKER_IMAGE}" \
+    --build-arg GIT_COMMIT="${GIT_COMMIT}" \
+    --build-arg GIT_VERSION="${GIT_VERSION}" \
+    --build-arg BUILD_NUMBER="${BUILD_NUMBER}" \
+    "$ROOT/build/docker"
 
 clean_folder

--- a/contrib/docker/config.yaml
+++ b/contrib/docker/config.yaml
@@ -3,13 +3,6 @@ core:
     level: debug
 
 modules:
-  plugins:
-    load:
-      - "libopenperf_tvlp.so"
-    path: "/opt/openperf/plugins"
-  api:
-    port: 9000
-
   socket:
     force-unlink: true
 

--- a/contrib/docker/init.sh
+++ b/contrib/docker/init.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Run script for the OpenPerf docker container entrypoint
+#
+# This script translates container environment variables with OP_ prefix
+# to the long options of the OpenPerf. All underscores in variable name
+# will be replaced by dots. Prefix OP_ will be cutted.
+#
+# For example:
+#   OP_CONFIG -> --config
+#   OP_MODULES_PLUGINS_LOAD -> --modules.plugins.load
+#
+
+# The executable program should be passed through EXECUTABLE
+# environment variable or as first argument of this stript.
+if [ -z "${EXECUTABLE}" ]; then
+  EXECUTABLE=${1}
+  shift
+fi
+
+# Print environment variables to console for debugging
+#echo ">>> ENV Variables"
+#env | sort | sed -e 's/^/   /;$a\\n'
+
+function scan_plugins() {
+  if [ ! -d "$1" ]; then
+    echo "Plugins directory '${1}' doesn't exists"
+    return 1
+  fi
+
+  cd "$1"
+  local list=''
+  for plugin in *.so; do
+    list="${list} ${plugin}"
+  done
+  echo ${list}
+}
+
+#OP_CONFIG=${OP_CONFIG:-'config.yaml'}
+#OP_MODULES_PLUGINS_PATH=${OP_MODULES_PLUGINS_PATH:-'plugins'}
+if [ -n "${OP_MODULES_PLUGINS_PATH}" ]; then
+  OP_MODULES_PLUGINS_LOAD=${OP_MODULES_PLUGINS_LOAD:-$(scan_plugins ${OP_MODULES_PLUGINS_PATH})}
+fi
+
+IFS=$'\n'
+OPTIONS=($(set | awk '
+  BEGIN { FS = "\n"; OFS = "" };
+  $1 ~ /^OP_/ {
+    sub("OP_", "", $1);
+    var = substr($1, 0, index($1, "="));
+    val = substr($1, index($1, "=") + 1);
+    gsub("_", ".", var);
+
+    print("--", tolower(var))
+    print(val)
+  }'))
+
+#echo -e "Options: ${OPTIONS[@]}\n"
+
+exec "${EXECUTABLE}" \
+  $* "${OPTIONS[@]}"
+


### PR DESCRIPTION
Add an initialization script with processing configuration of the OpenPerf from environment variables beginning with OP_ prefix. Excess configuration was removed from the default configuration file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/373)
<!-- Reviewable:end -->
