### PR TITLE
modules/tvlp: use start time from generator

### DIFF
--- a/src/modules/block/task.cpp
+++ b/src/modules/block/task.cpp
@@ -226,7 +226,7 @@ task_stat_t block_task::spin()
 
 // Methods : private
 task_stat_t block_task::worker_spin(uint64_t nb_ops,
-                                    realtime::time_point deadline)
+                                    ref_clock::time_point deadline)
 {
     auto op_conf = operation_config{
         .fd = m_task_config.fd,

--- a/src/modules/block/task.hpp
+++ b/src/modules/block/task.hpp
@@ -15,7 +15,6 @@ namespace openperf::block::worker {
 
 using ref_clock = timesync::chrono::monotime;
 using realtime = timesync::chrono::realtime;
-using time_point = realtime::time_point;
 using duration = std::chrono::nanoseconds;
 
 enum class task_operation : uint8_t { READ = 0, WRITE };
@@ -57,7 +56,7 @@ struct task_stat_t
      */
 
     task_operation operation;
-    time_point updated = realtime::now();
+    realtime::time_point updated = realtime::now();
     uint_fast64_t ops_target = 0;
     uint_fast64_t ops_actual = 0;
     uint_fast64_t bytes_target = 0;
@@ -79,8 +78,8 @@ enum aio_state : uint8_t {
 
 struct operation_state
 {
-    time_point start;
-    time_point stop;
+    ref_clock::time_point start;
+    ref_clock::time_point stop;
     uint64_t io_bytes;
     enum aio_state state;
     aiocb aiocb;
@@ -94,7 +93,7 @@ private:
     std::vector<operation_state> m_aio_ops;
     std::vector<uint8_t> m_buf;
     pattern_generator m_pattern;
-    realtime::time_point m_operation_timestamp;
+    ref_clock::time_point m_operation_timestamp;
 
 public:
     block_task(const task_config_t&);
@@ -108,7 +107,7 @@ private:
     void config(const task_config_t&);
     void reset_spin_stat();
     int32_t calculate_rate();
-    task_stat_t worker_spin(uint64_t nb_ops, time_point deadline);
+    task_stat_t worker_spin(uint64_t nb_ops, ref_clock::time_point deadline);
 };
 
 } // namespace openperf::block::worker

--- a/src/modules/timesync/chrono.hpp
+++ b/src/modules/timesync/chrono.hpp
@@ -111,7 +111,7 @@ struct monotime
     using duration = std::chrono::nanoseconds;
     using rep = duration::rep;
     using period = duration::period;
-    using time_point = std::chrono::time_point<realtime, duration>;
+    using time_point = std::chrono::time_point<monotime, duration>;
 
     static constexpr bool is_steady = true;
 

--- a/src/modules/tvlp/worker.hpp
+++ b/src/modules/tvlp/worker.hpp
@@ -17,9 +17,6 @@
 
 namespace openperf::tvlp::internal::worker {
 
-using namespace std::chrono_literals;
-using stat_pair_t = std::pair<std::string, nlohmann::json>;
-
 struct tvlp_worker_state_t
 {
     std::atomic<model::tvlp_state_t> state;
@@ -30,6 +27,14 @@ struct tvlp_worker_state_t
 class tvlp_worker_t
 {
     using worker_future = std::future<tl::expected<void, std::string>>;
+
+protected:
+    struct start_result_t
+    {
+        std::string result_id;
+        nlohmann::json statistics;
+        model::realtime::time_point start_time = model::realtime::now();
+    };
 
 public:
     tvlp_worker_t() = delete;
@@ -51,7 +56,7 @@ public:
 protected:
     virtual tl::expected<std::string, std::string>
     send_create(const model::tvlp_profile_t::entry&, double load_scale) = 0;
-    virtual tl::expected<stat_pair_t, std::string>
+    virtual tl::expected<start_result_t, std::string>
     send_start(const std::string& id,
                const dynamic::configuration& dynamic_results = {}) = 0;
     virtual tl::expected<void, std::string>

--- a/src/modules/tvlp/workers/block.cpp
+++ b/src/modules/tvlp/workers/block.cpp
@@ -58,7 +58,7 @@ block_tvlp_worker_t::send_create(const model::tvlp_profile_t::entry& entry,
     return tl::make_unexpected("Unexpected error");
 }
 
-tl::expected<stat_pair_t, std::string>
+tl::expected<block_tvlp_worker_t::start_result_t, std::string>
 block_tvlp_worker_t::send_start(const std::string& id,
                                 const dynamic::configuration& dynamic_results)
 {
@@ -71,8 +71,12 @@ block_tvlp_worker_t::send_start(const std::string& id,
 
     if (auto r =
             std::get_if<reply_block_generator_results>(&api_reply.value())) {
-        return std::pair(r->results.front()->id(),
-                         to_swagger(*r->results.front())->toJson());
+        auto& result = r->results.front();
+        return start_result_t{
+            .result_id = result->id(),
+            .statistics = to_swagger(*result)->toJson(),
+            .start_time = result->start_timestamp(),
+        };
     } else if (auto error = std::get_if<reply_error>(&api_reply.value())) {
         return tl::make_unexpected(to_string(error->info));
     }

--- a/src/modules/tvlp/workers/block.hpp
+++ b/src/modules/tvlp/workers/block.hpp
@@ -17,7 +17,7 @@ protected:
     tl::expected<std::string, std::string>
     send_create(const model::tvlp_profile_t::entry&,
                 double load_scale) override;
-    tl::expected<stat_pair_t, std::string>
+    tl::expected<start_result_t, std::string>
     send_start(const std::string& id,
                const dynamic::configuration& dynamic_results) override;
     tl::expected<void, std::string> send_stop(const std::string& id) override;

--- a/src/modules/tvlp/workers/cpu.cpp
+++ b/src/modules/tvlp/workers/cpu.cpp
@@ -50,7 +50,7 @@ cpu_tvlp_worker_t::send_create(const model::tvlp_profile_t::entry& entry,
     return tl::make_unexpected("Unexpected error");
 }
 
-tl::expected<stat_pair_t, std::string>
+tl::expected<cpu_tvlp_worker_t::start_result_t, std::string>
 cpu_tvlp_worker_t::send_start(const std::string& id,
                               const dynamic::configuration& dynamic_results)
 {
@@ -62,8 +62,12 @@ cpu_tvlp_worker_t::send_start(const std::string& id,
             .and_then(deserialize_reply);
 
     if (auto r = std::get_if<reply_cpu_generator_results>(&api_reply.value())) {
-        return std::pair(r->results.front()->id(),
-                         to_swagger(*r->results.front())->toJson());
+        auto& result = r->results.front();
+        return start_result_t{
+            .result_id = result->id(),
+            .statistics = to_swagger(*result)->toJson(),
+            .start_time = result->start_timestamp(),
+        };
     } else if (auto error = std::get_if<reply_error>(&api_reply.value())) {
         return tl::make_unexpected(to_string(*error->info));
     }

--- a/src/modules/tvlp/workers/cpu.hpp
+++ b/src/modules/tvlp/workers/cpu.hpp
@@ -17,7 +17,7 @@ protected:
     tl::expected<std::string, std::string>
     send_create(const model::tvlp_profile_t::entry&,
                 double load_scale) override;
-    tl::expected<stat_pair_t, std::string>
+    tl::expected<start_result_t, std::string>
     send_start(const std::string& id,
                const dynamic::configuration& dynamic_results) override;
     tl::expected<void, std::string> send_stop(const std::string& id) override;

--- a/src/modules/tvlp/workers/memory.cpp
+++ b/src/modules/tvlp/workers/memory.cpp
@@ -53,7 +53,7 @@ memory_tvlp_worker_t::send_create(const model::tvlp_profile_t::entry& entry,
     return tl::make_unexpected("Unexpected error");
 }
 
-tl::expected<stat_pair_t, std::string>
+tl::expected<memory_tvlp_worker_t::start_result_t, std::string>
 memory_tvlp_worker_t::send_start(const std::string& id,
                                  const dynamic::configuration& dynamic_results)
 {
@@ -64,7 +64,11 @@ memory_tvlp_worker_t::send_start(const std::string& id,
                          .and_then(deserialize_reply);
 
     if (auto r = std::get_if<reply::statistic::item>(&api_reply.value())) {
-        return std::pair(r->id, to_swagger(*r).toJson());
+        return start_result_t{
+            .result_id = r->id,
+            .statistics = to_swagger(*r).toJson(),
+            .start_time = r->stat.start_timestamp(),
+        };
     } else if (auto error = std::get_if<reply::error>(&api_reply.value())) {
         auto e = to_error(*error);
         if (e.second) return tl::make_unexpected(e.second.value());

--- a/src/modules/tvlp/workers/memory.hpp
+++ b/src/modules/tvlp/workers/memory.hpp
@@ -17,7 +17,7 @@ protected:
     tl::expected<std::string, std::string>
     send_create(const model::tvlp_profile_t::entry&,
                 double load_scale) override;
-    tl::expected<stat_pair_t, std::string>
+    tl::expected<start_result_t, std::string>
     send_start(const std::string& id,
                const dynamic::configuration& dynamic_results) override;
     tl::expected<void, std::string> send_stop(const std::string& id) override;

--- a/src/modules/tvlp/workers/packet.cpp
+++ b/src/modules/tvlp/workers/packet.cpp
@@ -54,7 +54,8 @@ packet_tvlp_worker_t::send_create(const model::tvlp_profile_t::entry& entry,
     return tl::make_unexpected("Unexpected error");
 }
 
-tl::expected<stat_pair_t, std::string> packet_tvlp_worker_t::send_start(
+tl::expected<packet_tvlp_worker_t::start_result_t, std::string>
+packet_tvlp_worker_t::send_start(
     const std::string& id, const dynamic::configuration& /* dynamic_results */)
 {
     auto api_reply =
@@ -62,8 +63,11 @@ tl::expected<stat_pair_t, std::string> packet_tvlp_worker_t::send_start(
             .and_then(deserialize_reply);
 
     if (auto r = std::get_if<reply_generator_results>(&api_reply.value())) {
-        return std::pair(r->generator_results.front()->getId(),
-                         r->generator_results.front()->toJson());
+        auto& result = r->generator_results.front();
+        return start_result_t{
+            .result_id = result->getId(),
+            .statistics = result->toJson(),
+        };
     } else if (auto error = std::get_if<reply_error>(&api_reply.value())) {
         return tl::make_unexpected(to_string(*error));
     }

--- a/src/modules/tvlp/workers/packet.hpp
+++ b/src/modules/tvlp/workers/packet.hpp
@@ -17,7 +17,7 @@ protected:
     tl::expected<std::string, std::string>
     send_create(const model::tvlp_profile_t::entry&,
                 double load_scale) override;
-    tl::expected<stat_pair_t, std::string>
+    tl::expected<start_result_t, std::string>
     send_start(const std::string& id,
                const dynamic::configuration& dynamic_results) override;
     tl::expected<void, std::string> send_stop(const std::string& id) override;


### PR DESCRIPTION
Use start_time from generator statistics, instead of using `now()` method inside TVLP.
Should increases an accuracy of TVLP profile run time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/397)
<!-- Reviewable:end -->
