### PR TITLE
api: Fix dynamic_results parameter reference

### DIFF
--- a/api/schema/v1/modules/block.yaml
+++ b/api/schema/v1/modules/block.yaml
@@ -7,6 +7,9 @@ parameters:
     format: string
     required: true
 
+  dynamic_results:
+    $ref: "./dynamic.yaml#/parameters/dynamic_results"
+
 paths:
   /block-devices:
     get:
@@ -310,7 +313,7 @@ paths:
       description: Start an existing block generator.
       parameters:
         - $ref: "#/parameters/id"
-        - $ref: "./modules/dynamic.yaml#/parameters/dynamic_results"
+        - $ref: "#/parameters/dynamic_results"
       responses:
         201:
           description: Created

--- a/api/schema/v1/modules/cpu.yaml
+++ b/api/schema/v1/modules/cpu.yaml
@@ -7,6 +7,9 @@ parameters:
     format: string
     required: true
 
+  dynamic_results:
+    $ref: "./dynamic.yaml#/parameters/dynamic_results"
+
 paths:
   /cpu-generators:
     get:
@@ -149,7 +152,7 @@ paths:
       description: Start an existing CPU generator.
       parameters:
         - $ref: "#/parameters/id"
-        - $ref: "./modules/dynamic.yaml#/parameters/dynamic_results"
+        - $ref: "#/parameters/dynamic_results"
       responses:
         201:
           description: Created

--- a/api/schema/v1/modules/memory.yaml
+++ b/api/schema/v1/modules/memory.yaml
@@ -7,6 +7,9 @@ parameters:
     format: string
     required: true
 
+  dynamic_results:
+    $ref: "./dynamic.yaml#/parameters/dynamic_results"
+
 paths:
   /memory-generators:
     get:
@@ -149,7 +152,7 @@ paths:
       description: Start an existing memory generator.
       parameters:
         - $ref: "#/parameters/id"
-        - $ref: "./modules/dynamic.yaml#/parameters/dynamic_results"
+        - $ref: "#/parameters/dynamic_results"
       responses:
         201:
           description: Created


### PR DESCRIPTION
Add dynamic_results parameter to each module api specification.
This fix allows to validate OpenAPI 2.0 syntax using the
swagger-cli tool, without getting an error, caused by
incorrect path to the dynamic.yaml file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/378)
<!-- Reviewable:end -->
