### PR TITLE
Fix logs

### DIFF
--- a/src/framework/core/op_log.c
+++ b/src/framework/core/op_log.c
@@ -246,6 +246,18 @@ static void* get_thread_log_socket(void)
 }
 
 /**
+ * Explicit close the logging socket of the calling thread.
+ */
+void op_log_close(void)
+{
+    if (_log_socket == NULL) return;
+    if (op_list_delete_head(_thread_log_sockets, _log_socket)) {
+        zmq_close(_log_socket);
+        _log_socket = NULL;
+    }
+}
+
+/**
  * Take a message from an arbitrary context and send it to the logging
  * thread.  Not sure what to do about errors in this function, as the
  * inability to log messages probably ought to be fatal...

--- a/src/framework/core/op_log.h
+++ b/src/framework/core/op_log.h
@@ -120,6 +120,11 @@ int op_vlog(enum op_log_level level,
             va_list argp);
 
 /**
+ * Explicit close the logging socket of the calling thread.
+ */
+void op_log_close(void);
+
+/**
  * Intialize the logging subsystem
  *
  * @param context

--- a/src/framework/generator/controller.hpp
+++ b/src/framework/generator/controller.hpp
@@ -118,6 +118,8 @@ std::enable_if_t<!std::is_pointer_v<S>, void> controller::start(T&& processor)
                 if (!m_stop) throw e;
             }
         }
+
+        op_log_close();
     });
 }
 
@@ -143,6 +145,8 @@ std::enable_if_t<std::is_pointer_v<S>, void> controller::start(T&& processor)
                 if (!m_stop) throw e;
             }
         }
+
+        op_log_close();
     });
 }
 

--- a/src/framework/generator/worker.hpp
+++ b/src/framework/generator/worker.hpp
@@ -78,6 +78,7 @@ void worker::start(T&& task, std::optional<uint16_t> core_id)
         OP_LOG(OP_LOG_DEBUG, "Worker thread started");
 
         run(task);
+        op_log_close();
     });
 }
 


### PR DESCRIPTION
The fix adds new function `op_log_close()` to the log subsystem of `framework/core`.
This function explicitly closes ZMQ socket for the calling thread and releases resources.
Using `op_log_close()` helps to avoid resource leakage and eliminates the error of exceeding limit of open files.

Closes #353

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/392)
<!-- Reviewable:end -->
