### PR TITLE
TVLP internal API refactoring

### DIFF
--- a/src/framework/message/serialized_message.hpp
+++ b/src/framework/message/serialized_message.hpp
@@ -52,7 +52,9 @@ inline void pop_front(serialized_message& msg)
     msg.parts.erase(std::begin(msg.parts));
 }
 
-template <typename T> auto push(serialized_message& msg, const T& value)
+template <typename T>
+std::enable_if_t<std::is_trivially_copyable<T>::value, int>
+push(serialized_message& msg, const T& value)
 {
     auto& part = msg.parts.emplace_back();
 

--- a/src/modules/tvlp/handler.cpp
+++ b/src/modules/tvlp/handler.cpp
@@ -8,6 +8,7 @@
 
 #include "framework/core/op_core.h"
 #include "framework/config/op_config_utils.hpp"
+#include "message/serialized_message.hpp"
 #include "modules/api/api_route_handler.hpp"
 
 namespace openperf::tvlp::api {
@@ -24,22 +25,22 @@ std::string json_error(std::string_view msg)
 
 void response_error(Http::ResponseWriter& rsp, const reply::error& error)
 {
-    switch (error.data->type) {
-    case reply::error_data::NOT_FOUND:
+    switch (error.type) {
+    case reply::error::NOT_FOUND:
         rsp.send(Http::Code::Not_Found);
         break;
-    case reply::error_data::EXISTS:
+    case reply::error::EXISTS:
         rsp.headers().add<Http::Header::ContentType>(MIME(Application, Json));
         rsp.send(Http::Code::Bad_Request,
                  json_error("Item with such ID already existst"));
         break;
-    case reply::error_data::INVALID_ID:
+    case reply::error::INVALID_ID:
         rsp.headers().add<Http::Header::ContentType>(MIME(Application, Json));
         rsp.send(Http::Code::Bad_Request, json_error("Invalid ID format"));
         break;
-    case reply::error_data::BAD_REQUEST_ERROR:
+    case reply::error::BAD_REQUEST_ERROR:
         rsp.headers().add<Http::Header::ContentType>(MIME(Application, Json));
-        rsp.send(Http::Code::Bad_Request, json_error(error.data->value));
+        rsp.send(Http::Code::Bad_Request, json_error(error.message));
         break;
     default:
         rsp.send(Http::Code::Internal_Server_Error);
@@ -109,8 +110,8 @@ void handler::list_tvlp(const Rest::Request&, Http::ResponseWriter response)
     if (auto list = std::get_if<reply::tvlp::list>(&api_reply)) {
         auto array = json::array();
         std::transform(
-            list->data->begin(),
-            list->data->end(),
+            list->begin(),
+            list->end(),
             std::back_inserter(array),
             [](const auto& item) -> json { return to_swagger(item).toJson(); });
 
@@ -146,16 +147,16 @@ void handler::create_tvlp(const Rest::Request& request,
                     .c_str());
         }
 
-        auto api_reply = submit_request(request::tvlp::create{
-            .data = std::make_unique<tvlp_config_t>(from_swagger(model))});
+        auto api_reply =
+            submit_request(request::tvlp::create{from_swagger(model)});
 
         if (auto item = std::get_if<reply::tvlp::item>(&api_reply)) {
             response.headers().add<Http::Header::ContentType>(
                 MIME(Application, Json));
             response.headers().add<Http::Header::Location>("/tvlp/"
-                                                           + item->data->id());
+                                                           + item->id());
             response.send(Http::Code::Created,
-                          to_swagger(*item->data).toJson().dump());
+                          to_swagger(*item).toJson().dump());
         } else if (auto error = std::get_if<reply::error>(&api_reply)) {
             response_error(response, *error);
         }
@@ -177,10 +178,10 @@ void handler::get_tvlp(const Rest::Request& request,
 
     auto api_reply = submit_request(request::tvlp::get{{.id = id}});
 
-    if (auto r = std::get_if<reply::tvlp::item>(&api_reply)) {
+    if (auto item = std::get_if<reply::tvlp::item>(&api_reply)) {
         response.headers().add<Http::Header::ContentType>(
             MIME(Application, Json));
-        response.send(Http::Code::Ok, to_swagger(*r->data).toJson().dump());
+        response.send(Http::Code::Ok, to_swagger(*item).toJson().dump());
         return;
     }
 
@@ -227,20 +228,20 @@ void handler::start_tvlp(const Rest::Request& request,
     auto start_time = realtime::now();
     if (request.query().has("time")) {
         auto time = from_rfc3339(request.query().get("time").get());
-        if (time)
-            start_time = time.value();
-        else {
+        if (!time) {
             response.send(Http::Code::Bad_Request, "Wrong time format");
             return;
         }
+        start_time = time.value();
     }
 
-    using start_data_t = request::tvlp::start::start_data;
     auto api_reply = submit_request(request::tvlp::start{
-        .data = std::make_unique<start_data_t>(
-            start_data_t{.id = id, .start_time = start_time})});
+        .id = id,
+        .start_time = start_time,
+    });
+
     if (auto item = std::get_if<reply::tvlp::result::item>(&api_reply)) {
-        auto model = to_swagger(*item->data);
+        auto model = to_swagger(*item);
         response.headers().add<Http::Header::ContentType>(
             MIME(Application, Json));
         response.headers().add<Http::Header::Location>("/tvlp-results/"
@@ -288,8 +289,8 @@ void handler::list_results(const Rest::Request&, Http::ResponseWriter response)
     if (auto list = std::get_if<reply::tvlp::result::list>(&api_reply)) {
         auto array = json::array();
         std::transform(
-            list->data->begin(),
-            list->data->end(),
+            list->begin(),
+            list->end(),
             std::back_inserter(array),
             [](const auto& item) -> json { return to_swagger(item).toJson(); });
 
@@ -320,7 +321,7 @@ void handler::get_result(const Rest::Request& request,
     if (auto item = std::get_if<reply::tvlp::result::item>(&api_reply)) {
         response.headers().add<Http::Header::ContentType>(
             MIME(Application, Json));
-        response.send(Http::Code::Ok, to_swagger(*item->data).toJson().dump());
+        response.send(Http::Code::Ok, to_swagger(*item).toJson().dump());
         return;
     }
 
@@ -356,21 +357,20 @@ api::api_reply handler::submit_request(api::api_request&& request)
     if (auto error = openperf::message::send(
             socket.get(), api::serialize(std::forward<api_request>(request)));
         error != 0) {
-        api::reply::error_data data{.type = api::reply::error_data::ZMQ_ERROR,
-                                    .code = error};
 
         return api::reply::error{
-            .data = std::make_unique<api::reply::error_data>(std::move(data))};
+            .type = api::reply::error::ZMQ_ERROR,
+            .code = error,
+        };
     }
 
     auto reply =
         openperf::message::recv(socket.get()).and_then(api::deserialize_reply);
     if (!reply) {
-        api::reply::error_data data{.type = api::reply::error_data::ZMQ_ERROR,
-                                    .code = reply.error()};
-
         return api::reply::error{
-            .data = std::make_unique<api::reply::error_data>(std::move(data))};
+            .type = api::reply::error::ZMQ_ERROR,
+            .code = reply.error(),
+        };
     }
 
     return std::move(*reply);


### PR DESCRIPTION
Add triviality check to `serialized_message::push` template to avoid pushing complex objects.

Improve the internal API readability and intelligibility.
Remove excess wrapping messages data to `std::unique_ptr`.
Move needed wrappings to the `api_transmogrify.cpp` file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/384)
<!-- Reviewable:end -->
