### PR TITLE
TVLP move {load,time}_scale from create to start

### DIFF
--- a/api/schema/v1/modules/tvlp.yaml
+++ b/api/schema/v1/modules/tvlp.yaml
@@ -339,7 +339,9 @@ definitions:
       start_time:
         type: string
         format: date-time
-        description: The ISO8601-formatted date and time to start profile replay
+        description: |
+          The ISO8601-formatted date and time to start profile replay.
+          If not specified the profile will start immediately.
       cpu:
         $ref: "#/definitions/TvlpStartSeriesConfiguration"
       memory:

--- a/api/schema/v1/modules/tvlp.yaml
+++ b/api/schema/v1/modules/tvlp.yaml
@@ -7,14 +7,6 @@ parameters:
     format: string
     required: true
 
-  start_time:
-    name: time
-    in: query
-    description: The ISO8601-formatted date and time to start profile replay
-    type: string
-    format: date-time
-    required: false
-
 paths:
   /tvlp:
     get:
@@ -88,7 +80,6 @@ paths:
       description: Start an existing TVLP configuration.
       parameters:
         - $ref: "#/parameters/id"
-        - $ref: "#/parameters/start_time"
         - name: start
           in: body
           description: TVLP Start parameters
@@ -345,6 +336,10 @@ definitions:
     type: object
     description: TVLP start configuration
     properties:
+      start_time:
+        type: string
+        format: date-time
+        description: The ISO8601-formatted date and time to start profile replay
       cpu:
         $ref: "#/definitions/TvlpStartSeriesConfiguration"
       memory:
@@ -372,9 +367,5 @@ definitions:
         default: 1.0
         minimum: 0.0
         exclusiveMinimum: true
-      start_time:
-        type: string
-        format: date-time
-        description: The ISO8601-formatted date and time to start profile replay
       dynamic_results:
         $ref: "./dynamic.yaml#/definitions/DynamicResultsConfig"

--- a/api/schema/v1/modules/tvlp.yaml
+++ b/api/schema/v1/modules/tvlp.yaml
@@ -215,20 +215,6 @@ definitions:
       memory:
         type: object
         properties:
-          load_scale:
-            type: number
-            format: double
-            description: The scale multiplier for load parameters of generators
-            default: 1.0
-            minimum: 0.0
-            exclusiveMinimum: true
-          time_scale:
-            type: number
-            format: double
-            description: The scale multiplier for the length of each profile entry
-            default: 1.0
-            minimum: 0.0
-            exclusiveMinimum: true
           series:
             type: array
             items:
@@ -251,20 +237,6 @@ definitions:
       block:
         type: object
         properties:
-          load_scale:
-            type: number
-            format: double
-            description: The scale multiplier for load parameters of generators
-            default: 1.0
-            minimum: 0.0
-            exclusiveMinimum: true
-          time_scale:
-            type: number
-            format: double
-            description: The scale multiplier for the length of each profile entry
-            default: 1.0
-            minimum: 0.0
-            exclusiveMinimum: true
           series:
             type: array
             items:
@@ -291,20 +263,6 @@ definitions:
       cpu:
         type: object
         properties:
-          load_scale:
-            type: number
-            format: double
-            description: The scale multiplier for load parameters of generators
-            default: 1.0
-            minimum: 0.0
-            exclusiveMinimum: true
-          time_scale:
-            type: number
-            format: double
-            description: The scale multiplier for the length of each profile entry
-            default: 1.0
-            minimum: 0.0
-            exclusiveMinimum: true
           series:
             type: array
             items:
@@ -327,20 +285,6 @@ definitions:
       packet:
         type: object
         properties:
-          load_scale:
-            type: number
-            format: double
-            description: The scale multiplier for load parameters of generators
-            default: 1.0
-            minimum: 0.0
-            exclusiveMinimum: true
-          time_scale:
-            type: number
-            format: double
-            description: The scale multiplier for the length of each profile entry
-            default: 1.0
-            minimum: 0.0
-            exclusiveMinimum: true
           series:
             type: array
             items:
@@ -414,5 +358,23 @@ definitions:
     type: object
     description: TVLP series start configuration
     properties:
+      load_scale:
+        type: number
+        format: double
+        description: The scale multiplier for load parameters of generators
+        default: 1.0
+        minimum: 0.0
+        exclusiveMinimum: true
+      time_scale:
+        type: number
+        format: double
+        description: The scale multiplier for the length of each profile entry
+        default: 1.0
+        minimum: 0.0
+        exclusiveMinimum: true
+      start_time:
+        type: string
+        format: date-time
+        description: The ISO8601-formatted date and time to start profile replay
       dynamic_results:
         $ref: "./dynamic.yaml#/definitions/DynamicResultsConfig"

--- a/api/schema/v1/openperf.yaml
+++ b/api/schema/v1/openperf.yaml
@@ -37,9 +37,6 @@ parameters:
   dynamic_results:
     $ref: ./modules/dynamic.yaml#/parameters/dynamic_results
 
-  start_time:
-    $ref: ./modules/tvlp.yaml#/parameters/start_time
-
 tags:
   - name: Interfaces
   - name: Modules

--- a/doc/modules/tvlp.md
+++ b/doc/modules/tvlp.md
@@ -44,11 +44,22 @@ The TVLP module responds to the following configuration properties:
 
 #### Profile
 
-* **load_scale** - scale multiplier for load parameters of generators.
-* **time_scale** - scale multiplier for the length of each profile entry.
 * **series** - sequence of generator configurations
     * **config** - generator configuration
     * **length** - time of execution current configuration
+
+#### Start parameters
+
+* **start_time** - time of start profile in ISO8601 format.
+* **memory** - start options for the _memory_ series.
+* **block** - start options for the _block_ series.
+* **cpu** - start options for the _cpu_ series.
+* **packet** - start options for the _packet_ series.
+
+Start options:
+* **load_scale** - scale multiplier for load parameters of generators.
+* **time_scale** - scale multiplier for the length of each profile entry.
+* **dynamic_results** - dynamic results set for series.
 
 ### Load Scale
 
@@ -180,8 +191,19 @@ curl --location --request POST '<OPENPERF_HOST>:<OPENPERF_PORT>/tvlp' \
 
 ### Start existing TVLP Configuration
 
+Start immediately:
 ```bash
-curl --location --request POST '<OPENPERF_HOST>:<OPENPERF_PORT>/tvlp/:id/start?time=2020-10-01T00:00:00.000000Z'
+curl --location --request POST '<OPENPERF_HOST>:<OPENPERF_PORT>/tvlp/:id/start'
+```
+
+Start at specific time:
+```bash
+curl --location --request POST '<OPENPERF_HOST>:<OPENPERF_PORT>/tvlp/:id/start' \
+--header 'Content-Type: application/json' \
+--data-raw '
+{
+    "start_time": "2020-10-01T00:00:00.000000Z"
+}'
 ```
 
 ### Check the created TVLP Result

--- a/src/modules/tvlp/api.hpp
+++ b/src/modules/tvlp/api.hpp
@@ -47,8 +47,7 @@ using create = model::tvlp_configuration_t;
 struct start : message
 {
     std::string id;
-    time_point start_time;
-    model::tvlp_dynamic_t dynamic_results;
+    model::tvlp_start_t start_configuration;
 };
 struct stop : id_message
 {};

