### PR TITLE
modules/socket: fix release build

### DIFF
--- a/src/modules/socket/server/dgram_channel.cpp
+++ b/src/modules/socket/server/dgram_channel.cpp
@@ -207,7 +207,7 @@ bool dgram_channel::send(const pbuf* p)
         },
     };
 
-    auto written = write(items.data(), items.size());
+    [[maybe_unused]] auto written = write(items.data(), items.size());
     assert(written == buffer_required(p->len));
     notify();
 
@@ -236,7 +236,7 @@ bool dgram_channel::send(const pbuf* p,
         },
     };
 
-    auto written = write(items.data(), items.size());
+    [[maybe_unused]] auto written = write(items.data(), items.size());
     assert(written == buffer_required(p->len));
     notify();
 

--- a/src/modules/socket/server/stream_channel.cpp
+++ b/src/modules/socket/server/stream_channel.cpp
@@ -220,7 +220,7 @@ size_t stream_channel::recv_drop(size_t length)
 {
     if (!length) return (0);
 
-    auto adjust = drop(length);
+    [[maybe_unused]] auto adjust = drop(length);
     assert(adjust == length); /* should always be true for us */
 
     unblock();


### PR DESCRIPTION
Apply the `maybe_unused` tag to variables only used in `assert()`
statements to fix unused variable errors in the release build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/386)
<!-- Reviewable:end -->
