### PR TITLE
modules/packetio: add ability to skip packetio init

### DIFF
--- a/doc/dev-guide/configuration.md
+++ b/doc/dev-guide/configuration.md
@@ -3,34 +3,70 @@
 
 ## dynamic config.yaml
 
+   * API
+       - modules.api.port
+           + Rest API HTTP port
+
+   * Core
+       - core.prefix
+           + Prefix for temporary file system files, e.g. sockets. Needed when running multiple instances.
+
+       - core.log.prefix
+           + Used to specify the log level. Currently supported log levels are:
+             + critical
+             + error
+             + warning
+             + info
+             + debug
+             + trace
+
    * DPDK
-       - modules.packetio.dpdk.test-portpairs
-           + number of loopback port pairs for testing, defaults to 1
+       - modules.packetio.dpdk.no-rx-interrupts
+           + Use polling instead of interrupts to service DPDK receive queues.
+             Note: polling will always be used for drivers that do not support receive interrupts
+
+       - modules.packetio.dpdk.no-lro
+           + Disable Large Receive Offload. LRO is used by default if supported by the driver;
+             unfortunately, many drivers are buggy.
+
+       - modules.packetio.dpdk.no-init
+           + Disable DPDK entirely. The PacketIO module and all dependent modules will be unusable.
+             This is equivalent to setting the packetio CPU mask to 0.
+
+       - modules.packetio.dpdk.options
+           + Provide explicit options to DPDK. Example: ["-m256m", "--no-huge"]
+
+       - modules.packetio.dpdk.port-ids
+           + Use well-known strings for port id's instead of random UUID's. Example: [port0: port0, port1: port1]
+             This option is necessary when creating port based resources in the configuration file.
 
        - modules.packetio.dpdk.test-mode
            + enable test mode by creating loopback port pairs
 
-       - modules.packetio.dpdk.options
-           + Example: ["-m256m", "--no-huge"]
-           
-       - modules.packetio.dpdk.port-ids
-           + Example: [port0: port0, port1: port1]
+       - modules.packetio.dpdk.test-portpairs
+           + number of loopback port pairs for testing, defaults to 1
 
-       - modules.packetio.dpdk.no-rx-interrupts
-           + disable receive queue interrupts
-       
+       - modules.packetio.dpdk.misc-worker-mask
+           + Provide an explicit mask for miscellaneous worker threads. Must be a subset of the module or DPDK mask.
+             Currently only used for stack threads. Setting this mask to 0x0 will disable the stack.
+
+       - modules.packetio.dpdk.rx-worker-mask
+           + Provide an explicit mask for receive worker threads. Must be a subset of the module or DPDK mask.
+
+       - modules.packetio.dpdk.tx-worker-mask
+           + Provide an explicit mask for transmit worker threads. Must be a subset of the module or DPDK mask.
+
+   * PacketIO
+       - modules.packetio.cpu-mask
+           + Provide an explicit CPU mask for packetio module threads.
+             By, default, packetio will use all available CPU's. Setting this
+             option to 0 will disable the packetio module.
+
    * Socket
        - modules.socket.force-unlink
            + Force removal of stale files
 