--- a/src/modules/tvlp/api.hpp
+++ b/src/modules/tvlp/api.hpp
@@ -20,8 +20,6 @@ namespace openperf::tvlp::api {
 
 static constexpr auto endpoint = "inproc://openperf_tvlp";
 
-using realtime = timesync::chrono::realtime;
-using time_point = realtime::time_point;
 using serialized_msg = openperf::message::serialized_message;
 
 struct message

--- a/src/modules/tvlp/api_converters.cpp
+++ b/src/modules/tvlp/api_converters.cpp
@@ -98,9 +98,9 @@ tvlp_configuration_t from_swagger(const swagger::TvlpConfiguration& m)
     if (m.getProfile()->blockIsSet()) {
         auto profile_model = m.getProfile()->getBlock();
 
-        profile.block = std::vector<tvlp_profile_entry_t>();
+        profile.block = tvlp_profile_t::series{};
         for (const auto& block_entry : profile_model->getSeries()) {
-            profile.block.value().push_back(tvlp_profile_entry_t{
+            profile.block.value().push_back(tvlp_profile_t::entry{
                 .length = model::duration(block_entry->getLength()),
                 .resource_id = block_entry->getResourceId(),
                 .config = block_entry->getConfig()->toJson(),
@@ -111,9 +111,9 @@ tvlp_configuration_t from_swagger(const swagger::TvlpConfiguration& m)
     if (m.getProfile()->memoryIsSet()) {
         auto profile_model = m.getProfile()->getMemory();
 
-        profile.memory = std::vector<tvlp_profile_entry_t>();
+        profile.memory = tvlp_profile_t::series{};
         for (const auto& memory_entry : profile_model->getSeries()) {
-            profile.memory.value().push_back(tvlp_profile_entry_t{
+            profile.memory.value().push_back(tvlp_profile_t::entry{
                 .length = model::duration(memory_entry->getLength()),
                 .config = memory_entry->getConfig()->toJson(),
             });
@@ -123,9 +123,9 @@ tvlp_configuration_t from_swagger(const swagger::TvlpConfiguration& m)
     if (m.getProfile()->cpuIsSet()) {
         auto profile_model = m.getProfile()->getCpu();
 
-        profile.cpu = std::vector<tvlp_profile_entry_t>();
+        profile.cpu = tvlp_profile_t::series{};
         for (const auto& cpu_entry : profile_model->getSeries()) {
-            profile.cpu.value().push_back(tvlp_profile_entry_t{
+            profile.cpu.value().push_back(tvlp_profile_t::entry{
                 .length = model::duration(cpu_entry->getLength()),
                 .config = cpu_entry->getConfig()->toJson(),
             });
@@ -135,9 +135,9 @@ tvlp_configuration_t from_swagger(const swagger::TvlpConfiguration& m)
     if (m.getProfile()->packetIsSet()) {
         auto profile_model = m.getProfile()->getPacket();
 
-        profile.packet = std::vector<tvlp_profile_entry_t>();
+        profile.packet = tvlp_profile_t::series{};
         for (const auto& packet_entry : profile_model->getSeries()) {
-            profile.packet.value().push_back(tvlp_profile_entry_t{
+            profile.packet.value().push_back(tvlp_profile_t::entry{
                 .length = model::duration(packet_entry->getLength()),
                 .resource_id = packet_entry->getTargetId(),
                 .config = packet_entry->getConfig()->toJson(),

--- a/src/modules/tvlp/api_converters.cpp
+++ b/src/modules/tvlp/api_converters.cpp
@@ -49,16 +49,16 @@ is_valid(const swagger::TvlpStartConfiguration& config)
 {
     auto errors = std::vector<std::string>();
 
-    auto scale_check = [&errors](auto&& profile) {
-        if (profile->getTimeScale() <= 0.0) {
+    auto scale_check = [&errors](auto&& start_options) {
+        if (start_options->getTimeScale() <= 0.0) {
             errors.emplace_back("Time scale value '"
-                                + std::to_string(profile->getTimeScale())
+                                + std::to_string(start_options->getTimeScale())
                                 + "' should be greater than 0.0");
         }
 
-        if (profile->getLoadScale() <= 0.0) {
+        if (start_options->getLoadScale() <= 0.0) {
             errors.emplace_back("Load scale value '"
-                                + std::to_string(profile->getLoadScale())
+                                + std::to_string(start_options->getLoadScale())
                                 + "' should be greater than 0.0");
         }
     };
@@ -78,9 +78,9 @@ is_valid(const swagger::TvlpStartConfiguration& config)
 
 void apply_defaults(swagger::TvlpStartConfiguration& config)
 {
-    auto apply_scales = [](auto&& profile) {
-        if (!profile->timeScaleIsSet()) profile->setTimeScale(1.0);
-        if (!profile->loadScaleIsSet()) profile->setLoadScale(1.0);
+    auto apply_scales = [](auto&& start_options) {
+        if (!start_options->timeScaleIsSet()) start_options->setTimeScale(1.0);
+        if (!start_options->loadScaleIsSet()) start_options->setLoadScale(1.0);
     };
 
     if (config.blockIsSet()) apply_scales(config.getBlock());

--- a/src/modules/tvlp/api_converters.hpp
+++ b/src/modules/tvlp/api_converters.hpp
@@ -15,10 +15,12 @@ namespace swagger = ::swagger::v1::model;
 using namespace tvlp::model;
 
 tl::expected<bool, std::vector<std::string>>
-is_valid(const swagger::TvlpConfiguration&);
+is_valid(const swagger::TvlpStartConfiguration&);
 
 std::optional<time_point> from_rfc3339(const std::string& from);
-tvlp_dynamic_t from_swagger(const swagger::TvlpStartConfiguration&);
+void apply_defaults(swagger::TvlpStartConfiguration&);
+
+tvlp_start_t from_swagger(const swagger::TvlpStartConfiguration&);
 tvlp_configuration_t from_swagger(const swagger::TvlpConfiguration&);
 swagger::TvlpConfiguration to_swagger(const tvlp_configuration_t&);
 swagger::TvlpResult to_swagger(const tvlp_result_t&);

--- a/src/modules/tvlp/api_transmogrify.cpp
+++ b/src/modules/tvlp/api_transmogrify.cpp
@@ -21,13 +21,11 @@ serialized_msg serialize(api_request&& msg)
                  },
                  [&](request::tvlp::start& start) -> int {
                      return openperf::message::push(serialized, start.id)
-                            || openperf::message::push(serialized,
-                                                       start.start_time)
                             || openperf::message::push(
                                 serialized,
                                 std::make_unique<decltype(
-                                    start.dynamic_results)>(
-                                    std::move(start.dynamic_results)));
+                                    start.start_configuration)>(
+                                    std::move(start.start_configuration)));
                  },
                  [&](const id_message& msg) {
                      return openperf::message::push(serialized, msg.id);
@@ -101,10 +99,9 @@ tl::expected<api_request, int> deserialize_request(serialized_msg&& msg)
     case utils::variant_index<api_request, request::tvlp::start>(): {
         request::tvlp::start request{};
         request.id = openperf::message::pop_string(msg);
-        request.start_time = openperf::message::pop<time_point>(msg);
-        request.dynamic_results =
-            std::move(*std::unique_ptr<decltype(request.dynamic_results)>(
-                openperf::message::pop<decltype(request.dynamic_results)*>(
+        request.start_configuration =
+            std::move(*std::unique_ptr<decltype(request.start_configuration)>(
+                openperf::message::pop<decltype(request.start_configuration)*>(
                     msg)));
         return request;
     }

--- a/src/modules/tvlp/controller.cpp
+++ b/src/modules/tvlp/controller.cpp
@@ -20,7 +20,7 @@ controller_t::controller_t(void* context,
     : model::tvlp_configuration_t(model)
     , m_context(context)
 {
-    auto scale_length = [](model::tvlp_module_profile_t& profiles) {
+    auto series_length = [](model::tvlp_module_profile_t& profiles) {
         duration total_length = 0ms;
         for (const auto& p : profiles) {
             if (p.length <= 0ms) {
@@ -38,28 +38,28 @@ controller_t::controller_t(void* context,
     duration total_length = 0ms;
     if (m_profile.block) {
         total_length =
-            std::max(total_length, scale_length(m_profile.block.value()));
+            std::max(total_length, series_length(m_profile.block.value()));
         m_block = std::make_unique<worker::block_tvlp_worker_t>(
             m_context, m_profile.block.value());
     }
 
     if (m_profile.memory) {
         total_length =
-            std::max(total_length, scale_length(m_profile.memory.value()));
+            std::max(total_length, series_length(m_profile.memory.value()));
         m_memory = std::make_unique<worker::memory_tvlp_worker_t>(
             m_context, m_profile.memory.value());
     }
 
     if (m_profile.cpu) {
         total_length =
-            std::max(total_length, scale_length(m_profile.cpu.value()));
+            std::max(total_length, series_length(m_profile.cpu.value()));
         m_cpu = std::make_unique<worker::cpu_tvlp_worker_t>(
             m_context, m_profile.cpu.value());
     }
 
     if (m_profile.packet) {
         total_length =
-            std::max(total_length, scale_length(m_profile.packet.value()));
+            std::max(total_length, series_length(m_profile.packet.value()));
         m_packet = std::make_unique<worker::packet_tvlp_worker_t>(
             m_context, m_profile.packet.value());
     }

--- a/src/modules/tvlp/controller.cpp
+++ b/src/modules/tvlp/controller.cpp
@@ -20,7 +20,6 @@ controller_t::controller_t(void* context,
     : model::tvlp_configuration_t(model)
     , m_context(context)
 {
-
     auto scale_length = [](model::tvlp_module_profile_t& profiles) {
         duration total_length = 0ms;
         for (const auto& p : profiles) {
@@ -30,9 +29,7 @@ controller_t::controller_t(void* context,
                     "or equal to zero");
             }
 
-            total_length +=
-                std::chrono::duration_cast<std::chrono::nanoseconds>(
-                    p.length * p.time_scale);
+            total_length += p.length;
         }
 
         return total_length;
@@ -78,8 +75,7 @@ controller_t::controller_t(void* context,
 }
 
 std::shared_ptr<model::tvlp_result_t>
-controller_t::start(const time_point& start_time,
-                    const model::tvlp_dynamic_t& dynamic_results)
+controller_t::start(const model::tvlp_start_t& start_configuration)
 {
     if (is_running()) return m_result;
 
@@ -87,30 +83,38 @@ controller_t::start(const time_point& start_time,
 
     if (m_profile.block) {
         modules_results.block = model::json_vector();
+
         // Starting already running worker should never happen
-        assert(m_block->start(start_time, dynamic_results.block));
+        assert(m_block->start(start_configuration.start_time,
+                              start_configuration.block));
     }
 
     if (m_profile.memory) {
         modules_results.memory = model::json_vector();
+
         // Starting already running worker should never happen
-        assert(m_memory->start(start_time, dynamic_results.memory));
+        assert(m_memory->start(start_configuration.start_time,
+                               start_configuration.memory));
     }
 
     if (m_profile.cpu) {
         modules_results.cpu = model::json_vector();
+
         // Starting already running worker should never happen
-        assert(m_cpu->start(start_time, dynamic_results.cpu));
+        assert(m_cpu->start(start_configuration.start_time,
+                            start_configuration.cpu));
     }
 
     if (m_profile.packet) {
         modules_results.packet = model::json_vector();
+
         // Starting already running worker should never happen
-        assert(m_packet->start(start_time, dynamic_results.packet));
+        assert(m_packet->start(start_configuration.start_time,
+                               start_configuration.packet));
     }
 
-    m_start_time = start_time;
-    if (start_time > timesync::chrono::realtime::now())
+    m_start_time = start_configuration.start_time;
+    if (m_start_time > timesync::chrono::realtime::now())
         m_state = model::COUNTDOWN;
     else
         m_state = model::RUNNING;

--- a/src/modules/tvlp/controller.cpp
+++ b/src/modules/tvlp/controller.cpp
@@ -20,9 +20,9 @@ controller_t::controller_t(void* context,
     : model::tvlp_configuration_t(model)
     , m_context(context)
 {
-    auto series_length = [](model::tvlp_profile_t::series& profiles) {
+    auto series_length = [](const model::tvlp_profile_t::series& series) {
         duration total_length = 0ms;
-        for (const auto& p : profiles) {
+        for (const auto& p : series) {
             if (p.length <= 0ms) {
                 throw std::runtime_error(
                     "Invalid field value: profile length cannot be less than "

--- a/src/modules/tvlp/controller.cpp
+++ b/src/modules/tvlp/controller.cpp
@@ -20,7 +20,7 @@ controller_t::controller_t(void* context,
     : model::tvlp_configuration_t(model)
     , m_context(context)
 {
-    auto series_length = [](model::tvlp_module_profile_t& profiles) {
+    auto series_length = [](model::tvlp_profile_t::series& profiles) {
         duration total_length = 0ms;
         for (const auto& p : profiles) {
             if (p.length <= 0ms) {

--- a/src/modules/tvlp/controller.hpp
+++ b/src/modules/tvlp/controller.hpp
@@ -13,10 +13,9 @@ namespace openperf::tvlp::internal {
 
 class controller_t : public model::tvlp_configuration_t
 {
-    using time_point = std::chrono::time_point<timesync::chrono::realtime>;
+    static constexpr auto NAME_PREFIX = "op_tvlp";
 
 private:
-    static constexpr auto NAME_PREFIX = "op_tvlp";
     void* m_context;
     std::shared_ptr<model::tvlp_result_t> m_result;
     std::unique_ptr<worker::tvlp_worker_t> m_block, m_memory, m_cpu, m_packet;

--- a/src/modules/tvlp/controller.hpp
+++ b/src/modules/tvlp/controller.hpp
@@ -32,8 +32,7 @@ public:
     controller_t& operator=(const controller_t&) = delete;
 
     std::shared_ptr<model::tvlp_result_t>
-    start(const time_point& start_time,
-          const model::tvlp_dynamic_t& dynamic_results);
+    start(const model::tvlp_start_t& start_configuration);
     void stop();
     bool is_running() const;
 

--- a/src/modules/tvlp/controller_stack.cpp
+++ b/src/modules/tvlp/controller_stack.cpp
@@ -67,8 +67,7 @@ tl::expected<void, std::string> controller_stack::erase(const std::string& id)
 
 tl::expected<controller_stack::tvlp_result_ptr, std::string>
 controller_stack::start(const std::string& id,
-                        const time_point& start_time,
-                        const model::tvlp_dynamic_t& dynamic_results)
+                        const model::tvlp_start_t& start_configuration)
 {
     auto controller = get(id);
     if (!controller) return tl::make_unexpected(controller.error());
@@ -77,7 +76,7 @@ controller_stack::start(const std::string& id,
         return tl::make_unexpected("Generator is already in running state");
     }
 
-    auto result = controller.value()->start(start_time, dynamic_results);
+    auto result = controller.value()->start(start_configuration);
     m_results[result->id()] = result;
     return result;
 }

--- a/src/modules/tvlp/controller_stack.hpp
+++ b/src/modules/tvlp/controller_stack.hpp
@@ -36,7 +36,7 @@ public:
     tl::expected<void, std::string> erase(const std::string& id);
 
     tl::expected<tvlp_result_ptr, std::string>
-    start(const std::string&, const time_point&, const model::tvlp_dynamic_t&);
+    start(const std::string&, const model::tvlp_start_t&);
     tl::expected<void, std::string> stop(const std::string&);
 
     std::vector<tvlp_result_ptr> results() const;

--- a/src/modules/tvlp/controller_stack.hpp
+++ b/src/modules/tvlp/controller_stack.hpp
@@ -12,7 +12,6 @@ namespace openperf::tvlp::internal {
 
 class controller_stack
 {
-    using time_point = std::chrono::time_point<timesync::chrono::realtime>;
     using tvlp_controller_ptr = std::shared_ptr<controller_t>;
     using tvlp_controller_map =
         std::unordered_map<std::string, tvlp_controller_ptr>;

--- a/src/modules/tvlp/models/tvlp_config.hpp
+++ b/src/modules/tvlp/models/tvlp_config.hpp
@@ -12,6 +12,8 @@
 
 namespace openperf::tvlp::model {
 
+using ref_clock = timesync::chrono::monotime;
+using realtime = timesync::chrono::realtime;
 using duration = std::chrono::nanoseconds;
 using time_point = timesync::chrono::realtime::time_point;
 
@@ -41,7 +43,7 @@ struct tvlp_start_t
         dynamic::configuration dynamic_results;
     };
 
-    time_point start_time = timesync::chrono::realtime::now();
+    time_point start_time = realtime::now();
     start_t block;
     start_t cpu;
     start_t memory;

--- a/src/modules/tvlp/models/tvlp_config.hpp
+++ b/src/modules/tvlp/models/tvlp_config.hpp
@@ -13,15 +13,13 @@
 namespace openperf::tvlp::model {
 
 using duration = std::chrono::nanoseconds;
-using time_point = std::chrono::time_point<timesync::chrono::realtime>;
+using time_point = timesync::chrono::realtime::time_point;
 
 struct tvlp_profile_entry_t
 {
     duration length;
     std::optional<std::string> resource_id;
     nlohmann::json config;
-    double time_scale = 1.0;
-    double load_scale = 1.0;
 };
 
 using tvlp_module_profile_t = std::vector<tvlp_profile_entry_t>;
@@ -34,12 +32,20 @@ struct tvlp_profile_t
     std::optional<tvlp_module_profile_t> packet;
 };
 
-struct tvlp_dynamic_t
+struct tvlp_start_t
 {
-    std::optional<dynamic::configuration> block;
-    std::optional<dynamic::configuration> cpu;
-    std::optional<dynamic::configuration> memory;
-    std::optional<dynamic::configuration> packet;
+    struct start_t
+    {
+        double time_scale = 1.0;
+        double load_scale = 1.0;
+        dynamic::configuration dynamic_results;
+    };
+
+    time_point start_time = timesync::chrono::realtime::now();
+    start_t block;
+    start_t cpu;
+    start_t memory;
+    start_t packet;
 };
 
 enum tvlp_state_t { READY = 0, COUNTDOWN, RUNNING, ERROR };

--- a/src/modules/tvlp/models/tvlp_config.hpp
+++ b/src/modules/tvlp/models/tvlp_config.hpp
@@ -17,21 +17,21 @@ using realtime = timesync::chrono::realtime;
 using duration = std::chrono::nanoseconds;
 using time_point = timesync::chrono::realtime::time_point;
 
-struct tvlp_profile_entry_t
-{
-    duration length;
-    std::optional<std::string> resource_id;
-    nlohmann::json config;
-};
-
-using tvlp_module_profile_t = std::vector<tvlp_profile_entry_t>;
-
 struct tvlp_profile_t
 {
-    std::optional<tvlp_module_profile_t> block;
-    std::optional<tvlp_module_profile_t> cpu;
-    std::optional<tvlp_module_profile_t> memory;
-    std::optional<tvlp_module_profile_t> packet;
+    struct entry
+    {
+        duration length;
+        std::optional<std::string> resource_id;
+        nlohmann::json config;
+    };
+
+    using series = std::vector<entry>;
+
+    std::optional<series> block;
+    std::optional<series> cpu;
+    std::optional<series> memory;
+    std::optional<series> packet;
 };
 
 struct tvlp_start_t

--- a/src/modules/tvlp/server.cpp
+++ b/src/modules/tvlp/server.cpp
@@ -121,8 +121,8 @@ api_reply server::handle_request(const request::tvlp::start& request)
         };
     }
 
-    auto result = m_controller_stack->start(
-        request.id, request.start_time, request.dynamic_results);
+    auto result =
+        m_controller_stack->start(request.id, request.start_configuration);
     if (!result) {
         return reply::error{
             .type = reply::error::BAD_REQUEST_ERROR,

--- a/src/modules/tvlp/worker.cpp
+++ b/src/modules/tvlp/worker.cpp
@@ -9,7 +9,7 @@ constexpr model::duration THRESHOLD = 100ms;
 
 tvlp_worker_t::tvlp_worker_t(void* context,
                              const std::string& endpoint,
-                             const model::tvlp_module_profile_t& profile)
+                             const model::tvlp_profile_t::series& profile)
     : m_socket(op_socket_get_client(context, ZMQ_REQ, endpoint.data()))
     , m_profile(profile)
 {
@@ -41,9 +41,7 @@ tvlp_worker_t::start(const model::time_point& start_time,
     delete m_result.exchange(new model::json_vector());
     m_scheduler_thread = std::async(
         std::launch::async,
-        [this](const model::tvlp_module_profile_t& profile,
-               const model::time_point& time,
-               const model::tvlp_start_t::start_t start) {
+        [this](auto&& profile, auto&& time, auto&& start) {
             return schedule(profile, time, start);
         },
         m_profile,
@@ -108,7 +106,7 @@ void tvlp_worker_t::store_results(const nlohmann::json& result,
 }
 
 tl::expected<void, std::string>
-tvlp_worker_t::schedule(const model::tvlp_module_profile_t& profile,
+tvlp_worker_t::schedule(const model::tvlp_profile_t::series& profile,
                         const model::time_point& start_time,
                         const model::tvlp_start_t::start_t& start_config)
 {

--- a/src/modules/tvlp/worker.hpp
+++ b/src/modules/tvlp/worker.hpp
@@ -36,7 +36,7 @@ public:
     tvlp_worker_t(const tvlp_worker_t&) = delete;
     explicit tvlp_worker_t(void*,
                            const std::string&,
-                           const model::tvlp_module_profile_t&);
+                           const model::tvlp_profile_t::series&);
     virtual ~tvlp_worker_t();
 
     tl::expected<void, std::string> start(const model::time_point& start_time,
@@ -50,7 +50,7 @@ public:
 
 protected:
     virtual tl::expected<std::string, std::string>
-    send_create(const model::tvlp_profile_entry_t&, double load_scale) = 0;
+    send_create(const model::tvlp_profile_t::entry&, double load_scale) = 0;
     virtual tl::expected<stat_pair_t, std::string>
     send_start(const std::string& id,
                const dynamic::configuration& dynamic_results = {}) = 0;
@@ -68,7 +68,7 @@ protected:
 
 private:
     tl::expected<void, std::string>
-    schedule(const model::tvlp_module_profile_t& profile,
+    schedule(const model::tvlp_profile_t::series& profile,
              const model::time_point& time,
              const model::tvlp_start_t::start_t& start_config);
 
@@ -76,7 +76,7 @@ private:
     std::string m_error;
     std::atomic<model::json_vector*> m_result;
     worker_future m_scheduler_thread;
-    model::tvlp_module_profile_t m_profile;
+    model::tvlp_profile_t::series m_profile;
 
     enum class result_store_operation { ADD = 0, UPDATE };
     void store_results(const nlohmann::json& result,

--- a/src/modules/tvlp/worker.hpp
+++ b/src/modules/tvlp/worker.hpp
@@ -42,10 +42,8 @@ public:
                            const model::tvlp_module_profile_t&);
     virtual ~tvlp_worker_t();
 
-    tl::expected<void, std::string>
-    start(const realtime::time_point& start_time = realtime::now(),
-          const std::optional<dynamic::configuration>& dynamic_results =
-              std::nullopt);
+    tl::expected<void, std::string> start(const model::time_point& start_time,
+                                          const model::tvlp_start_t::start_t&);
     void stop();
 
     model::tvlp_state_t state() const;
@@ -55,7 +53,7 @@ public:
 
 protected:
     virtual tl::expected<std::string, std::string>
-    send_create(const model::tvlp_profile_entry_t&) = 0;
+    send_create(const model::tvlp_profile_entry_t&, double load_scale) = 0;
     virtual tl::expected<stat_pair_t, std::string>
     send_start(const std::string& id,
                const dynamic::configuration& dynamic_results = {}) = 0;
@@ -73,10 +71,9 @@ protected:
 
 private:
     tl::expected<void, std::string>
-    schedule(realtime::time_point start_time,
-             const model::tvlp_module_profile_t& profile,
-             const std::optional<dynamic::configuration>& dynamic_results =
-                 std::nullopt);
+    schedule(const model::tvlp_module_profile_t& profile,
+             const model::time_point& time,
+             const model::tvlp_start_t::start_t& start_config);
 
     tvlp_worker_state_t m_state;
     std::string m_error;

--- a/src/modules/tvlp/worker.hpp
+++ b/src/modules/tvlp/worker.hpp
@@ -76,7 +76,7 @@ private:
     std::string m_error;
     std::atomic<model::json_vector*> m_result;
     worker_future m_scheduler_thread;
-    model::tvlp_profile_t::series m_profile;
+    model::tvlp_profile_t::series m_series;
 
     enum class result_store_operation { ADD = 0, UPDATE };
     void store_results(const nlohmann::json& result,

--- a/src/modules/tvlp/worker.hpp
+++ b/src/modules/tvlp/worker.hpp
@@ -18,15 +18,12 @@
 namespace openperf::tvlp::internal::worker {
 
 using namespace std::chrono_literals;
-using ref_clock = timesync::chrono::monotime;
-using realtime = timesync::chrono::realtime;
-using duration = std::chrono::nanoseconds;
 using stat_pair_t = std::pair<std::string, nlohmann::json>;
 
 struct tvlp_worker_state_t
 {
     std::atomic<model::tvlp_state_t> state;
-    std::atomic<duration> offset;
+    std::atomic<model::duration> offset;
     std::atomic_bool stopped;
 };
 
@@ -48,7 +45,7 @@ public:
 
     model::tvlp_state_t state() const;
     std::optional<std::string> error() const;
-    duration offset() const;
+    model::duration offset() const;
     model::json_vector results() const;
 
 protected:

--- a/src/modules/tvlp/workers/block.cpp
+++ b/src/modules/tvlp/workers/block.cpp
@@ -11,14 +11,14 @@ namespace swagger = swagger::v1::model;
 using namespace openperf::block::api;
 
 block_tvlp_worker_t::block_tvlp_worker_t(
-    void* context, const model::tvlp_module_profile_t& profile)
+    void* context, const model::tvlp_profile_t::series& profile)
     : tvlp_worker_t(context, endpoint, profile)
 {}
 
 block_tvlp_worker_t::~block_tvlp_worker_t() { stop(); }
 
 tl::expected<std::string, std::string>
-block_tvlp_worker_t::send_create(const model::tvlp_profile_entry_t& entry,
+block_tvlp_worker_t::send_create(const model::tvlp_profile_t::entry& entry,
                                  double load_scale)
 {
     assert(entry.resource_id.has_value());

--- a/src/modules/tvlp/workers/block.cpp
+++ b/src/modules/tvlp/workers/block.cpp
@@ -18,7 +18,8 @@ block_tvlp_worker_t::block_tvlp_worker_t(
 block_tvlp_worker_t::~block_tvlp_worker_t() { stop(); }
 
 tl::expected<std::string, std::string>
-block_tvlp_worker_t::send_create(const model::tvlp_profile_entry_t& entry)
+block_tvlp_worker_t::send_create(const model::tvlp_profile_entry_t& entry,
+                                 double load_scale)
 {
     assert(entry.resource_id.has_value());
 
@@ -27,13 +28,13 @@ block_tvlp_worker_t::send_create(const model::tvlp_profile_entry_t& entry)
 
     // Apply Load Scale to generator configuration
     config->setReadSize(
-        static_cast<uint32_t>(config->getReadSize() * entry.load_scale));
+        static_cast<uint32_t>(config->getReadSize() * load_scale));
     config->setReadsPerSec(
-        static_cast<uint32_t>(config->getReadsPerSec() * entry.load_scale));
+        static_cast<uint32_t>(config->getReadsPerSec() * load_scale));
     config->setWriteSize(
-        static_cast<uint32_t>(config->getWriteSize() * entry.load_scale));
+        static_cast<uint32_t>(config->getWriteSize() * load_scale));
     config->setWritesPerSec(
-        static_cast<uint32_t>(config->getWritesPerSec() * entry.load_scale));
+        static_cast<uint32_t>(config->getWritesPerSec() * load_scale));
 
     swagger::BlockGenerator gen;
     gen.setResourceId(entry.resource_id.value());

--- a/src/modules/tvlp/workers/block.cpp
+++ b/src/modules/tvlp/workers/block.cpp
@@ -11,8 +11,8 @@ namespace swagger = swagger::v1::model;
 using namespace openperf::block::api;
 
 block_tvlp_worker_t::block_tvlp_worker_t(
-    void* context, const model::tvlp_profile_t::series& profile)
-    : tvlp_worker_t(context, endpoint, profile)
+    void* context, const model::tvlp_profile_t::series& series)
+    : tvlp_worker_t(context, endpoint, series)
 {}
 
 block_tvlp_worker_t::~block_tvlp_worker_t() { stop(); }

--- a/src/modules/tvlp/workers/block.hpp
+++ b/src/modules/tvlp/workers/block.hpp
@@ -10,12 +10,13 @@ class block_tvlp_worker_t : public tvlp_worker_t
 public:
     block_tvlp_worker_t() = delete;
     block_tvlp_worker_t(const block_tvlp_worker_t&) = delete;
-    block_tvlp_worker_t(void* context, const model::tvlp_module_profile_t&);
+    block_tvlp_worker_t(void* context, const model::tvlp_profile_t::series&);
     ~block_tvlp_worker_t();
 
 protected:
     tl::expected<std::string, std::string>
-    send_create(const model::tvlp_profile_entry_t&, double load_scale) override;
+    send_create(const model::tvlp_profile_t::entry&,
+                double load_scale) override;
     tl::expected<stat_pair_t, std::string>
     send_start(const std::string& id,
                const dynamic::configuration& dynamic_results) override;

--- a/src/modules/tvlp/workers/block.hpp
+++ b/src/modules/tvlp/workers/block.hpp
@@ -15,7 +15,7 @@ public:
 
 protected:
     tl::expected<std::string, std::string>
-    send_create(const model::tvlp_profile_entry_t&) override;
+    send_create(const model::tvlp_profile_entry_t&, double load_scale) override;
     tl::expected<stat_pair_t, std::string>
     send_start(const std::string& id,
                const dynamic::configuration& dynamic_results) override;

--- a/src/modules/tvlp/workers/cpu.cpp
+++ b/src/modules/tvlp/workers/cpu.cpp
@@ -11,8 +11,8 @@ namespace swagger = swagger::v1::model;
 using namespace openperf::cpu::api;
 
 cpu_tvlp_worker_t::cpu_tvlp_worker_t(
-    void* context, const model::tvlp_profile_t::series& profile)
-    : tvlp_worker_t(context, endpoint, profile){};
+    void* context, const model::tvlp_profile_t::series& series)
+    : tvlp_worker_t(context, endpoint, series){};
 
 cpu_tvlp_worker_t::~cpu_tvlp_worker_t() { stop(); }
 

--- a/src/modules/tvlp/workers/cpu.cpp
+++ b/src/modules/tvlp/workers/cpu.cpp
@@ -17,18 +17,19 @@ cpu_tvlp_worker_t::cpu_tvlp_worker_t(
 cpu_tvlp_worker_t::~cpu_tvlp_worker_t() { stop(); }
 
 tl::expected<std::string, std::string>
-cpu_tvlp_worker_t::send_create(const model::tvlp_profile_entry_t& entry)
+cpu_tvlp_worker_t::send_create(const model::tvlp_profile_entry_t& entry,
+                               double load_scale)
 {
     auto config = std::make_shared<swagger::CpuGeneratorConfig>();
     config->fromJson(const_cast<nlohmann::json&>(entry.config));
     if (config->getMethod() == "system") {
         config->getSystem()->setUtilization(
-            std::min(config->getSystem()->getUtilization() * entry.load_scale,
+            std::min(config->getSystem()->getUtilization() * load_scale,
                      100.0 * op_get_cpu_count()));
     } else if (config->getMethod() == "cores") {
         for (auto& core : config->getCores()) {
             core->setUtilization(
-                std::min(core->getUtilization() * entry.load_scale, 100.0));
+                std::min(core->getUtilization() * load_scale, 100.0));
         }
     }
 

--- a/src/modules/tvlp/workers/cpu.cpp
+++ b/src/modules/tvlp/workers/cpu.cpp
@@ -11,13 +11,13 @@ namespace swagger = swagger::v1::model;
 using namespace openperf::cpu::api;
 
 cpu_tvlp_worker_t::cpu_tvlp_worker_t(
-    void* context, const model::tvlp_module_profile_t& profile)
+    void* context, const model::tvlp_profile_t::series& profile)
     : tvlp_worker_t(context, endpoint, profile){};
 
 cpu_tvlp_worker_t::~cpu_tvlp_worker_t() { stop(); }
 
 tl::expected<std::string, std::string>
-cpu_tvlp_worker_t::send_create(const model::tvlp_profile_entry_t& entry,
+cpu_tvlp_worker_t::send_create(const model::tvlp_profile_t::entry& entry,
                                double load_scale)
 {
     auto config = std::make_shared<swagger::CpuGeneratorConfig>();

--- a/src/modules/tvlp/workers/cpu.hpp
+++ b/src/modules/tvlp/workers/cpu.hpp
@@ -10,12 +10,13 @@ class cpu_tvlp_worker_t : public tvlp_worker_t
 public:
     cpu_tvlp_worker_t() = delete;
     cpu_tvlp_worker_t(const cpu_tvlp_worker_t&) = delete;
-    cpu_tvlp_worker_t(void* context, const model::tvlp_module_profile_t&);
+    cpu_tvlp_worker_t(void* context, const model::tvlp_profile_t::series&);
     ~cpu_tvlp_worker_t();
 
 protected:
     tl::expected<std::string, std::string>
-    send_create(const model::tvlp_profile_entry_t&, double load_scale) override;
+    send_create(const model::tvlp_profile_t::entry&,
+                double load_scale) override;
     tl::expected<stat_pair_t, std::string>
     send_start(const std::string& id,
                const dynamic::configuration& dynamic_results) override;

--- a/src/modules/tvlp/workers/cpu.hpp
+++ b/src/modules/tvlp/workers/cpu.hpp
@@ -15,7 +15,7 @@ public:
 
 protected:
     tl::expected<std::string, std::string>
-    send_create(const model::tvlp_profile_entry_t&) override;
+    send_create(const model::tvlp_profile_entry_t&, double load_scale) override;
     tl::expected<stat_pair_t, std::string>
     send_start(const std::string& id,
                const dynamic::configuration& dynamic_results) override;

--- a/src/modules/tvlp/workers/memory.cpp
+++ b/src/modules/tvlp/workers/memory.cpp
@@ -19,20 +19,21 @@ memory_tvlp_worker_t::memory_tvlp_worker_t(
 memory_tvlp_worker_t::~memory_tvlp_worker_t() { stop(); }
 
 tl::expected<std::string, std::string>
-memory_tvlp_worker_t::send_create(const model::tvlp_profile_entry_t& entry)
+memory_tvlp_worker_t::send_create(const model::tvlp_profile_entry_t& entry,
+                                  double load_scale)
 {
     auto config = swagger::MemoryGeneratorConfig{};
     config.fromJson(const_cast<nlohmann::json&>(entry.config));
 
     // Apply Load Scale to generator configuration
     config.setReadSize(
-        static_cast<uint32_t>(config.getReadSize() * entry.load_scale));
+        static_cast<uint32_t>(config.getReadSize() * load_scale));
     config.setReadsPerSec(
-        static_cast<uint32_t>(config.getReadsPerSec() * entry.load_scale));
+        static_cast<uint32_t>(config.getReadsPerSec() * load_scale));
     config.setWriteSize(
-        static_cast<uint32_t>(config.getWriteSize() * entry.load_scale));
+        static_cast<uint32_t>(config.getWriteSize() * load_scale));
     config.setWritesPerSec(
-        static_cast<uint32_t>(config.getWritesPerSec() * entry.load_scale));
+        static_cast<uint32_t>(config.getWritesPerSec() * load_scale));
 
     request::generator::create data{
         .is_running = false,

--- a/src/modules/tvlp/workers/memory.cpp
+++ b/src/modules/tvlp/workers/memory.cpp
@@ -12,8 +12,8 @@ using namespace openperf::memory::api;
 // using namespace Pistache;
 
 memory_tvlp_worker_t::memory_tvlp_worker_t(
-    void* context, const model::tvlp_profile_t::series& profile)
-    : tvlp_worker_t(context, endpoint, profile)
+    void* context, const model::tvlp_profile_t::series& series)
+    : tvlp_worker_t(context, endpoint, series)
 {}
 
 memory_tvlp_worker_t::~memory_tvlp_worker_t() { stop(); }

--- a/src/modules/tvlp/workers/memory.cpp
+++ b/src/modules/tvlp/workers/memory.cpp
@@ -12,14 +12,14 @@ using namespace openperf::memory::api;
 // using namespace Pistache;
 
 memory_tvlp_worker_t::memory_tvlp_worker_t(
-    void* context, const model::tvlp_module_profile_t& profile)
+    void* context, const model::tvlp_profile_t::series& profile)
     : tvlp_worker_t(context, endpoint, profile)
 {}
 
 memory_tvlp_worker_t::~memory_tvlp_worker_t() { stop(); }
 
 tl::expected<std::string, std::string>
-memory_tvlp_worker_t::send_create(const model::tvlp_profile_entry_t& entry,
+memory_tvlp_worker_t::send_create(const model::tvlp_profile_t::entry& entry,
                                   double load_scale)
 {
     auto config = swagger::MemoryGeneratorConfig{};

--- a/src/modules/tvlp/workers/memory.hpp
+++ b/src/modules/tvlp/workers/memory.hpp
@@ -10,12 +10,13 @@ class memory_tvlp_worker_t : public tvlp_worker_t
 public:
     memory_tvlp_worker_t() = delete;
     memory_tvlp_worker_t(const memory_tvlp_worker_t&) = delete;
-    memory_tvlp_worker_t(void* context, const model::tvlp_module_profile_t&);
+    memory_tvlp_worker_t(void* context, const model::tvlp_profile_t::series&);
     ~memory_tvlp_worker_t();
 
 protected:
     tl::expected<std::string, std::string>
-    send_create(const model::tvlp_profile_entry_t&, double load_scale) override;
+    send_create(const model::tvlp_profile_t::entry&,
+                double load_scale) override;
     tl::expected<stat_pair_t, std::string>
     send_start(const std::string& id,
                const dynamic::configuration& dynamic_results) override;

--- a/src/modules/tvlp/workers/memory.hpp
+++ b/src/modules/tvlp/workers/memory.hpp
@@ -15,7 +15,7 @@ public:
 
 protected:
     tl::expected<std::string, std::string>
-    send_create(const model::tvlp_profile_entry_t&) override;
+    send_create(const model::tvlp_profile_entry_t&, double load_scale) override;
     tl::expected<stat_pair_t, std::string>
     send_start(const std::string& id,
                const dynamic::configuration& dynamic_results) override;

--- a/src/modules/tvlp/workers/packet.cpp
+++ b/src/modules/tvlp/workers/packet.cpp
@@ -13,8 +13,8 @@ using namespace openperf::packet::generator::api;
 using namespace Pistache;
 
 packet_tvlp_worker_t::packet_tvlp_worker_t(
-    void* context, const model::tvlp_profile_t::series& profile)
-    : tvlp_worker_t(context, std::string(endpoint), profile){};
+    void* context, const model::tvlp_profile_t::series& series)
+    : tvlp_worker_t(context, std::string(endpoint), series){};
 
 packet_tvlp_worker_t::~packet_tvlp_worker_t() { stop(); }
 

--- a/src/modules/tvlp/workers/packet.cpp
+++ b/src/modules/tvlp/workers/packet.cpp
@@ -19,7 +19,8 @@ packet_tvlp_worker_t::packet_tvlp_worker_t(
 packet_tvlp_worker_t::~packet_tvlp_worker_t() { stop(); }
 
 tl::expected<std::string, std::string>
-packet_tvlp_worker_t::send_create(const model::tvlp_profile_entry_t& entry)
+packet_tvlp_worker_t::send_create(const model::tvlp_profile_entry_t& entry,
+                                  double load_scale)
 {
     assert(entry.resource_id.has_value());
 
@@ -29,10 +30,10 @@ packet_tvlp_worker_t::send_create(const model::tvlp_profile_entry_t& entry)
 
     auto load = config->getLoad();
     load->setBurstSize(
-        static_cast<uint32_t>(load->getBurstSize() * entry.load_scale));
+        static_cast<uint32_t>(load->getBurstSize() * load_scale));
 
     auto rate = config->getLoad()->getRate();
-    rate->setValue(static_cast<uint64_t>(rate->getValue() * entry.load_scale));
+    rate->setValue(static_cast<uint64_t>(rate->getValue() * load_scale));
 
     PacketGenerator gen;
     gen.setTargetId(entry.resource_id.value());

--- a/src/modules/tvlp/workers/packet.cpp
+++ b/src/modules/tvlp/workers/packet.cpp
@@ -13,13 +13,13 @@ using namespace openperf::packet::generator::api;
 using namespace Pistache;
 
 packet_tvlp_worker_t::packet_tvlp_worker_t(
-    void* context, const model::tvlp_module_profile_t& profile)
+    void* context, const model::tvlp_profile_t::series& profile)
     : tvlp_worker_t(context, std::string(endpoint), profile){};
 
 packet_tvlp_worker_t::~packet_tvlp_worker_t() { stop(); }
 
 tl::expected<std::string, std::string>
-packet_tvlp_worker_t::send_create(const model::tvlp_profile_entry_t& entry,
+packet_tvlp_worker_t::send_create(const model::tvlp_profile_t::entry& entry,
                                   double load_scale)
 {
     assert(entry.resource_id.has_value());

--- a/src/modules/tvlp/workers/packet.hpp
+++ b/src/modules/tvlp/workers/packet.hpp
@@ -10,12 +10,13 @@ class packet_tvlp_worker_t : public tvlp_worker_t
 public:
     packet_tvlp_worker_t() = delete;
     packet_tvlp_worker_t(const packet_tvlp_worker_t&) = delete;
-    packet_tvlp_worker_t(void* context, const model::tvlp_module_profile_t&);
+    packet_tvlp_worker_t(void* context, const model::tvlp_profile_t::series&);
     ~packet_tvlp_worker_t();
 
 protected:
     tl::expected<std::string, std::string>
-    send_create(const model::tvlp_profile_entry_t&, double load_scale) override;
+    send_create(const model::tvlp_profile_t::entry&,
+                double load_scale) override;
     tl::expected<stat_pair_t, std::string>
     send_start(const std::string& id,
                const dynamic::configuration& dynamic_results) override;

--- a/src/modules/tvlp/workers/packet.hpp
+++ b/src/modules/tvlp/workers/packet.hpp
@@ -15,7 +15,7 @@ public:
 
 protected:
     tl::expected<std::string, std::string>
-    send_create(const model::tvlp_profile_entry_t&) override;
+    send_create(const model::tvlp_profile_entry_t&, double load_scale) override;
     tl::expected<stat_pair_t, std::string>
     send_start(const std::string& id,
                const dynamic::configuration& dynamic_results) override;

--- a/src/swagger/converters/tvlp.cpp
+++ b/src/swagger/converters/tvlp.cpp
@@ -20,16 +20,6 @@ void from_json(const nlohmann::json& j, TvlpProfile_cpu_series& cpu_series)
 void from_json(const nlohmann::json& j, TvlpProfile_cpu& cpu_profile)
 {
     auto val = const_cast<nlohmann::json&>(j);
-    if (j.find("time_scale") != j.end())
-        cpu_profile.setTimeScale(j.at("time_scale"));
-    else
-        cpu_profile.setTimeScale(1.0);
-
-    if (j.find("load_scale") != j.end())
-        cpu_profile.setLoadScale(j.at("load_scale"));
-    else
-        cpu_profile.setLoadScale(1.0);
-
     cpu_profile.getSeries().clear();
     for (auto& item : val["series"]) {
         auto newItem = std::make_shared<TvlpProfile_cpu_series>(
@@ -53,17 +43,6 @@ void from_json(const nlohmann::json& j, TvlpProfile_block_series& block_series)
 void from_json(const nlohmann::json& j, TvlpProfile_block& block_profile)
 {
     auto val = const_cast<nlohmann::json&>(j);
-
-    if (j.find("time_scale") != j.end())
-        block_profile.setTimeScale(j.at("time_scale"));
-    else
-        block_profile.setTimeScale(1.0);
-
-    if (j.find("load_scale") != j.end())
-        block_profile.setLoadScale(j.at("load_scale"));
-    else
-        block_profile.setLoadScale(1.0);
-
     block_profile.getSeries().clear();
     for (auto& item : val["series"]) {
         auto newItem = std::make_shared<TvlpProfile_block_series>(
@@ -87,17 +66,6 @@ void from_json(const nlohmann::json& j,
 void from_json(const nlohmann::json& j, TvlpProfile_memory& memory_profile)
 {
     auto val = const_cast<nlohmann::json&>(j);
-
-    if (j.find("time_scale") != j.end())
-        memory_profile.setTimeScale(j.at("time_scale"));
-    else
-        memory_profile.setTimeScale(1.0);
-
-    if (j.find("load_scale") != j.end())
-        memory_profile.setLoadScale(j.at("load_scale"));
-    else
-        memory_profile.setLoadScale(1.0);
-
     memory_profile.getSeries().clear();
     if (val.find("series") != val.end()) {
         for (auto& item : val["series"]) {
@@ -124,16 +92,6 @@ void from_json(const nlohmann::json& j,
 void from_json(const nlohmann::json& j, TvlpProfile_packet& packet_profile)
 {
     auto val = const_cast<nlohmann::json&>(j);
-    if (j.find("time_scale") != j.end())
-        packet_profile.setTimeScale(j.at("time_scale"));
-    else
-        packet_profile.setTimeScale(1.0);
-
-    if (j.find("load_scale") != j.end())
-        packet_profile.setLoadScale(j.at("load_scale"));
-    else
-        packet_profile.setLoadScale(1.0);
-
     packet_profile.getSeries().clear();
     if (val.find("series") != val.end()) {
         for (auto& item : val["series"]) {

--- a/src/swagger/v1/model/TvlpProfile_block.cpp
+++ b/src/swagger/v1/model/TvlpProfile_block.cpp
@@ -19,8 +19,6 @@ namespace model {
 
 TvlpProfile_block::TvlpProfile_block()
 {
-    m_Load_scale = 0.0;
-    m_Time_scale = 0.0;
     
 }
 
@@ -37,8 +35,6 @@ nlohmann::json TvlpProfile_block::toJson() const
 {
     nlohmann::json val = nlohmann::json::object();
 
-    val["load_scale"] = m_Load_scale;
-    val["time_scale"] = m_Time_scale;
     {
         nlohmann::json jsonArray;
         for( auto& item : m_Series )
@@ -54,8 +50,6 @@ nlohmann::json TvlpProfile_block::toJson() const
 
 void TvlpProfile_block::fromJson(nlohmann::json& val)
 {
-    setLoadScale(val.at("load_scale"));
-    setTimeScale(val.at("time_scale"));
     {
         m_Series.clear();
         nlohmann::json jsonArray;
@@ -79,24 +73,6 @@ void TvlpProfile_block::fromJson(nlohmann::json& val)
 }
 
 
-double TvlpProfile_block::getLoadScale() const
-{
-    return m_Load_scale;
-}
-void TvlpProfile_block::setLoadScale(double value)
-{
-    m_Load_scale = value;
-    
-}
-double TvlpProfile_block::getTimeScale() const
-{
-    return m_Time_scale;
-}
-void TvlpProfile_block::setTimeScale(double value)
-{
-    m_Time_scale = value;
-    
-}
 std::vector<std::shared_ptr<TvlpProfile_block_series>>& TvlpProfile_block::getSeries()
 {
     return m_Series;

--- a/src/swagger/v1/model/TvlpProfile_block.h
+++ b/src/swagger/v1/model/TvlpProfile_block.h
@@ -50,25 +50,11 @@ public:
     /// TvlpProfile_block members
 
     /// <summary>
-    /// The scale multiplier for load parameters of generators
-    /// </summary>
-    double getLoadScale() const;
-    void setLoadScale(double value);
-        /// <summary>
-    /// The scale multiplier for the length of each profile entry
-    /// </summary>
-    double getTimeScale() const;
-    void setTimeScale(double value);
-        /// <summary>
     /// 
     /// </summary>
     std::vector<std::shared_ptr<TvlpProfile_block_series>>& getSeries();
     
 protected:
-    double m_Load_scale;
-
-    double m_Time_scale;
-
     std::vector<std::shared_ptr<TvlpProfile_block_series>> m_Series;
 
 };

--- a/src/swagger/v1/model/TvlpProfile_cpu.cpp
+++ b/src/swagger/v1/model/TvlpProfile_cpu.cpp
@@ -19,8 +19,6 @@ namespace model {
 
 TvlpProfile_cpu::TvlpProfile_cpu()
 {
-    m_Load_scale = 0.0;
-    m_Time_scale = 0.0;
     
 }
 
@@ -37,8 +35,6 @@ nlohmann::json TvlpProfile_cpu::toJson() const
 {
     nlohmann::json val = nlohmann::json::object();
 
-    val["load_scale"] = m_Load_scale;
-    val["time_scale"] = m_Time_scale;
     {
         nlohmann::json jsonArray;
         for( auto& item : m_Series )
@@ -54,8 +50,6 @@ nlohmann::json TvlpProfile_cpu::toJson() const
 
 void TvlpProfile_cpu::fromJson(nlohmann::json& val)
 {
-    setLoadScale(val.at("load_scale"));
-    setTimeScale(val.at("time_scale"));
     {
         m_Series.clear();
         nlohmann::json jsonArray;
@@ -79,24 +73,6 @@ void TvlpProfile_cpu::fromJson(nlohmann::json& val)
 }
 
 
-double TvlpProfile_cpu::getLoadScale() const
-{
-    return m_Load_scale;
-}
-void TvlpProfile_cpu::setLoadScale(double value)
-{
-    m_Load_scale = value;
-    
-}
-double TvlpProfile_cpu::getTimeScale() const
-{
-    return m_Time_scale;
-}
-void TvlpProfile_cpu::setTimeScale(double value)
-{
-    m_Time_scale = value;
-    
-}
 std::vector<std::shared_ptr<TvlpProfile_cpu_series>>& TvlpProfile_cpu::getSeries()
 {
     return m_Series;

--- a/src/swagger/v1/model/TvlpProfile_cpu.h
+++ b/src/swagger/v1/model/TvlpProfile_cpu.h
@@ -50,25 +50,11 @@ public:
     /// TvlpProfile_cpu members
 
     /// <summary>
-    /// The scale multiplier for load parameters of generators
-    /// </summary>
-    double getLoadScale() const;
-    void setLoadScale(double value);
-        /// <summary>
-    /// The scale multiplier for the length of each profile entry
-    /// </summary>
-    double getTimeScale() const;
-    void setTimeScale(double value);
-        /// <summary>
     /// 
     /// </summary>
     std::vector<std::shared_ptr<TvlpProfile_cpu_series>>& getSeries();
     
 protected:
-    double m_Load_scale;
-
-    double m_Time_scale;
-
     std::vector<std::shared_ptr<TvlpProfile_cpu_series>> m_Series;
 
 };

--- a/src/swagger/v1/model/TvlpProfile_memory.cpp
+++ b/src/swagger/v1/model/TvlpProfile_memory.cpp
@@ -19,8 +19,6 @@ namespace model {
 
 TvlpProfile_memory::TvlpProfile_memory()
 {
-    m_Load_scale = 0.0;
-    m_Time_scale = 0.0;
     
 }
 
@@ -37,8 +35,6 @@ nlohmann::json TvlpProfile_memory::toJson() const
 {
     nlohmann::json val = nlohmann::json::object();
 
-    val["load_scale"] = m_Load_scale;
-    val["time_scale"] = m_Time_scale;
     {
         nlohmann::json jsonArray;
         for( auto& item : m_Series )
@@ -54,8 +50,6 @@ nlohmann::json TvlpProfile_memory::toJson() const
 
 void TvlpProfile_memory::fromJson(nlohmann::json& val)
 {
-    setLoadScale(val.at("load_scale"));
-    setTimeScale(val.at("time_scale"));
     {
         m_Series.clear();
         nlohmann::json jsonArray;
@@ -79,24 +73,6 @@ void TvlpProfile_memory::fromJson(nlohmann::json& val)
 }
 
 
-double TvlpProfile_memory::getLoadScale() const
-{
-    return m_Load_scale;
-}
-void TvlpProfile_memory::setLoadScale(double value)
-{
-    m_Load_scale = value;
-    
-}
-double TvlpProfile_memory::getTimeScale() const
-{
-    return m_Time_scale;
-}
-void TvlpProfile_memory::setTimeScale(double value)
-{
-    m_Time_scale = value;
-    
-}
 std::vector<std::shared_ptr<TvlpProfile_memory_series>>& TvlpProfile_memory::getSeries()
 {
     return m_Series;

--- a/src/swagger/v1/model/TvlpProfile_memory.h
+++ b/src/swagger/v1/model/TvlpProfile_memory.h
@@ -50,25 +50,11 @@ public:
     /// TvlpProfile_memory members
 
     /// <summary>
-    /// The scale multiplier for load parameters of generators
-    /// </summary>
-    double getLoadScale() const;
-    void setLoadScale(double value);
-        /// <summary>
-    /// The scale multiplier for the length of each profile entry
-    /// </summary>
-    double getTimeScale() const;
-    void setTimeScale(double value);
-        /// <summary>
     /// 
     /// </summary>
     std::vector<std::shared_ptr<TvlpProfile_memory_series>>& getSeries();
     
 protected:
-    double m_Load_scale;
-
-    double m_Time_scale;
-
     std::vector<std::shared_ptr<TvlpProfile_memory_series>> m_Series;
 
 };

--- a/src/swagger/v1/model/TvlpProfile_packet.cpp
+++ b/src/swagger/v1/model/TvlpProfile_packet.cpp
@@ -19,8 +19,6 @@ namespace model {
 
 TvlpProfile_packet::TvlpProfile_packet()
 {
-    m_Load_scale = 0.0;
-    m_Time_scale = 0.0;
     
 }
 
@@ -37,8 +35,6 @@ nlohmann::json TvlpProfile_packet::toJson() const
 {
     nlohmann::json val = nlohmann::json::object();
 
-    val["load_scale"] = m_Load_scale;
-    val["time_scale"] = m_Time_scale;
     {
         nlohmann::json jsonArray;
         for( auto& item : m_Series )
@@ -54,8 +50,6 @@ nlohmann::json TvlpProfile_packet::toJson() const
 
 void TvlpProfile_packet::fromJson(nlohmann::json& val)
 {
-    setLoadScale(val.at("load_scale"));
-    setTimeScale(val.at("time_scale"));
     {
         m_Series.clear();
         nlohmann::json jsonArray;
@@ -79,24 +73,6 @@ void TvlpProfile_packet::fromJson(nlohmann::json& val)
 }
 
 
-double TvlpProfile_packet::getLoadScale() const
-{
-    return m_Load_scale;
-}
-void TvlpProfile_packet::setLoadScale(double value)
-{
-    m_Load_scale = value;
-    
-}
-double TvlpProfile_packet::getTimeScale() const
-{
-    return m_Time_scale;
-}
-void TvlpProfile_packet::setTimeScale(double value)
-{
-    m_Time_scale = value;
-    
-}
 std::vector<std::shared_ptr<TvlpProfile_packet_series>>& TvlpProfile_packet::getSeries()
 {
     return m_Series;

--- a/src/swagger/v1/model/TvlpProfile_packet.h
+++ b/src/swagger/v1/model/TvlpProfile_packet.h
@@ -50,25 +50,11 @@ public:
     /// TvlpProfile_packet members
 
     /// <summary>
-    /// The scale multiplier for load parameters of generators
-    /// </summary>
-    double getLoadScale() const;
-    void setLoadScale(double value);
-        /// <summary>
-    /// The scale multiplier for the length of each profile entry
-    /// </summary>
-    double getTimeScale() const;
-    void setTimeScale(double value);
-        /// <summary>
     /// 
     /// </summary>
     std::vector<std::shared_ptr<TvlpProfile_packet_series>>& getSeries();
     
 protected:
-    double m_Load_scale;
-
-    double m_Time_scale;
-
     std::vector<std::shared_ptr<TvlpProfile_packet_series>> m_Series;
 
 };

--- a/src/swagger/v1/model/TvlpStartConfiguration.cpp
+++ b/src/swagger/v1/model/TvlpStartConfiguration.cpp
@@ -19,6 +19,8 @@ namespace model {
 
 TvlpStartConfiguration::TvlpStartConfiguration()
 {
+    m_Start_time = "";
+    m_Start_timeIsSet = false;
     m_CpuIsSet = false;
     m_MemoryIsSet = false;
     m_BlockIsSet = false;
@@ -39,6 +41,10 @@ nlohmann::json TvlpStartConfiguration::toJson() const
 {
     nlohmann::json val = nlohmann::json::object();
 
+    if(m_Start_timeIsSet)
+    {
+        val["start_time"] = ModelBase::toJson(m_Start_time);
+    }
     if(m_CpuIsSet)
     {
         val["cpu"] = ModelBase::toJson(m_Cpu);
@@ -62,6 +68,11 @@ nlohmann::json TvlpStartConfiguration::toJson() const
 
 void TvlpStartConfiguration::fromJson(nlohmann::json& val)
 {
+    if(val.find("start_time") != val.end())
+    {
+        setStartTime(val.at("start_time"));
+        
+    }
     if(val.find("cpu") != val.end())
     {
         if(!val["cpu"].is_null())
@@ -106,6 +117,23 @@ void TvlpStartConfiguration::fromJson(nlohmann::json& val)
 }
 
 
+std::string TvlpStartConfiguration::getStartTime() const
+{
+    return m_Start_time;
+}
+void TvlpStartConfiguration::setStartTime(std::string value)
+{
+    m_Start_time = value;
+    m_Start_timeIsSet = true;
+}
+bool TvlpStartConfiguration::startTimeIsSet() const
+{
+    return m_Start_timeIsSet;
+}
+void TvlpStartConfiguration::unsetStart_time()
+{
+    m_Start_timeIsSet = false;
+}
 std::shared_ptr<TvlpStartSeriesConfiguration> TvlpStartConfiguration::getCpu() const
 {
     return m_Cpu;

--- a/src/swagger/v1/model/TvlpStartConfiguration.h
+++ b/src/swagger/v1/model/TvlpStartConfiguration.h
@@ -22,6 +22,7 @@
 #include "ModelBase.h"
 
 #include "TvlpStartSeriesConfiguration.h"
+#include <string>
 
 namespace swagger {
 namespace v1 {
@@ -48,6 +49,13 @@ public:
     /////////////////////////////////////////////
     /// TvlpStartConfiguration members
 
+    /// <summary>
+    /// The ISO8601-formatted date and time to start profile replay
+    /// </summary>
+    std::string getStartTime() const;
+    void setStartTime(std::string value);
+    bool startTimeIsSet() const;
+    void unsetStart_time();
     /// <summary>
     /// 
     /// </summary>
@@ -78,6 +86,8 @@ public:
     void unsetPacket();
 
 protected:
+    std::string m_Start_time;
+    bool m_Start_timeIsSet;
     std::shared_ptr<TvlpStartSeriesConfiguration> m_Cpu;
     bool m_CpuIsSet;
     std::shared_ptr<TvlpStartSeriesConfiguration> m_Memory;

--- a/src/swagger/v1/model/TvlpStartConfiguration.h
+++ b/src/swagger/v1/model/TvlpStartConfiguration.h
@@ -50,7 +50,7 @@ public:
     /// TvlpStartConfiguration members
 
     /// <summary>
-    /// The ISO8601-formatted date and time to start profile replay
+    /// The ISO8601-formatted date and time to start profile replay. If not specified the profile will start immediately. 
     /// </summary>
     std::string getStartTime() const;
     void setStartTime(std::string value);

--- a/src/swagger/v1/model/TvlpStartSeriesConfiguration.cpp
+++ b/src/swagger/v1/model/TvlpStartSeriesConfiguration.cpp
@@ -19,6 +19,12 @@ namespace model {
 
 TvlpStartSeriesConfiguration::TvlpStartSeriesConfiguration()
 {
+    m_Load_scale = 0.0;
+    m_Load_scaleIsSet = false;
+    m_Time_scale = 0.0;
+    m_Time_scaleIsSet = false;
+    m_Start_time = "";
+    m_Start_timeIsSet = false;
     m_Dynamic_resultsIsSet = false;
     
 }
@@ -36,6 +42,18 @@ nlohmann::json TvlpStartSeriesConfiguration::toJson() const
 {
     nlohmann::json val = nlohmann::json::object();
 
+    if(m_Load_scaleIsSet)
+    {
+        val["load_scale"] = m_Load_scale;
+    }
+    if(m_Time_scaleIsSet)
+    {
+        val["time_scale"] = m_Time_scale;
+    }
+    if(m_Start_timeIsSet)
+    {
+        val["start_time"] = ModelBase::toJson(m_Start_time);
+    }
     if(m_Dynamic_resultsIsSet)
     {
         val["dynamic_results"] = ModelBase::toJson(m_Dynamic_results);
@@ -47,6 +65,19 @@ nlohmann::json TvlpStartSeriesConfiguration::toJson() const
 
 void TvlpStartSeriesConfiguration::fromJson(nlohmann::json& val)
 {
+    if(val.find("load_scale") != val.end())
+    {
+        setLoadScale(val.at("load_scale"));
+    }
+    if(val.find("time_scale") != val.end())
+    {
+        setTimeScale(val.at("time_scale"));
+    }
+    if(val.find("start_time") != val.end())
+    {
+        setStartTime(val.at("start_time"));
+        
+    }
     if(val.find("dynamic_results") != val.end())
     {
         if(!val["dynamic_results"].is_null())
@@ -61,6 +92,57 @@ void TvlpStartSeriesConfiguration::fromJson(nlohmann::json& val)
 }
 
 
+double TvlpStartSeriesConfiguration::getLoadScale() const
+{
+    return m_Load_scale;
+}
+void TvlpStartSeriesConfiguration::setLoadScale(double value)
+{
+    m_Load_scale = value;
+    m_Load_scaleIsSet = true;
+}
+bool TvlpStartSeriesConfiguration::loadScaleIsSet() const
+{
+    return m_Load_scaleIsSet;
+}
+void TvlpStartSeriesConfiguration::unsetLoad_scale()
+{
+    m_Load_scaleIsSet = false;
+}
+double TvlpStartSeriesConfiguration::getTimeScale() const
+{
+    return m_Time_scale;
+}
+void TvlpStartSeriesConfiguration::setTimeScale(double value)
+{
+    m_Time_scale = value;
+    m_Time_scaleIsSet = true;
+}
+bool TvlpStartSeriesConfiguration::timeScaleIsSet() const
+{
+    return m_Time_scaleIsSet;
+}
+void TvlpStartSeriesConfiguration::unsetTime_scale()
+{
+    m_Time_scaleIsSet = false;
+}
+std::string TvlpStartSeriesConfiguration::getStartTime() const
+{
+    return m_Start_time;
+}
+void TvlpStartSeriesConfiguration::setStartTime(std::string value)
+{
+    m_Start_time = value;
+    m_Start_timeIsSet = true;
+}
+bool TvlpStartSeriesConfiguration::startTimeIsSet() const
+{
+    return m_Start_timeIsSet;
+}
+void TvlpStartSeriesConfiguration::unsetStart_time()
+{
+    m_Start_timeIsSet = false;
+}
 std::shared_ptr<DynamicResultsConfig> TvlpStartSeriesConfiguration::getDynamicResults() const
 {
     return m_Dynamic_results;

--- a/src/swagger/v1/model/TvlpStartSeriesConfiguration.cpp
+++ b/src/swagger/v1/model/TvlpStartSeriesConfiguration.cpp
@@ -23,8 +23,6 @@ TvlpStartSeriesConfiguration::TvlpStartSeriesConfiguration()
     m_Load_scaleIsSet = false;
     m_Time_scale = 0.0;
     m_Time_scaleIsSet = false;
-    m_Start_time = "";
-    m_Start_timeIsSet = false;
     m_Dynamic_resultsIsSet = false;
     
 }
@@ -50,10 +48,6 @@ nlohmann::json TvlpStartSeriesConfiguration::toJson() const
     {
         val["time_scale"] = m_Time_scale;
     }
-    if(m_Start_timeIsSet)
-    {
-        val["start_time"] = ModelBase::toJson(m_Start_time);
-    }
     if(m_Dynamic_resultsIsSet)
     {
         val["dynamic_results"] = ModelBase::toJson(m_Dynamic_results);
@@ -72,11 +66,6 @@ void TvlpStartSeriesConfiguration::fromJson(nlohmann::json& val)
     if(val.find("time_scale") != val.end())
     {
         setTimeScale(val.at("time_scale"));
-    }
-    if(val.find("start_time") != val.end())
-    {
-        setStartTime(val.at("start_time"));
-        
     }
     if(val.find("dynamic_results") != val.end())
     {
@@ -125,23 +114,6 @@ bool TvlpStartSeriesConfiguration::timeScaleIsSet() const
 void TvlpStartSeriesConfiguration::unsetTime_scale()
 {
     m_Time_scaleIsSet = false;
-}
-std::string TvlpStartSeriesConfiguration::getStartTime() const
-{
-    return m_Start_time;
-}
-void TvlpStartSeriesConfiguration::setStartTime(std::string value)
-{
-    m_Start_time = value;
-    m_Start_timeIsSet = true;
-}
-bool TvlpStartSeriesConfiguration::startTimeIsSet() const
-{
-    return m_Start_timeIsSet;
-}
-void TvlpStartSeriesConfiguration::unsetStart_time()
-{
-    m_Start_timeIsSet = false;
 }
 std::shared_ptr<DynamicResultsConfig> TvlpStartSeriesConfiguration::getDynamicResults() const
 {

--- a/src/swagger/v1/model/TvlpStartSeriesConfiguration.h
+++ b/src/swagger/v1/model/TvlpStartSeriesConfiguration.h
@@ -21,7 +21,6 @@
 
 #include "ModelBase.h"
 
-#include <string>
 #include "DynamicResultsConfig.h"
 
 namespace swagger {
@@ -64,13 +63,6 @@ public:
     bool timeScaleIsSet() const;
     void unsetTime_scale();
     /// <summary>
-    /// The ISO8601-formatted date and time to start profile replay
-    /// </summary>
-    std::string getStartTime() const;
-    void setStartTime(std::string value);
-    bool startTimeIsSet() const;
-    void unsetStart_time();
-    /// <summary>
     /// 
     /// </summary>
     std::shared_ptr<DynamicResultsConfig> getDynamicResults() const;
@@ -83,8 +75,6 @@ protected:
     bool m_Load_scaleIsSet;
     double m_Time_scale;
     bool m_Time_scaleIsSet;
-    std::string m_Start_time;
-    bool m_Start_timeIsSet;
     std::shared_ptr<DynamicResultsConfig> m_Dynamic_results;
     bool m_Dynamic_resultsIsSet;
 };

--- a/src/swagger/v1/model/TvlpStartSeriesConfiguration.h
+++ b/src/swagger/v1/model/TvlpStartSeriesConfiguration.h
@@ -21,6 +21,7 @@
 
 #include "ModelBase.h"
 
+#include <string>
 #include "DynamicResultsConfig.h"
 
 namespace swagger {
@@ -49,6 +50,27 @@ public:
     /// TvlpStartSeriesConfiguration members
 
     /// <summary>
+    /// The scale multiplier for load parameters of generators
+    /// </summary>
+    double getLoadScale() const;
+    void setLoadScale(double value);
+    bool loadScaleIsSet() const;
+    void unsetLoad_scale();
+    /// <summary>
+    /// The scale multiplier for the length of each profile entry
+    /// </summary>
+    double getTimeScale() const;
+    void setTimeScale(double value);
+    bool timeScaleIsSet() const;
+    void unsetTime_scale();
+    /// <summary>
+    /// The ISO8601-formatted date and time to start profile replay
+    /// </summary>
+    std::string getStartTime() const;
+    void setStartTime(std::string value);
+    bool startTimeIsSet() const;
+    void unsetStart_time();
+    /// <summary>
     /// 
     /// </summary>
     std::shared_ptr<DynamicResultsConfig> getDynamicResults() const;
@@ -57,6 +79,12 @@ public:
     void unsetDynamic_results();
 
 protected:
+    double m_Load_scale;
+    bool m_Load_scaleIsSet;
+    double m_Time_scale;
+    bool m_Time_scaleIsSet;
+    std::string m_Start_time;
+    bool m_Start_timeIsSet;
     std::shared_ptr<DynamicResultsConfig> m_Dynamic_results;
     bool m_Dynamic_resultsIsSet;
 };

--- a/tests/aat/api/v1/client/api/tvlp_api.py
+++ b/tests/aat/api/v1/client/api/tvlp_api.py
@@ -719,7 +719,6 @@ class TVLPApi(object):
 
         :param async_req bool
         :param str id: Unique resource identifier (required)
-        :param datetime time: The ISO8601-formatted date and time to start profile replay
         :param TvlpStartConfiguration start: TVLP Start parameters
         :return: TvlpResult
                  If the method is called asynchronously,
@@ -743,14 +742,13 @@ class TVLPApi(object):
 
         :param async_req bool
         :param str id: Unique resource identifier (required)
-        :param datetime time: The ISO8601-formatted date and time to start profile replay
         :param TvlpStartConfiguration start: TVLP Start parameters
         :return: TvlpResult
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
-        all_params = ['id', 'time', 'start']  # noqa: E501
+        all_params = ['id', 'start']  # noqa: E501
         all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
@@ -777,8 +775,6 @@ class TVLPApi(object):
             path_params['id'] = params['id']  # noqa: E501
 
         query_params = []
-        if 'time' in params:
-            query_params.append(('time', params['time']))  # noqa: E501
 
         header_params = {}
 

--- a/tests/aat/api/v1/client/models/tvlp_profile_block.py
+++ b/tests/aat/api/v1/client/models/tvlp_profile_block.py
@@ -31,72 +31,20 @@ class TvlpProfileBlock(object):
                             and the value is json key in definition.
     """
     swagger_types = {
-        'load_scale': 'float',
-        'time_scale': 'float',
         'series': 'list[TvlpProfileBlockSeries]'
     }
 
     attribute_map = {
-        'load_scale': 'load_scale',
-        'time_scale': 'time_scale',
         'series': 'series'
     }
 
-    def __init__(self, load_scale=1.0, time_scale=1.0, series=None):  # noqa: E501
+    def __init__(self, series=None):  # noqa: E501
         """TvlpProfileBlock - a model defined in Swagger"""  # noqa: E501
 
-        self._load_scale = None
-        self._time_scale = None
         self._series = None
         self.discriminator = None
 
-        self.load_scale = load_scale
-        self.time_scale = time_scale
         self.series = series
-
-    @property
-    def load_scale(self):
-        """Gets the load_scale of this TvlpProfileBlock.  # noqa: E501
-
-        The scale multiplier for load parameters of generators  # noqa: E501
-
-        :return: The load_scale of this TvlpProfileBlock.  # noqa: E501
-        :rtype: float
-        """
-        return self._load_scale
-
-    @load_scale.setter
-    def load_scale(self, load_scale):
-        """Sets the load_scale of this TvlpProfileBlock.
-
-        The scale multiplier for load parameters of generators  # noqa: E501
-
-        :param load_scale: The load_scale of this TvlpProfileBlock.  # noqa: E501
-        :type: float
-        """
-        self._load_scale = load_scale
-
-    @property
-    def time_scale(self):
-        """Gets the time_scale of this TvlpProfileBlock.  # noqa: E501
-
-        The scale multiplier for the length of each profile entry  # noqa: E501
-
-        :return: The time_scale of this TvlpProfileBlock.  # noqa: E501
-        :rtype: float
-        """
-        return self._time_scale
-
-    @time_scale.setter
-    def time_scale(self, time_scale):
-        """Sets the time_scale of this TvlpProfileBlock.
-
-        The scale multiplier for the length of each profile entry  # noqa: E501
-
-        :param time_scale: The time_scale of this TvlpProfileBlock.  # noqa: E501
-        :type: float
-        """
-        self._time_scale = time_scale
 
     @property
     def series(self):

--- a/tests/aat/api/v1/client/models/tvlp_profile_cpu.py
+++ b/tests/aat/api/v1/client/models/tvlp_profile_cpu.py
@@ -31,72 +31,20 @@ class TvlpProfileCpu(object):
                             and the value is json key in definition.
     """
     swagger_types = {
-        'load_scale': 'float',
-        'time_scale': 'float',
         'series': 'list[TvlpProfileCpuSeries]'
     }
 
     attribute_map = {
-        'load_scale': 'load_scale',
-        'time_scale': 'time_scale',
         'series': 'series'
     }
 
-    def __init__(self, load_scale=1.0, time_scale=1.0, series=None):  # noqa: E501
+    def __init__(self, series=None):  # noqa: E501
         """TvlpProfileCpu - a model defined in Swagger"""  # noqa: E501
 
-        self._load_scale = None
-        self._time_scale = None
         self._series = None
         self.discriminator = None
 
-        self.load_scale = load_scale
-        self.time_scale = time_scale
         self.series = series
-
-    @property
-    def load_scale(self):
-        """Gets the load_scale of this TvlpProfileCpu.  # noqa: E501
-
-        The scale multiplier for load parameters of generators  # noqa: E501
-
-        :return: The load_scale of this TvlpProfileCpu.  # noqa: E501
-        :rtype: float
-        """
-        return self._load_scale
-
-    @load_scale.setter
-    def load_scale(self, load_scale):
-        """Sets the load_scale of this TvlpProfileCpu.
-
-        The scale multiplier for load parameters of generators  # noqa: E501
-
-        :param load_scale: The load_scale of this TvlpProfileCpu.  # noqa: E501
-        :type: float
-        """
-        self._load_scale = load_scale
-
-    @property
-    def time_scale(self):
-        """Gets the time_scale of this TvlpProfileCpu.  # noqa: E501
-
-        The scale multiplier for the length of each profile entry  # noqa: E501
-
-        :return: The time_scale of this TvlpProfileCpu.  # noqa: E501
-        :rtype: float
-        """
-        return self._time_scale
-
-    @time_scale.setter
-    def time_scale(self, time_scale):
-        """Sets the time_scale of this TvlpProfileCpu.
-
-        The scale multiplier for the length of each profile entry  # noqa: E501
-
-        :param time_scale: The time_scale of this TvlpProfileCpu.  # noqa: E501
-        :type: float
-        """
-        self._time_scale = time_scale
 
     @property
     def series(self):

--- a/tests/aat/api/v1/client/models/tvlp_profile_memory.py
+++ b/tests/aat/api/v1/client/models/tvlp_profile_memory.py
@@ -31,72 +31,20 @@ class TvlpProfileMemory(object):
                             and the value is json key in definition.
     """
     swagger_types = {
-        'load_scale': 'float',
-        'time_scale': 'float',
         'series': 'list[TvlpProfileMemorySeries]'
     }
 
     attribute_map = {
-        'load_scale': 'load_scale',
-        'time_scale': 'time_scale',
         'series': 'series'
     }
 
-    def __init__(self, load_scale=1.0, time_scale=1.0, series=None):  # noqa: E501
+    def __init__(self, series=None):  # noqa: E501
         """TvlpProfileMemory - a model defined in Swagger"""  # noqa: E501
 
-        self._load_scale = None
-        self._time_scale = None
         self._series = None
         self.discriminator = None
 
-        self.load_scale = load_scale
-        self.time_scale = time_scale
         self.series = series
-
-    @property
-    def load_scale(self):
-        """Gets the load_scale of this TvlpProfileMemory.  # noqa: E501
-
-        The scale multiplier for load parameters of generators  # noqa: E501
-
-        :return: The load_scale of this TvlpProfileMemory.  # noqa: E501
-        :rtype: float
-        """
-        return self._load_scale
-
-    @load_scale.setter
-    def load_scale(self, load_scale):
-        """Sets the load_scale of this TvlpProfileMemory.
-
-        The scale multiplier for load parameters of generators  # noqa: E501
-
-        :param load_scale: The load_scale of this TvlpProfileMemory.  # noqa: E501
-        :type: float
-        """
-        self._load_scale = load_scale
-
-    @property
-    def time_scale(self):
-        """Gets the time_scale of this TvlpProfileMemory.  # noqa: E501
-
-        The scale multiplier for the length of each profile entry  # noqa: E501
-
-        :return: The time_scale of this TvlpProfileMemory.  # noqa: E501
-        :rtype: float
-        """
-        return self._time_scale
-
-    @time_scale.setter
-    def time_scale(self, time_scale):
-        """Sets the time_scale of this TvlpProfileMemory.
-
-        The scale multiplier for the length of each profile entry  # noqa: E501
-
-        :param time_scale: The time_scale of this TvlpProfileMemory.  # noqa: E501
-        :type: float
-        """
-        self._time_scale = time_scale
 
     @property
     def series(self):

--- a/tests/aat/api/v1/client/models/tvlp_profile_packet.py
+++ b/tests/aat/api/v1/client/models/tvlp_profile_packet.py
@@ -31,72 +31,20 @@ class TvlpProfilePacket(object):
                             and the value is json key in definition.
     """
     swagger_types = {
-        'load_scale': 'float',
-        'time_scale': 'float',
         'series': 'list[TvlpProfilePacketSeries]'
     }
 
     attribute_map = {
-        'load_scale': 'load_scale',
-        'time_scale': 'time_scale',
         'series': 'series'
     }
 
-    def __init__(self, load_scale=1.0, time_scale=1.0, series=None):  # noqa: E501
+    def __init__(self, series=None):  # noqa: E501
         """TvlpProfilePacket - a model defined in Swagger"""  # noqa: E501
 
-        self._load_scale = None
-        self._time_scale = None
         self._series = None
         self.discriminator = None
 
-        self.load_scale = load_scale
-        self.time_scale = time_scale
         self.series = series
-
-    @property
-    def load_scale(self):
-        """Gets the load_scale of this TvlpProfilePacket.  # noqa: E501
-
-        The scale multiplier for load parameters of generators  # noqa: E501
-
-        :return: The load_scale of this TvlpProfilePacket.  # noqa: E501
-        :rtype: float
-        """
-        return self._load_scale
-
-    @load_scale.setter
-    def load_scale(self, load_scale):
-        """Sets the load_scale of this TvlpProfilePacket.
-
-        The scale multiplier for load parameters of generators  # noqa: E501
-
-        :param load_scale: The load_scale of this TvlpProfilePacket.  # noqa: E501
-        :type: float
-        """
-        self._load_scale = load_scale
-
-    @property
-    def time_scale(self):
-        """Gets the time_scale of this TvlpProfilePacket.  # noqa: E501
-
-        The scale multiplier for the length of each profile entry  # noqa: E501
-
-        :return: The time_scale of this TvlpProfilePacket.  # noqa: E501
-        :rtype: float
-        """
-        return self._time_scale
-
-    @time_scale.setter
-    def time_scale(self, time_scale):
-        """Sets the time_scale of this TvlpProfilePacket.
-
-        The scale multiplier for the length of each profile entry  # noqa: E501
-
-        :param time_scale: The time_scale of this TvlpProfilePacket.  # noqa: E501
-        :type: float
-        """
-        self._time_scale = time_scale
 
     @property
     def series(self):

--- a/tests/aat/api/v1/client/models/tvlp_start_configuration.py
+++ b/tests/aat/api/v1/client/models/tvlp_start_configuration.py
@@ -31,6 +31,7 @@ class TvlpStartConfiguration(object):
                             and the value is json key in definition.
     """
     swagger_types = {
+        'start_time': 'datetime',
         'cpu': 'TvlpStartSeriesConfiguration',
         'memory': 'TvlpStartSeriesConfiguration',
         'block': 'TvlpStartSeriesConfiguration',
@@ -38,21 +39,25 @@ class TvlpStartConfiguration(object):
     }
 
     attribute_map = {
+        'start_time': 'start_time',
         'cpu': 'cpu',
         'memory': 'memory',
         'block': 'block',
         'packet': 'packet'
     }
 
-    def __init__(self, cpu=None, memory=None, block=None, packet=None):  # noqa: E501
+    def __init__(self, start_time=None, cpu=None, memory=None, block=None, packet=None):  # noqa: E501
         """TvlpStartConfiguration - a model defined in Swagger"""  # noqa: E501
 
+        self._start_time = None
         self._cpu = None
         self._memory = None
         self._block = None
         self._packet = None
         self.discriminator = None
 
+        if start_time is not None:
+            self.start_time = start_time
         if cpu is not None:
             self.cpu = cpu
         if memory is not None:
@@ -61,6 +66,28 @@ class TvlpStartConfiguration(object):
             self.block = block
         if packet is not None:
             self.packet = packet
+
+    @property
+    def start_time(self):
+        """Gets the start_time of this TvlpStartConfiguration.  # noqa: E501
+
+        The ISO8601-formatted date and time to start profile replay  # noqa: E501
+
+        :return: The start_time of this TvlpStartConfiguration.  # noqa: E501
+        :rtype: datetime
+        """
+        return self._start_time
+
+    @start_time.setter
+    def start_time(self, start_time):
+        """Sets the start_time of this TvlpStartConfiguration.
+
+        The ISO8601-formatted date and time to start profile replay  # noqa: E501
+
+        :param start_time: The start_time of this TvlpStartConfiguration.  # noqa: E501
+        :type: datetime
+        """
+        self._start_time = start_time
 
     @property
     def cpu(self):

--- a/tests/aat/api/v1/client/models/tvlp_start_configuration.py
+++ b/tests/aat/api/v1/client/models/tvlp_start_configuration.py
@@ -71,7 +71,7 @@ class TvlpStartConfiguration(object):
     def start_time(self):
         """Gets the start_time of this TvlpStartConfiguration.  # noqa: E501
 
-        The ISO8601-formatted date and time to start profile replay  # noqa: E501
+        The ISO8601-formatted date and time to start profile replay. If not specified the profile will start immediately.   # noqa: E501
 
         :return: The start_time of this TvlpStartConfiguration.  # noqa: E501
         :rtype: datetime
@@ -82,7 +82,7 @@ class TvlpStartConfiguration(object):
     def start_time(self, start_time):
         """Sets the start_time of this TvlpStartConfiguration.
 
-        The ISO8601-formatted date and time to start profile replay  # noqa: E501
+        The ISO8601-formatted date and time to start profile replay. If not specified the profile will start immediately.   # noqa: E501
 
         :param start_time: The start_time of this TvlpStartConfiguration.  # noqa: E501
         :type: datetime

--- a/tests/aat/api/v1/client/models/tvlp_start_series_configuration.py
+++ b/tests/aat/api/v1/client/models/tvlp_start_series_configuration.py
@@ -31,21 +31,102 @@ class TvlpStartSeriesConfiguration(object):
                             and the value is json key in definition.
     """
     swagger_types = {
+        'load_scale': 'float',
+        'time_scale': 'float',
+        'start_time': 'datetime',
         'dynamic_results': 'DynamicResultsConfig'
     }
 
     attribute_map = {
+        'load_scale': 'load_scale',
+        'time_scale': 'time_scale',
+        'start_time': 'start_time',
         'dynamic_results': 'dynamic_results'
     }
 
-    def __init__(self, dynamic_results=None):  # noqa: E501
+    def __init__(self, load_scale=1.0, time_scale=1.0, start_time=None, dynamic_results=None):  # noqa: E501
         """TvlpStartSeriesConfiguration - a model defined in Swagger"""  # noqa: E501
 
+        self._load_scale = None
+        self._time_scale = None
+        self._start_time = None
         self._dynamic_results = None
         self.discriminator = None
 
+        if load_scale is not None:
+            self.load_scale = load_scale
+        if time_scale is not None:
+            self.time_scale = time_scale
+        if start_time is not None:
+            self.start_time = start_time
         if dynamic_results is not None:
             self.dynamic_results = dynamic_results
+
+    @property
+    def load_scale(self):
+        """Gets the load_scale of this TvlpStartSeriesConfiguration.  # noqa: E501
+
+        The scale multiplier for load parameters of generators  # noqa: E501
+
+        :return: The load_scale of this TvlpStartSeriesConfiguration.  # noqa: E501
+        :rtype: float
+        """
+        return self._load_scale
+
+    @load_scale.setter
+    def load_scale(self, load_scale):
+        """Sets the load_scale of this TvlpStartSeriesConfiguration.
+
+        The scale multiplier for load parameters of generators  # noqa: E501
+
+        :param load_scale: The load_scale of this TvlpStartSeriesConfiguration.  # noqa: E501
+        :type: float
+        """
+        self._load_scale = load_scale
+
+    @property
+    def time_scale(self):
+        """Gets the time_scale of this TvlpStartSeriesConfiguration.  # noqa: E501
+
+        The scale multiplier for the length of each profile entry  # noqa: E501
+
+        :return: The time_scale of this TvlpStartSeriesConfiguration.  # noqa: E501
+        :rtype: float
+        """
+        return self._time_scale
+
+    @time_scale.setter
+    def time_scale(self, time_scale):
+        """Sets the time_scale of this TvlpStartSeriesConfiguration.
+
+        The scale multiplier for the length of each profile entry  # noqa: E501
+
+        :param time_scale: The time_scale of this TvlpStartSeriesConfiguration.  # noqa: E501
+        :type: float
+        """
+        self._time_scale = time_scale
+
+    @property
+    def start_time(self):
+        """Gets the start_time of this TvlpStartSeriesConfiguration.  # noqa: E501
+
+        The ISO8601-formatted date and time to start profile replay  # noqa: E501
+
+        :return: The start_time of this TvlpStartSeriesConfiguration.  # noqa: E501
+        :rtype: datetime
+        """
+        return self._start_time
+
+    @start_time.setter
+    def start_time(self, start_time):
+        """Sets the start_time of this TvlpStartSeriesConfiguration.
+
+        The ISO8601-formatted date and time to start profile replay  # noqa: E501
+
+        :param start_time: The start_time of this TvlpStartSeriesConfiguration.  # noqa: E501
+        :type: datetime
+        """
+        self._start_time = start_time
 
     @property
     def dynamic_results(self):

--- a/tests/aat/api/v1/client/models/tvlp_start_series_configuration.py
+++ b/tests/aat/api/v1/client/models/tvlp_start_series_configuration.py
@@ -33,23 +33,20 @@ class TvlpStartSeriesConfiguration(object):
     swagger_types = {
         'load_scale': 'float',
         'time_scale': 'float',
-        'start_time': 'datetime',
         'dynamic_results': 'DynamicResultsConfig'
     }
 
     attribute_map = {
         'load_scale': 'load_scale',
         'time_scale': 'time_scale',
-        'start_time': 'start_time',
         'dynamic_results': 'dynamic_results'
     }
 
-    def __init__(self, load_scale=1.0, time_scale=1.0, start_time=None, dynamic_results=None):  # noqa: E501
+    def __init__(self, load_scale=1.0, time_scale=1.0, dynamic_results=None):  # noqa: E501
         """TvlpStartSeriesConfiguration - a model defined in Swagger"""  # noqa: E501
 
         self._load_scale = None
         self._time_scale = None
-        self._start_time = None
         self._dynamic_results = None
         self.discriminator = None
 
@@ -57,8 +54,6 @@ class TvlpStartSeriesConfiguration(object):
             self.load_scale = load_scale
         if time_scale is not None:
             self.time_scale = time_scale
-        if start_time is not None:
-            self.start_time = start_time
         if dynamic_results is not None:
             self.dynamic_results = dynamic_results
 
@@ -105,28 +100,6 @@ class TvlpStartSeriesConfiguration(object):
         :type: float
         """
         self._time_scale = time_scale
-
-    @property
-    def start_time(self):
-        """Gets the start_time of this TvlpStartSeriesConfiguration.  # noqa: E501
-
-        The ISO8601-formatted date and time to start profile replay  # noqa: E501
-
-        :return: The start_time of this TvlpStartSeriesConfiguration.  # noqa: E501
-        :rtype: datetime
-        """
-        return self._start_time
-
-    @start_time.setter
-    def start_time(self, start_time):
-        """Sets the start_time of this TvlpStartSeriesConfiguration.
-
-        The ISO8601-formatted date and time to start profile replay  # noqa: E501
-
-        :param start_time: The start_time of this TvlpStartSeriesConfiguration.  # noqa: E501
-        :type: datetime
-        """
-        self._start_time = start_time
 
     @property
     def dynamic_results(self):

--- a/tests/aat/api/v1/docs/TVLPApi.md
+++ b/tests/aat/api/v1/docs/TVLPApi.md
@@ -340,7 +340,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **start_tvlp_configuration**
-> TvlpResult start_tvlp_configuration(id, time=time, start=start)
+> TvlpResult start_tvlp_configuration(id, start=start)
 
 Start a TVLP configuration
 
@@ -357,12 +357,11 @@ from pprint import pprint
 # create an instance of the API class
 api_instance = client.TVLPApi()
 id = 'id_example' # str | Unique resource identifier
-time = '2013-10-20T19:20:30+01:00' # datetime | The ISO8601-formatted date and time to start profile replay (optional)
 start = client.TvlpStartConfiguration() # TvlpStartConfiguration | TVLP Start parameters (optional)
 
 try:
     # Start a TVLP configuration
-    api_response = api_instance.start_tvlp_configuration(id, time=time, start=start)
+    api_response = api_instance.start_tvlp_configuration(id, start=start)
     pprint(api_response)
 except ApiException as e:
     print("Exception when calling TVLPApi->start_tvlp_configuration: %s\n" % e)
@@ -373,7 +372,6 @@ except ApiException as e:
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **id** | **str**| Unique resource identifier | 
- **time** | **datetime**| The ISO8601-formatted date and time to start profile replay | [optional] 
  **start** | [**TvlpStartConfiguration**](TvlpStartConfiguration.md)| TVLP Start parameters | [optional] 
 
 ### Return type

--- a/tests/aat/api/v1/docs/TvlpProfileBlock.md
+++ b/tests/aat/api/v1/docs/TvlpProfileBlock.md
@@ -3,8 +3,6 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**load_scale** | **float** | The scale multiplier for load parameters of generators | [default to 1.0]
-**time_scale** | **float** | The scale multiplier for the length of each profile entry | [default to 1.0]
 **series** | [**list[TvlpProfileBlockSeries]**](TvlpProfileBlockSeries.md) |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/tests/aat/api/v1/docs/TvlpProfileCpu.md
+++ b/tests/aat/api/v1/docs/TvlpProfileCpu.md
@@ -3,8 +3,6 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**load_scale** | **float** | The scale multiplier for load parameters of generators | [default to 1.0]
-**time_scale** | **float** | The scale multiplier for the length of each profile entry | [default to 1.0]
 **series** | [**list[TvlpProfileCpuSeries]**](TvlpProfileCpuSeries.md) |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/tests/aat/api/v1/docs/TvlpProfileMemory.md
+++ b/tests/aat/api/v1/docs/TvlpProfileMemory.md
@@ -3,8 +3,6 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**load_scale** | **float** | The scale multiplier for load parameters of generators | [default to 1.0]
-**time_scale** | **float** | The scale multiplier for the length of each profile entry | [default to 1.0]
 **series** | [**list[TvlpProfileMemorySeries]**](TvlpProfileMemorySeries.md) |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/tests/aat/api/v1/docs/TvlpProfilePacket.md
+++ b/tests/aat/api/v1/docs/TvlpProfilePacket.md
@@ -3,8 +3,6 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**load_scale** | **float** | The scale multiplier for load parameters of generators | [default to 1.0]
-**time_scale** | **float** | The scale multiplier for the length of each profile entry | [default to 1.0]
 **series** | [**list[TvlpProfilePacketSeries]**](TvlpProfilePacketSeries.md) |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/tests/aat/api/v1/docs/TvlpStartConfiguration.md
+++ b/tests/aat/api/v1/docs/TvlpStartConfiguration.md
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**start_time** | **datetime** | The ISO8601-formatted date and time to start profile replay | [optional] 
+**start_time** | **datetime** | The ISO8601-formatted date and time to start profile replay. If not specified the profile will start immediately.  | [optional] 
 **cpu** | [**TvlpStartSeriesConfiguration**](TvlpStartSeriesConfiguration.md) |  | [optional] 
 **memory** | [**TvlpStartSeriesConfiguration**](TvlpStartSeriesConfiguration.md) |  | [optional] 
 **block** | [**TvlpStartSeriesConfiguration**](TvlpStartSeriesConfiguration.md) |  | [optional] 

--- a/tests/aat/api/v1/docs/TvlpStartConfiguration.md
+++ b/tests/aat/api/v1/docs/TvlpStartConfiguration.md
@@ -3,6 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**start_time** | **datetime** | The ISO8601-formatted date and time to start profile replay | [optional] 
 **cpu** | [**TvlpStartSeriesConfiguration**](TvlpStartSeriesConfiguration.md) |  | [optional] 
 **memory** | [**TvlpStartSeriesConfiguration**](TvlpStartSeriesConfiguration.md) |  | [optional] 
 **block** | [**TvlpStartSeriesConfiguration**](TvlpStartSeriesConfiguration.md) |  | [optional] 

--- a/tests/aat/api/v1/docs/TvlpStartSeriesConfiguration.md
+++ b/tests/aat/api/v1/docs/TvlpStartSeriesConfiguration.md
@@ -5,7 +5,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **load_scale** | **float** | The scale multiplier for load parameters of generators | [optional] [default to 1.0]
 **time_scale** | **float** | The scale multiplier for the length of each profile entry | [optional] [default to 1.0]
-**start_time** | **datetime** | The ISO8601-formatted date and time to start profile replay | [optional] 
 **dynamic_results** | [**DynamicResultsConfig**](DynamicResultsConfig.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/tests/aat/api/v1/docs/TvlpStartSeriesConfiguration.md
+++ b/tests/aat/api/v1/docs/TvlpStartSeriesConfiguration.md
@@ -3,6 +3,9 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**load_scale** | **float** | The scale multiplier for load parameters of generators | [optional] [default to 1.0]
+**time_scale** | **float** | The scale multiplier for the length of each profile entry | [optional] [default to 1.0]
+**start_time** | **datetime** | The ISO8601-formatted date and time to start profile replay | [optional] 
 **dynamic_results** | [**DynamicResultsConfig**](DynamicResultsConfig.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/tests/aat/common/helper/tvlp.py
+++ b/tests/aat/common/helper/tvlp.py
@@ -13,8 +13,8 @@ def tvlp_model():
     return tc
 
 
-def tvlp_block_profile_model(entries, length, resource_id, time_scale=1.0, load_scale=1.0):
-    tp = client.models.TvlpProfileBlock(series=[], time_scale=time_scale, load_scale=load_scale)
+def tvlp_block_profile_model(entries, length, resource_id):
+    tp = client.models.TvlpProfileBlock(series=[])
     for i in range(entries):
         ps = client.models.TvlpProfileBlockSeries()
         ps.length = length
@@ -24,8 +24,8 @@ def tvlp_block_profile_model(entries, length, resource_id, time_scale=1.0, load_
     return tp
 
 
-def tvlp_memory_profile_model(entries, length, time_scale=1.0, load_scale=1.0):
-    tp = client.models.TvlpProfileMemory(series=[], time_scale=time_scale, load_scale=load_scale)
+def tvlp_memory_profile_model(entries, length):
+    tp = client.models.TvlpProfileMemory(series=[])
     for i in range(entries):
         ps = client.models.TvlpProfileMemorySeries()
         ps.length = length
@@ -34,8 +34,8 @@ def tvlp_memory_profile_model(entries, length, time_scale=1.0, load_scale=1.0):
     return tp
 
 
-def tvlp_cpu_profile_model(entries, length, time_scale=1.0, load_scale=1.0):
-    tp = client.models.TvlpProfileCpu(series=[], time_scale=time_scale, load_scale=load_scale)
+def tvlp_cpu_profile_model(entries, length):
+    tp = client.models.TvlpProfileCpu(series=[])
     for i in range(entries):
         ps = client.models.TvlpProfileCpuSeries()
         ps.length = length
@@ -44,8 +44,8 @@ def tvlp_cpu_profile_model(entries, length, time_scale=1.0, load_scale=1.0):
     return tp
 
 
-def tvlp_packet_profile_model(entries, length, target_id, time_scale=1.0, load_scale=1.0):
-    tp = client.models.TvlpProfilePacket(series=[], time_scale=time_scale, load_scale=load_scale)
+def tvlp_packet_profile_model(entries, length, target_id):
+    tp = client.models.TvlpProfilePacket(series=[])
     for i in range(entries):
         ps = client.models.TvlpProfilePacketSeries()
         ps.length = length
@@ -55,15 +55,21 @@ def tvlp_packet_profile_model(entries, length, target_id, time_scale=1.0, load_s
     return tp
 
 
-def tvlp_start_configuration():
+def tvlp_start_configuration(time_scale=1.0, load_scale=1.0):
     start = client.models.TvlpStartConfiguration()
     start.memory = client.models.TvlpStartSeriesConfiguration()
+    start.memory.load_scale = load_scale
+    start.memory.time_scale = time_scale
     start.memory.dynamic_results = dynamic.make_dynamic_results_config(
         memory.get_memory_dynamic_results_fields())
     start.block = client.models.TvlpStartSeriesConfiguration()
+    start.block.load_scale = load_scale
+    start.block.time_scale = time_scale
     start.block.dynamic_results = dynamic.make_dynamic_results_config(
         block.get_block_dynamic_results_fields())
     start.cpu = client.models.TvlpStartSeriesConfiguration()
+    start.cpu.load_scale = load_scale
+    start.cpu.time_scale = time_scale
     start.cpu.dynamic_results = dynamic.make_dynamic_results_config(
         ["utilization", "steal"])
     return start

--- a/tests/aat/common/matcher/tvlp.py
+++ b/tests/aat/common/matcher/tvlp.py
@@ -5,6 +5,7 @@ from common.matcher import be_valid_dynamic_results
 
 import client.models
 
+
 class _be_valid_tvlp_configuration(Matcher):
     def _match(self, config):
         expect(config).to(be_a(client.models.TvlpConfiguration))
@@ -14,6 +15,7 @@ class _be_valid_tvlp_configuration(Matcher):
         expect(config.error).to(be_none)
         expect(config.profile).to(be_a(client.models.TvlpProfile))
         return True, ['is valid TVLP configuration']
+
 
 class _be_valid_block_tvlp_profile(Matcher):
     def _match(self, profile):
@@ -27,6 +29,7 @@ class _be_valid_block_tvlp_profile(Matcher):
             expect(conf.config).to(be_a(client.models.BlockGeneratorConfig))
         return True, ['is valid Block TVLP profile']
 
+
 class _be_valid_memory_tvlp_profile(Matcher):
     def _match(self, profile):
         expect(profile).to(be_a(client.models.TvlpProfileMemory))
@@ -38,6 +41,7 @@ class _be_valid_memory_tvlp_profile(Matcher):
             expect(conf.config).to(be_a(client.models.MemoryGeneratorConfig))
         return True, ['is valid Memory TVLP profile']
 
+
 class _be_valid_cpu_tvlp_profile(Matcher):
     def _match(self, profile):
         expect(profile).to(be_a(client.models.TvlpProfileCpu))
@@ -48,6 +52,7 @@ class _be_valid_cpu_tvlp_profile(Matcher):
             expect(conf.length).to(be_above(0))
             expect(conf.config).to(be_a(client.models.CpuGeneratorConfig))
         return True, ['is valid Cpu TVLP profile']
+
 
 class _be_valid_packet_tvlp_profile(Matcher):
     def _match(self, profile):
@@ -61,6 +66,7 @@ class _be_valid_packet_tvlp_profile(Matcher):
             expect(conf.config).to(be_a(client.models.PacketGeneratorConfig))
         return True, ['is valid Packet TVLP profile']
 
+
 class _be_valid_tvlp_result(Matcher):
     def _match(self, result):
         expect(result).to(be_a(client.models.TvlpResult))
@@ -71,6 +77,7 @@ class _be_valid_tvlp_result(Matcher):
             for gen_result in prof:
                 expect(gen_result.dynamic_results).to(be_valid_dynamic_results)
         return True, ['is valid TVLP result']
+
 
 be_valid_tvlp_configuration = _be_valid_tvlp_configuration()
 be_valid_block_tvlp_profile = _be_valid_block_tvlp_profile()

--- a/tests/aat/spec/tvlp_spec.py
+++ b/tests/aat/spec/tvlp_spec.py
@@ -123,68 +123,6 @@ with description('TVLP,', 'tvlp') as self:
                         self.skip()
                     expect(self._config[0].profile.packet).to(be_valid_packet_tvlp_profile)
 
-            with description("custom time_scale,"):
-                with before.all:
-                    self._scale = 2.0
-                    self._length = 0.0
-                    t = tvlp_model()
-                    if self._block_linked:
-                        t.profile.block = tvlp_block_profile_model(1, 100000000, "tmp", time_scale=self._scale)
-                        self._length = max(self._length, tvlp_profile_length(t.profile.block))
-                    if self._memory_linked:
-                        t.profile.memory = tvlp_memory_profile_model(1, 100000000, time_scale=self._scale)
-                        self._length = max(self._length, tvlp_profile_length(t.profile.memory))
-                    if self._cpu_linked:
-                        t.profile.cpu = tvlp_cpu_profile_model(1, 100000000, time_scale=self._scale)
-                        self._length = max(self._length, tvlp_profile_length(t.profile.cpu))
-                    if self._packet_linked:
-                        t.profile.packet = tvlp_packet_profile_model(1, 100000000,
-                            get_first_port_id(self.service.client()), time_scale=self._scale)
-                        self._length = max(self._length, tvlp_profile_length(t.profile.packet))
-
-                    self._config = self.tvlp_api.create_tvlp_configuration_with_http_info(t)
-
-                with it('code Created'):
-                    expect(self._config[1]).to(equal(201))
-
-                with it('has valid Location header,'):
-                    expect(self._config[2]).to(has_location('/tvlp/' + self._config[0].id))
-
-                with it('has a valid tvlp configuration'):
-                    expect(self._config[0]).to(be_valid_tvlp_configuration)
-
-                with it('has a valid block profile'):
-                    if not self._block_linked:
-                        self.skip()
-                    expect(self._config[0].profile.block).to(be_valid_block_tvlp_profile)
-
-                with it('has a valid memory profile'):
-                    if not self._memory_linked:
-                        self.skip()
-                    expect(self._config[0].profile.memory).to(be_valid_memory_tvlp_profile)
-
-                with it('has a valid cpu profile'):
-                    if not self._cpu_linked:
-                        self.skip()
-                    expect(self._config[0].profile.cpu).to(be_valid_cpu_tvlp_profile)
-
-                with it('has a valid packet profile'):
-                    if not self._packet_linked:
-                        self.skip()
-                    expect(self._config[0].profile.packet).to(be_valid_packet_tvlp_profile)
-
-                with it('has a valid common length'):
-                    length = 0.0
-                    if self._block_linked:
-                        length = max(length, tvlp_profile_length(self._config[0].profile.block))
-                    if self._memory_linked:
-                        length = max(length, tvlp_profile_length(self._config[0].profile.memory))
-                    if self._cpu_linked:
-                        length = max(length, tvlp_profile_length(self._config[0].profile.cpu))
-                    if self._packet_linked:
-                        length = max(length, tvlp_profile_length(self._config[0].profile.packet))
-                    expect(self._length).to(equal(length))
-                    expect(self._config[0].time.length).to(equal(length))
 
             with description("no profile entries,"):
                 with it('returns 400'):
@@ -310,8 +248,8 @@ with description('TVLP,', 'tvlp') as self:
             with description('delayed,'):
                 with it('succeeded'):
                     next_day = datetime.datetime.today() + datetime.timedelta(days=2)
-                    fmt_day = next_day.strftime("%Y-%m-%dT%H:%M:%S")
-                    result = self.tvlp_api.start_tvlp_configuration_with_http_info(self._config.id, time=str(fmt_day))
+                    result = self.tvlp_api.start_tvlp_configuration_with_http_info(self._config.id,
+                        start=client.models.TvlpStartConfiguration(start_time=next_day))
                     expect(result[1]).to(equal(201))
                     expect(result[2]).to(has_location('/tvlp-results/' + result[0].id))
                     expect(result[0]).to(be_valid_tvlp_result)
@@ -328,6 +266,15 @@ with description('TVLP,', 'tvlp') as self:
                     expect(result[0]).to(be_valid_tvlp_result)
                     result = self.tvlp_api.get_tvlp_result(result[0].id)
                     expect(result).to(be_valid_tvlp_result)
+
+            with description("custom time and load scales,"):
+                with it('succeeded'):
+                    result = self.tvlp_api.start_tvlp_configuration_with_http_info(
+                        id=self._config.id, start=tvlp_start_configuration(
+                            time_scale=2.0, load_scale=2.0))
+                    expect(result[1]).to(equal(201))
+                    expect(result[2]).to(has_location('/tvlp-results/' + result[0].id))
+                    expect(result[0]).to(be_valid_tvlp_result)
 
             with description('running,'):
                 with it('returns 400'):


### PR DESCRIPTION
The change moves `load_scale` and `time_scale` properties from `create` to `start` method.
This will let users run once created profile with different scales.
I believe this one significantly increase the TVLP flexibility.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/393)
<!-- Reviewable:end -->
