### PR TITLE
api/block: rename file_size to size

### DIFF
--- a/api/schema/v1/modules/block.yaml
+++ b/api/schema/v1/modules/block.yaml
@@ -490,7 +490,7 @@ definitions:
       id:
         type: string
         description: Unique file identifier
-      file_size:
+      size:
         type: integer
         description: Size of test file (in bytes)
         format: int64
@@ -511,7 +511,7 @@ definitions:
           - ready
     required:
       - id
-      - file_size
+      - size
       - init_percent_complete
       - path
       - state

--- a/src/modules/block/api_converters.cpp
+++ b/src/modules/block/api_converters.cpp
@@ -83,9 +83,7 @@ bool is_valid(const BlockFile& file, std::vector<std::string>& errors)
 {
     auto init_errors = errors.size();
 
-    if (file.getFileSize() <= 0) {
-        errors.emplace_back("File size is not valid.");
-    }
+    if (file.getSize() <= 0) { errors.emplace_back("File size is not valid."); }
 
     return (errors.size() == init_errors);
 }
@@ -149,7 +147,7 @@ std::shared_ptr<BlockFile> to_swagger(const model::file& p_file)
     auto blkfile = std::make_shared<BlockFile>();
     blkfile->setId(p_file.id());
     blkfile->setPath(p_file.path());
-    blkfile->setFileSize(p_file.size());
+    blkfile->setSize(p_file.size());
     blkfile->setInitPercentComplete(p_file.init_percent_complete());
     blkfile->setState(std::string(to_string(p_file.state())));
     return blkfile;
@@ -224,7 +222,7 @@ model::file from_swagger(const BlockFile& p_file)
     model::file f;
     f.id(p_file.getId());
     f.path(p_file.getPath());
-    f.size(p_file.getFileSize());
+    f.size(p_file.getSize());
     f.init_percent_complete(p_file.getInitPercentComplete());
     return f;
 }