-       - modules.socket.prefix
-           + Prefix used when running multiple instances
-       
-   * API   
-       - modules.api.port
-           + Rest API HTTP port
-
-When running AAT, the typical configuration is 
+When running AAT, the typical configuration is
 
 ```YAML
 modules:

--- a/src/modules/packet/generator/init.cpp
+++ b/src/modules/packet/generator/init.cpp
@@ -3,6 +3,7 @@
 #include <zmq.h>
 
 #include "core/op_core.h"
+#include "packetio/init.hpp"
 #include "packet/generator/server.hpp"
 
 namespace openperf::packet::generator {
@@ -21,8 +22,7 @@ static int handle_zmq_shutdown(const op_event_data* data, void*)
 
 struct service
 {
-    std::unique_ptr<openperf::core::event_loop> m_loop =
-        std::make_unique<openperf::core::event_loop>();
+    std::unique_ptr<openperf::core::event_loop> m_loop;
     std::unique_ptr<api::server> m_server;
     std::unique_ptr<void, op_socket_deleter> m_shutdown;
     std::thread m_service;
@@ -34,6 +34,14 @@ struct service
 
     void init(void* context)
     {
+        if (!packetio::is_enabled()) {
+            OP_LOG(OP_LOG_WARNING,
+                   "PacketIO module is not enabled; skipping packet generator "
+                   "initialization\n");
+            return;
+        }
+
+        m_loop = std::make_unique<core::event_loop>();
         m_server = std::make_unique<api::server>(context, *m_loop);
 
         m_shutdown.reset(op_socket_get_server(
@@ -42,6 +50,8 @@ struct service
 
     void start()
     {
+        if (!m_loop) { return; }
+
         m_service = std::thread([this]() {
             op_thread_setname("op_packet_gen");
 

--- a/src/modules/packet/stack/dpdk/sys_arch.cpp
+++ b/src/modules/packet/stack/dpdk/sys_arch.cpp
@@ -136,6 +136,12 @@ static int get_waiting_lcore()
     return (-1);
 }
 
+int sys_stack_worker_id()
+{
+    return (
+        openperf::packetio::dpdk::topology::get_stack_lcore_id().value_or(-1));
+}
+
 sys_thread_t sys_thread_new(const char* name,
                             lwip_thread_fn function,
                             void* arg,
@@ -149,8 +155,7 @@ sys_thread_t sys_thread_new(const char* name,
      * Luckily for us the TCPIP thread identifies itself clearly, so we can
      * put it on a specific core.  Otherwise, just pick one that is free.
      */
-    int lcore = (strcmp(TCPIP_THREAD_NAME, name) == 0 ? static_cast<int>(
-                     openperf::packetio::dpdk::topology::get_stack_lcore_id())
+    int lcore = (strcmp(TCPIP_THREAD_NAME, name) == 0 ? sys_stack_worker_id()
                                                       : get_waiting_lcore());
 
     if (lcore < 0) {

--- a/src/modules/packet/stack/init.hpp
+++ b/src/modules/packet/stack/init.hpp
@@ -1,0 +1,10 @@
+#ifndef _OP_PACKET_STACK_INIT_HPP_
+#define _OP_PACKET_STACK_INIT_HPP_
+
+namespace openperf::packet::stack {
+
+bool is_enabled();
+
+}
+
+#endif /* _OP_PACKET_STACK_INIT_HPP_ */

--- a/src/modules/packet/stack/lwip/include/arch/sys_arch.h
+++ b/src/modules/packet/stack/lwip/include/arch/sys_arch.h
@@ -29,4 +29,10 @@ typedef struct sys_thread* sys_thread_t;
 void sys_check_timeouts();
 u32_t sys_timeouts_sleeptime();
 
+/*
+ * Retrieve the worker id for the stack thread. Returns -1 if no
+ * thread is available.
+ */
+int sys_stack_worker_id();
+
 #endif /* _OP_PACKETIO_STACK_DPDK_SYS_ARCH_H_ */

--- a/src/modules/packetio/drivers/dpdk/arg_parser.hpp
+++ b/src/modules/packetio/drivers/dpdk/arg_parser.hpp
@@ -9,9 +9,11 @@
 
 #include "packetio/drivers/dpdk/core_mask.hpp"
 
+extern const char op_packetio_cpu_mask[];
+extern const char op_packetio_dpdk_misc_worker_mask[];
+extern const char op_packetio_dpdk_no_init[];
 extern const char op_packetio_dpdk_options[];
 extern const char op_packetio_dpdk_port_ids[];
-extern const char op_packetio_dpdk_misc_worker_mask[];
 extern const char op_packetio_dpdk_rx_worker_mask[];
 extern const char op_packetio_dpdk_tx_worker_mask[];
 
@@ -21,9 +23,12 @@ std::vector<std::string> dpdk_args(); /**< Retrieve a copy of args for use */
 std::vector<std::string> common_dpdk_args(); /**< Common args for all
                                                 process types */
 
+bool dpdk_disabled();
+
 std::map<uint16_t, std::string>
 dpdk_id_map(); /**< Retrieve a copy of port idx->id map */
 
+std::optional<core_mask> packetio_mask();
 std::optional<core_mask> misc_core_mask();
 std::optional<core_mask> rx_core_mask();
 std::optional<core_mask> tx_core_mask();

--- a/src/modules/packetio/drivers/dpdk/arg_parser_register.c
+++ b/src/modules/packetio/drivers/dpdk/arg_parser_register.c
@@ -1,10 +1,12 @@
 #include "core/op_core.h"
 #include "config/op_config_file.hpp"
 
-const char op_packetio_dpdk_options[] = "modules.packetio.dpdk.options";
-const char op_packetio_dpdk_port_ids[] = "modules.packetio.dpdk.port-ids";
+const char op_packetio_cpu_mask[] = "modules.packetio.cpu-mask";
 const char op_packetio_dpdk_misc_worker_mask[] =
     "modules.packetio.dpdk.misc-worker-mask";
+const char op_packetio_dpdk_no_init[] = "modules.packetio.dpdk.no-init";
+const char op_packetio_dpdk_options[] = "modules.packetio.dpdk.options";
+const char op_packetio_dpdk_port_ids[] = "modules.packetio.dpdk.port-ids";
 const char op_packetio_dpdk_rx_worker_mask[] =
     "modules.packetio.dpdk.rx-worker-mask";
 const char op_packetio_dpdk_tx_worker_mask[] =
@@ -13,6 +15,14 @@ const char op_packetio_dpdk_tx_worker_mask[] =
 MAKE_OPTION_DATA(
     dpdk,
     NULL,
+    MAKE_OPT("specifies CPU core mask for all threads, in hex",
+             op_packetio_cpu_mask,
+             0,
+             OP_OPTION_TYPE_HEX),
+    MAKE_OPT("specifies CPU core mask for miscellaneous threads, in hex",
+             op_packetio_dpdk_misc_worker_mask,
+             'M',
+             OP_OPTION_TYPE_HEX),
     MAKE_OPT("quoted, comma separated options for DPDK",
              op_packetio_dpdk_options,
              'd',
@@ -22,10 +32,10 @@ MAKE_OPTION_DATA(
              op_packetio_dpdk_port_ids,
              0,
              OP_OPTION_TYPE_MAP),
-    MAKE_OPT("specifies CPU core mask for miscellaneous threads, in hex",
-             op_packetio_dpdk_misc_worker_mask,
-             'M',
-             OP_OPTION_TYPE_HEX),
+    MAKE_OPT("skip DPDK initialization",
+             op_packetio_dpdk_no_init,
+             0,
+             OP_OPTION_TYPE_NONE),
     MAKE_OPT("specifies CPU core mask for receive threads, in hex",
              op_packetio_dpdk_rx_worker_mask,
              'R',

--- a/src/modules/packetio/drivers/dpdk/driver.hpp
+++ b/src/modules/packetio/drivers/dpdk/driver.hpp
@@ -44,6 +44,8 @@ public:
     void start_all_ports();
     void stop_all_ports();
 
+    bool is_usable();
+
     using port_id_map = std::map<uint16_t, std::string>;
 
 private:

--- a/src/modules/packetio/drivers/dpdk/driver.tcc
+++ b/src/modules/packetio/drivers/dpdk/driver.tcc
@@ -65,7 +65,7 @@ static inline void log_port(uint16_t idx, std::string_view id)
 static inline void sanity_check_environment()
 {
     if (rte_lcore_count() <= 1) {
-        throw std::runtime_error("No DPDK workers cores are available! "
+        throw std::runtime_error("No DPDK worker cores are available! "
                                  "At least 2 CPU cores are required.");
     }
 
@@ -308,10 +308,7 @@ template <typename ProcessType> driver<ProcessType>::driver()
 
     m_ethdev_ports = port_ids;
 
-    if (m_ethdev_ports.empty()) {
-        throw std::runtime_error("No DPDK ports are available! "
-                                 "At least 1 port is required.");
-    }
+    if (m_ethdev_ports.empty()) { return; } /* nothing left to do */
 
     /* Log port details */
     std::for_each(std::begin(m_ethdev_ports),
@@ -510,6 +507,11 @@ template <typename ProcessType> void driver<ProcessType>::stop_all_ports()
         std::begin(m_ethdev_ports),
         std::end(m_ethdev_ports),
         [this](const auto& pair) { m_process->stop_port(pair.first); });
+}
+
+template <typename ProcessType> bool driver<ProcessType>::is_usable()
+{
+    return (!m_ethdev_ports.empty() && rte_lcore_count() > 0);
 }
 
 } // namespace openperf::packetio::dpdk

--- a/src/modules/packetio/drivers/dpdk/dummy_driver.hpp
+++ b/src/modules/packetio/drivers/dpdk/dummy_driver.hpp
@@ -1,0 +1,51 @@
+#ifndef _OP_PACKETIO_DPDK_DUMMY_DRIVER_HPP_
+#define _OP_PACKETIO_DPDK_DUMMY_DRIVER_HPP_
+
+#include <string>
+#include <vector>
+
+#include "packetio/generic_port.hpp"
+
+namespace openperf::packetio::dpdk {
+
+class dummy_driver
+{
+public:
+    std::vector<std::string> port_ids() const
+    {
+        return (std::vector<std::string>{});
+    }
+
+    std::optional<port::generic_port> port(std::string_view) const
+    {
+        return (std::nullopt);
+    }
+
+    std::optional<int> port_index(std::string_view) const
+    {
+        return (std::nullopt);
+    }
+
+    tl::expected<std::string, std::string> create_port(std::string_view,
+                                                       const port::config_data&)
+    {
+        return (
+            tl::make_unexpected("Dummy driver does not support port creation"));
+    }
+
+    tl::expected<void, std::string> delete_port(std::string_view)
+    {
+        return (
+            tl::make_unexpected("Dummy driver does not support port deletion"));
+    }
+
+    void start_all_ports() {}
+
+    void stop_all_ports() {}
+
+    bool is_usable() { return (false); }
+};
+
+} // namespace openperf::packetio::dpdk
+
+#endif /* _OP_PACKETIO_DPDK_DUMMY_DRIVER_HPP_ */

--- a/src/modules/packetio/drivers/dpdk/primary/driver_factory.cpp
+++ b/src/modules/packetio/drivers/dpdk/primary/driver_factory.cpp
@@ -1,5 +1,6 @@
 #include "packetio/generic_driver.hpp"
 #include "packetio/drivers/dpdk/driver.tcc"
+#include "packetio/drivers/dpdk/dummy_driver.hpp"
 #include "packetio/drivers/dpdk/primary/arg_parser.hpp"
 #include "packetio/drivers/dpdk/primary/eal_process.hpp"
 
@@ -13,9 +14,13 @@ namespace openperf::packetio::driver {
 std::unique_ptr<generic_driver> make()
 {
     /*
-     * Our driver depends on whether we are using test ports or not. Hence,
-     * check our config and create the appropriate driver instance.
+     * Our driver depends on various command line options.
+     * Check the options and respond appropriately.
      */
+    if (dpdk::config::dpdk_disabled()) {
+        return (std::make_unique<generic_driver>(dpdk::dummy_driver()));
+    }
+
     if (dpdk::config::dpdk_test_mode()) {
         return (std::make_unique<generic_driver>(
             dpdk::driver<dpdk::primary::test_port_process>()));

--- a/src/modules/packetio/drivers/dpdk/primary/eal_process.cpp
+++ b/src/modules/packetio/drivers/dpdk/primary/eal_process.cpp
@@ -66,7 +66,9 @@ static void log_idle_workers(const std::vector<queue::descriptor>& descriptors)
                   [&](const auto& d) { eal_mask.reset(d.worker_id); });
 
     /* Clear the bit used by the stack */
-    eal_mask.reset(topology::get_stack_lcore_id());
+    if (auto stack_id = topology::get_stack_lcore_id()) {
+        eal_mask.reset(stack_id.value());
+    }
 
     /* Warn if we are unable to use any of our available cores */
     if (eal_mask.count()) {

--- a/src/modules/packetio/drivers/dpdk/secondary/driver_factory.cpp
+++ b/src/modules/packetio/drivers/dpdk/secondary/driver_factory.cpp
@@ -1,5 +1,6 @@
 #include "packetio/generic_driver.hpp"
 #include "packetio/drivers/dpdk/driver.tcc"
+#include "packetio/drivers/dummy_driver.hpp"
 #include "packetio/drivers/dpdk/secondary/eal_process.hpp"
 
 namespace openperf::packetio {
@@ -10,6 +11,10 @@ namespace openperf::packetio::driver {
 
 std::unique_ptr<generic_driver> make()
 {
+    if (config::dpdk::dpdk_disabled()) {
+        return (std::make_unique<generic_driver>(dpdk::dummy_driver()));
+    }
+
     return (std::make_unique<generic_driver>(
         dpdk::driver<dpdk::secondary::eal_process>()));
 }

--- a/src/modules/packetio/drivers/dpdk/topology_utils.hpp
+++ b/src/modules/packetio/drivers/dpdk/topology_utils.hpp
@@ -12,8 +12,9 @@ namespace openperf::packetio::dpdk::topology {
 /**
  * Use the currently available ports, cores, and NUMA architecture to
  * determine a reasonable logical core to run the stack thread.
+ * Note: one might not be present.
  */
-unsigned get_stack_lcore_id();
+std::optional<unsigned> get_stack_lcore_id();
 
 std::vector<uint16_t> get_ports();
 

--- a/src/modules/packetio/generic_driver.hpp
+++ b/src/modules/packetio/generic_driver.hpp
@@ -47,6 +47,8 @@ public:
 
     void stop_all_ports() { return m_self->stop_all_ports(); }
 
+    bool is_usable() { return m_self->is_usable(); }
+
 private:
     struct driver_concept
     {
@@ -61,6 +63,7 @@ private:
         delete_port(std::string_view id) = 0;
         virtual void start_all_ports() = 0;
         virtual void stop_all_ports() = 0;
+        virtual bool is_usable() = 0;
     };
 
     template <typename Driver> struct driver_model final : driver_concept
@@ -101,6 +104,8 @@ private:
         void start_all_ports() override { return m_driver.start_all_ports(); }
 
         void stop_all_ports() override { return m_driver.stop_all_ports(); }
+
+        bool is_usable() override { return m_driver.is_usable(); }
 
         Driver m_driver;
     };

--- a/src/modules/packetio/init.hpp
+++ b/src/modules/packetio/init.hpp
@@ -1,0 +1,14 @@
+#ifndef _OP_PACKETIO_INIT_HPP_
+#define _OP_PACKETIO_INIT_HPP_
+
+namespace openperf::packetio {
+
+/*
+ * Simple function to report on whether the packetio module is available
+ * for use or not.
+ */
+bool is_enabled();
+
+} // namespace openperf::packetio
+
+#endif /* _OP_PACKETIO_INIT_HPP_ */

--- a/src/modules/packetio/workers/dpdk/worker_controller.cpp
+++ b/src/modules/packetio/workers/dpdk/worker_controller.cpp
@@ -921,6 +921,9 @@ tl::expected<std::string, int> worker_controller::add_task(
         return (tl::make_unexpected(EINVAL));
     }
 
+    auto stack_lcore_id = topology::get_stack_lcore_id();
+    if (!stack_lcore_id) { return (tl::make_unexpected(ENOTSUP)); }
+
     auto id = core::uuid::random();
     auto [it, success] =
         m_tasks.try_emplace(id,
@@ -937,8 +940,8 @@ tl::expected<std::string, int> worker_controller::add_task(
            name.data(),
            core::to_string(id).c_str());
 
-    std::vector<worker::descriptor> tasks{worker::descriptor(
-        topology::get_stack_lcore_id(), std::addressof(it->second))};
+    std::vector<worker::descriptor> tasks{
+        worker::descriptor(*stack_lcore_id, std::addressof(it->second))};
     m_workers->add_descriptors(tasks);
 
     return (core::to_string(id));
@@ -946,14 +949,17 @@ tl::expected<std::string, int> worker_controller::add_task(
 
 void worker_controller::del_task(std::string_view task_id)
 {
+    auto stack_lcore_id = topology::get_stack_lcore_id();
+    if (!stack_lcore_id) { return; }
+
     OP_LOG(OP_LOG_DEBUG,
            "Deleting task %.*s\n",
            static_cast<int>(task_id.length()),
            task_id.data());
     auto id = core::uuid(task_id);
     if (auto item = m_tasks.find(id); item != m_tasks.end()) {
-        std::vector<worker::descriptor> tasks{worker::descriptor(
-            topology::get_stack_lcore_id(), std::addressof(item->second))};
+        std::vector<worker::descriptor> tasks{
+            worker::descriptor(*stack_lcore_id, std::addressof(item->second))};
         m_workers->del_descriptors(tasks);
         m_recycler->writer_add_gc_callback([id, this]() { m_tasks.erase(id); });
     }

--- a/src/modules/socket/server/init.cpp
+++ b/src/modules/socket/server/init.cpp
@@ -1,6 +1,7 @@
 #include <thread>
 
 #include "core/op_core.h"
+#include "packet/stack/init.hpp"
 #include "socket/server/api_server.hpp"
 
 namespace openperf::socket::server {
@@ -11,12 +12,22 @@ struct service
 {
     void init(void* context)
     {
+        if (!packet::stack::is_enabled()) {
+            OP_LOG(OP_LOG_WARNING,
+                   "Packet stack module is not enabled; skipping socket server "
+                   "initialization\n");
+            return;
+        }
+
         m_server = std::make_unique<api::server>(context);
     }
 
-    int start() { return (m_server->start()); }
+    int start() { return (m_server ? m_server->start() : 0); }
 
-    void stop() { m_server->stop(); }
+    void stop()
+    {
+        if (m_server) { m_server->stop(); }
+    }
 
     std::unique_ptr<api::server> m_server;
 };

--- a/tests/aat/spec/config.yaml
+++ b/tests/aat/spec/config.yaml
@@ -26,6 +26,25 @@ services:
     init_url: http://127.0.0.1:9000/interfaces/dataplane-server
     init_timeout: 15s
 
+  # PacketIO argument test configs
+  packetio-args-1:
+    command: '../../build/openperf-linux-x86_64-testing/bin/openperf --modules.packetio.cpu-mask 0x0 -p 9000 >> openperf.log 2>&1'
+    base_url: http://127.0.0.1:9000
+    init_url: http://127.0.0.1:9000/version
+    init_timeout: 15s
+
+  packetio-args-2:
+    command: '../../build/openperf-linux-x86_64-testing/bin/openperf --modules.packetio.dpdk.no-init -p 9000 >> openperf.log 2>&1'
+    base_url: http://127.0.0.1:9000
+    init_url: http://127.0.0.1:9000/version
+    init_timeout: 15s
+
+  packetio-args-3:
+    command: '../../build/openperf-linux-x86_64-testing/bin/openperf --modules.packetio.cpu-mask 0x3 --modules.packetio.dpdk.options="-m256m,--no-huge" --modules.packetio.dpdk.test-mode --modules.packetio.dpdk.rx-worker-mask 0x2 --modules.packetio.dpdk.tx-worker-mask 0x2 -p 9000 >> openperf.log 2>&1'
+    base_url: http://127.0.0.1:9000
+    init_url: http://127.0.0.1:9000/version
+    init_timeout: 15s
+
   #TVLP support.
   tvlp:
     command: '../../build/openperf-linux-x86_64-testing/bin/openperf --modules.packetio.dpdk.test-mode --core.log.level debug --modules.socket.force-unlink --modules.packetio.dpdk.options="-m256m,--no-huge" --modules.packetio.dpdk.port-ids="port0=0, port1=1" -p 9000 -L "libopenperf_tvlp.so" -m "../../build/openperf-linux-x86_64-testing/plugins/" >> openperf.log 2>&1'

--- a/tests/aat/spec/packetio_args_spec.py
+++ b/tests/aat/spec/packetio_args_spec.py
@@ -1,0 +1,69 @@
+from mamba import description, before, after, it
+from expects import expect
+import os
+
+import client.api
+from common import Config, Service
+from common.helper import check_modules_exists
+
+
+CONFIG = Config(os.path.join(os.path.dirname(__file__), os.environ.get('MAMBA_CONFIG', 'config.yaml')))
+
+
+with description('PacketIO arguments,', 'packetio_args'):
+    with description('Empty core mask,'):
+        with before.all:
+            service = Service(CONFIG.service('packetio-args-1'))
+            self.process = service.start()
+            self.api = client.api.PortsApi(service.client())
+            if not check_modules_exists(service.client(), 'packetio'):
+                self.skip()
+
+        with description('binary started,'):
+            with it('has no port handlers'):
+                expect(lambda: self.api.list_ports().to(raise_api_exception(405)))
+
+        with after.all:
+            try:
+                self.process.terminate()
+                self.process.wait()
+            except AttributeError:
+                pass
+
+    with description('No-init flag,'):
+        with before.all:
+            service = Service(CONFIG.service('packetio-args-2'))
+            self.process = service.start()
+            self.api = client.api.PortsApi(service.client())
+            if not check_modules_exists(service.client(), 'packetio'):
+                self.skip()
+
+        with description('binary started,'):
+            with it('has no port handlers'):
+                expect(lambda: self.api.list_ports().to(raise_api_exception(405)))
+
+        with after.all:
+            try:
+                self.process.terminate()
+                self.process.wait()
+            except AttributeError:
+                pass
+
+    with description('No stack worker,'):
+        with before.all:
+            service = Service(CONFIG.service('packetio-args-3'))
+            self.process = service.start()
+            self.api = client.api.StacksApi(service.client())
+            if not check_modules_exists(service.client(), 'packet-stack'):
+                self.skip()
+
+        with description('binary started,'):
+            with it('has no stack handlers'):
+                expect(lambda: self.api.list_stacks().to(raise_api_exception(405)))
+
+        with after.all:
+            try:
+                self.process.terminate()
+                self.process.wait()
+            except AttributeError:
+                pass


### PR DESCRIPTION
Update the packetio initialization code to bail out of the
initialization process if the driver is unusable or the user explicitly
disables it. Add a function so that clients can determine whether the
packetio module is enabled or not. Finally, update dependent modules to
check the packetio module state so they can skip their own
initializations, if necessary.

Also, add some AAT's to verify command line argument processing and
module disablement.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/374)
<!-- Reviewable:end -->
