### PR TITLE
modules/packetio: add option to disable link interrupts

### DIFF
--- a/src/modules/packetio/drivers/dpdk/primary/arg_parser.hpp
+++ b/src/modules/packetio/drivers/dpdk/primary/arg_parser.hpp
@@ -5,6 +5,7 @@
 
 extern const char op_packetio_dpdk_no_lro[];
 extern const char op_packetio_dpdk_no_rx_irqs[];
+extern const char op_packetio_dpdk_no_link_irqs[];
 extern const char op_packetio_dpdk_test_mode[];
 extern const char op_packetio_dpdk_test_portpairs[];
 

--- a/src/modules/packetio/drivers/dpdk/primary/arg_parser_register.c
+++ b/src/modules/packetio/drivers/dpdk/primary/arg_parser_register.c
@@ -3,6 +3,8 @@
 
 const char op_packetio_dpdk_no_rx_irqs[] =
     "modules.packetio.dpdk.no-rx-interrupts";
+const char op_packetio_dpdk_no_link_irqs[] =
+    "modules.packetio.dpdk.no-link-interrupts";
 const char op_packetio_dpdk_no_lro[] = "modules.packetio.dpdk.no-lro";
 const char op_packetio_dpdk_test_mode[] = "modules.packetio.dpdk.test-mode";
 const char op_packetio_dpdk_test_portpairs[] =
@@ -21,6 +23,10 @@ MAKE_OPTION_DATA(
              OP_OPTION_TYPE_LONG),
     MAKE_OPT("disable receive queue interrupts",
              op_packetio_dpdk_no_rx_irqs,
+             0,
+             OP_OPTION_TYPE_NONE),
+    MAKE_OPT("disable link state and speed change interrupts",
+             op_packetio_dpdk_no_link_irqs,
              0,
              OP_OPTION_TYPE_NONE),
     MAKE_OPT("disable large receive offload",

--- a/src/modules/packetio/drivers/dpdk/primary/port_info.cpp
+++ b/src/modules/packetio/drivers/dpdk/primary/port_info.cpp
@@ -37,6 +37,10 @@ uint16_t tx_queue_default(uint16_t port_id)
 
 bool lsc_interrupt(uint16_t port_id)
 {
+    auto result =
+        openperf::config::file::op_config_get_param<OP_OPTION_TYPE_NONE>(
+            op_packetio_dpdk_no_link_irqs);
+    if (result.value_or(false)) return false;
     return (*(get_info_field(port_id, &rte_eth_dev_info::dev_flags))
             & RTE_ETH_DEV_INTR_LSC);
 }


### PR DESCRIPTION
Add modules.packetio.dpdk.no-link-interrupts option to disable link
interrupts.

Link interrupts are enabled by default when supported by the driver, but
unfortunately there are cases where link interrupts do not work.

The uio_pci_generic driver doesn't support interrupts at all.
The igb_uio driver only supports one interrupt but the rx interrupt takes
precedence so link interrupts don't work with the igb_uio driver.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/410)
<!-- Reviewable:end -->
