### PR TITLE
Add interface lookup to packetio internal api

### DIFF
--- a/src/modules/packetio/generic_workers.hpp
+++ b/src/modules/packetio/generic_workers.hpp
@@ -116,6 +116,12 @@ public:
         m_self->del_source(dst_id, source);
     }
 
+    tl::expected<interface::generic_interface, int>
+    interface(std::string_view interface_id) const
+    {
+        return (m_self->interface(interface_id));
+    }
+
     tl::expected<void, int> swap_source(std::string_view dst_id,
                                         packet::generic_source outgoing,
                                         packet::generic_source incoming)
@@ -181,6 +187,8 @@ private:
                       interface::generic_interface interface) = 0;
         virtual void del_interface(std::string_view port_id,
                                    interface::generic_interface interface) = 0;
+        virtual tl::expected<interface::generic_interface, int>
+        interface(std::string_view interface_id) const = 0;
         virtual tl::expected<void, int>
         add_sink(packet::traffic_direction direction,
                  std::string_view src_id,
@@ -237,6 +245,12 @@ private:
                            interface::generic_interface interface) override
         {
             m_workers.del_interface(port_id, interface);
+        }
+
+        tl::expected<interface::generic_interface, int>
+        interface(std::string_view interface_id) const override
+        {
+            return (m_workers.interface(interface_id));
         }
 
         tl::expected<void, int> add_sink(packet::traffic_direction direction,

--- a/src/modules/packetio/internal_api.hpp
+++ b/src/modules/packetio/internal_api.hpp
@@ -36,6 +36,11 @@ struct request_interface_add
     interface_data data;
 };
 
+struct request_interface
+{
+    std::string interface_id;
+};
+
 struct request_interface_del
 {
     interface_data data;
@@ -118,6 +123,11 @@ struct request_worker_ids
     packet::traffic_direction direction;
 };
 
+struct reply_interface
+{
+    interface_data data;
+};
+
 struct reply_task_add
 {
     std::string task_id;
@@ -151,7 +161,8 @@ struct reply_error
     int value;
 };
 
-using request_msg = std::variant<request_interface_add,
+using request_msg = std::variant<request_interface,
+                                 request_interface_add,
                                  request_interface_del,
                                  request_port_index,
                                  request_sink_add,
@@ -164,7 +175,8 @@ using request_msg = std::variant<request_interface_add,
                                  request_transmit_function,
                                  request_worker_ids>;
 
-using reply_msg = std::variant<reply_port_index,
+using reply_msg = std::variant<reply_interface,
+                               reply_port_index,
                                reply_task_add,
                                reply_transmit_function,
                                reply_worker_ids,

--- a/src/modules/packetio/internal_client.hpp
+++ b/src/modules/packetio/internal_client.hpp
@@ -61,6 +61,8 @@ public:
     tl::expected<void, int>
     del_interface(std::string_view port_id,
                   interface::generic_interface interface);
+    tl::expected<interface::generic_interface, int>
+    interface(std::string_view interface_id);
 
     tl::expected<void, int> add_sink(packet::traffic_direction direction,
                                      std::string_view src_id,

--- a/src/modules/packetio/internal_server.cpp
+++ b/src/modules/packetio/internal_server.cpp
@@ -20,6 +20,16 @@ reply_msg handle_request(server& s, const request_interface_add& request)
     }
 }
 
+reply_msg handle_request(server& s, const request_interface& request)
+{
+    auto maybe_interface = s.workers().interface(request.interface_id);
+    if (!maybe_interface) {
+        return (reply_error{maybe_interface.error()});
+    } else {
+        return (reply_interface{.data.interface = *maybe_interface});
+    }
+}
+
 reply_msg handle_request(server& s, const request_interface_del& request)
 {
     s.workers().del_interface(request.data.port_id, request.data.interface);
@@ -137,6 +147,9 @@ static std::string to_string(request_msg& request)
             [](const request_interface_add& msg) {
                 return ("add interface " + msg.data.interface.id() + " to port "
                         + std::string(msg.data.port_id));
+            },
+            [](const request_interface& msg) {
+                return ("get interface " + msg.interface_id);
             },
             [](const request_interface_del& msg) {
                 return ("delete interface " + msg.data.interface.id()

--- a/src/modules/packetio/workers/dpdk/worker_controller.cpp
+++ b/src/modules/packetio/workers/dpdk/worker_controller.cpp
@@ -484,6 +484,15 @@ void worker_controller::del_interface(
            *port_idx);
 }
 
+tl::expected<interface::generic_interface, int>
+worker_controller::interface(std::string_view interface_id) const
+{
+    auto maybe_interface = m_fib->find_interface(interface_id);
+    if (maybe_interface) { return (*maybe_interface); }
+
+    return (tl::make_unexpected(EINVAL));
+}
+
 template <typename Vector, typename Item>
 bool contains_match(const Vector& vector, const Item& match)
 {

--- a/src/modules/packetio/workers/dpdk/worker_controller.hpp
+++ b/src/modules/packetio/workers/dpdk/worker_controller.hpp
@@ -61,6 +61,8 @@ public:
                   const interface::generic_interface& interface);
     void del_interface(std::string_view port_id,
                        const interface::generic_interface& interface);
+    tl::expected<interface::generic_interface, int>
+    interface(std::string_view interface_id) const;
 
     tl::expected<void, int> add_sink(packet::traffic_direction direction,
                                      std::string_view src_id,


### PR DESCRIPTION
* packetio clients can query for interfaces by interface ID.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/387)
<!-- Reviewable:end -->