--- a/src/swagger/converters/block.cpp
+++ b/src/swagger/converters/block.cpp
@@ -15,7 +15,7 @@ namespace swagger::v1::model {
 
 void from_json(const nlohmann::json& j, BlockFile& file)
 {
-    file.setFileSize(j.at("file_size"));
+    file.setSize(j.at("size"));
     file.setPath(j.at("path"));
 
     if (j.find("id") != j.end()) file.setId(j.at("id"));

--- a/src/swagger/v1/model/BlockFile.cpp
+++ b/src/swagger/v1/model/BlockFile.cpp
@@ -20,7 +20,7 @@ namespace model {
 BlockFile::BlockFile()
 {
     m_Id = "";
-    m_File_size = 0L;
+    m_Size = 0L;
     m_Init_percent_complete = 0;
     m_Path = "";
     m_State = "";
@@ -41,7 +41,7 @@ nlohmann::json BlockFile::toJson() const
     nlohmann::json val = nlohmann::json::object();
 
     val["id"] = ModelBase::toJson(m_Id);
-    val["file_size"] = m_File_size;
+    val["size"] = m_Size;
     val["init_percent_complete"] = m_Init_percent_complete;
     val["path"] = ModelBase::toJson(m_Path);
     val["state"] = ModelBase::toJson(m_State);
@@ -53,7 +53,7 @@ nlohmann::json BlockFile::toJson() const
 void BlockFile::fromJson(nlohmann::json& val)
 {
     setId(val.at("id"));
-    setFileSize(val.at("file_size"));
+    setSize(val.at("size"));
     setInitPercentComplete(val.at("init_percent_complete"));
     setPath(val.at("path"));
     setState(val.at("state"));
@@ -70,13 +70,13 @@ void BlockFile::setId(std::string value)
     m_Id = value;
     
 }
-int64_t BlockFile::getFileSize() const
+int64_t BlockFile::getSize() const
 {
-    return m_File_size;
+    return m_Size;
 }
-void BlockFile::setFileSize(int64_t value)
+void BlockFile::setSize(int64_t value)
 {
-    m_File_size = value;
+    m_Size = value;
     
 }
 int32_t BlockFile::getInitPercentComplete() const

--- a/src/swagger/v1/model/BlockFile.h
+++ b/src/swagger/v1/model/BlockFile.h
@@ -56,8 +56,8 @@ public:
         /// <summary>
     /// Size of test file (in bytes)
     /// </summary>
-    int64_t getFileSize() const;
-    void setFileSize(int64_t value);
+    int64_t getSize() const;
+    void setSize(int64_t value);
         /// <summary>
     /// Percentage of initialization completed so far
     /// </summary>
@@ -77,7 +77,7 @@ public:
 protected:
     std::string m_Id;
 
-    int64_t m_File_size;
+    int64_t m_Size;
 
     int32_t m_Init_percent_complete;
 

--- a/tests/aat/api/v1/client/models/block_file.py
+++ b/tests/aat/api/v1/client/models/block_file.py
@@ -32,7 +32,7 @@ class BlockFile(object):
     """
     swagger_types = {
         'id': 'str',
-        'file_size': 'int',
+        'size': 'int',
         'init_percent_complete': 'int',
         'path': 'str',
         'state': 'str'
@@ -40,24 +40,24 @@ class BlockFile(object):
 
     attribute_map = {
         'id': 'id',
-        'file_size': 'file_size',
+        'size': 'size',
         'init_percent_complete': 'init_percent_complete',
         'path': 'path',
         'state': 'state'
     }
 
-    def __init__(self, id=None, file_size=None, init_percent_complete=None, path=None, state=None):  # noqa: E501
+    def __init__(self, id=None, size=None, init_percent_complete=None, path=None, state=None):  # noqa: E501
         """BlockFile - a model defined in Swagger"""  # noqa: E501
 
         self._id = None
-        self._file_size = None
+        self._size = None
         self._init_percent_complete = None
         self._path = None
         self._state = None
         self.discriminator = None
 
         self.id = id
-        self.file_size = file_size
+        self.size = size
         self.init_percent_complete = init_percent_complete
         self.path = path
         self.state = state
@@ -85,26 +85,26 @@ class BlockFile(object):
         self._id = id
 
     @property
-    def file_size(self):
-        """Gets the file_size of this BlockFile.  # noqa: E501
+    def size(self):
+        """Gets the size of this BlockFile.  # noqa: E501
 
         Size of test file (in bytes)  # noqa: E501
 
-        :return: The file_size of this BlockFile.  # noqa: E501
+        :return: The size of this BlockFile.  # noqa: E501
         :rtype: int
         """
-        return self._file_size
+        return self._size
 
-    @file_size.setter
-    def file_size(self, file_size):
-        """Sets the file_size of this BlockFile.
+    @size.setter
+    def size(self, size):
+        """Sets the size of this BlockFile.
 
         Size of test file (in bytes)  # noqa: E501
 
-        :param file_size: The file_size of this BlockFile.  # noqa: E501
+        :param size: The size of this BlockFile.  # noqa: E501
         :type: int
         """
-        self._file_size = file_size
+        self._size = size
 
     @property
     def init_percent_complete(self):

--- a/tests/aat/api/v1/docs/BlockFile.md
+++ b/tests/aat/api/v1/docs/BlockFile.md
@@ -4,7 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **id** | **str** | Unique file identifier | 
-**file_size** | **int** | Size of test file (in bytes) | 
+**size** | **int** | Size of test file (in bytes) | 
 **init_percent_complete** | **int** | Percentage of initialization completed so far | 
 **path** | **str** | Resource pathname | 
 **state** | **str** | State of resource | 

--- a/tests/aat/common/helper/block.py
+++ b/tests/aat/common/helper/block.py
@@ -33,10 +33,10 @@ def block_generator_model(resource_id = None):
     return bg
 
 
-def file_model(file_size = None, path = None):
+def file_model(size = None, path = None):
     ba = client.models.BlockFile()
     ba.id = ''
-    ba.file_size = file_size
+    ba.size = size
     ba.path = path
     ba.init_percent_complete = 0
     ba.state = 'none'

--- a/tests/aat/common/matcher/block.py
+++ b/tests/aat/common/matcher/block.py
@@ -18,7 +18,7 @@ class _be_valid_block_file(Matcher):
         expect(file).to(be_a(client.models.BlockFile))
         expect(file.id).not_to(be_empty)
         expect(file.path).not_to(be_empty)
-        expect(file.file_size).not_to(be_none)
+        expect(file.size).not_to(be_none)
         expect(file.init_percent_complete).not_to(be_none)
         expect(file.state).not_to(be_empty)
         return True, ['is valid block file']


### PR DESCRIPTION
Rename `file_size` BlockFile property to `size` for consistency with BlockDevice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/389)
<!-- Reviewable:end -->
