### PR TITLE
modules/block: change ID of device from UUID to name

### DIFF
--- a/src/modules/block/device_stack.cpp
+++ b/src/modules/block/device_stack.cpp
@@ -102,7 +102,7 @@ void device_stack::init_device_stack()
         if (!is_raw_device(entry->d_name)) continue;
 
         auto blkdev = std::make_shared<device>();
-        blkdev->id(core::to_string(core::uuid::random()));
+        blkdev->id(std::string(entry->d_name));
         blkdev->path(std::string(device_dir) + "/"
                      + std::string(entry->d_name));
 

--- a/src/modules/block/device_stack.hpp
+++ b/src/modules/block/device_stack.hpp
@@ -52,9 +52,6 @@ public:
 
 private:
     void init_device_stack();
-    uint64_t block_device_size(std::string_view id);
-    std::optional<std::string> block_device_info(std::string_view id);
-    bool is_raw_device(std::string_view id);
 };
 
 } // namespace openperf::block::device


### PR DESCRIPTION
Replace a random generated ID of a block device to a system name of such device.
For example, for `/dev/sda` will be assigned id `sda`.

Closes #381.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/395)
<!-- Reviewable:end -->
