### PR TITLE
TVLP Shared Buffer for Memory Generators in profile series

### DIFF
--- a/src/modules/memory/api_transmogrify.cpp
+++ b/src/modules/memory/api_transmogrify.cpp
@@ -75,7 +75,10 @@ serialized_msg serialize(api_reply&& msg)
                      return openperf::message::push(serialized, item.id)
                             || openperf::message::push(serialized,
                                                        item.is_running)
-                            || openperf::message::push(serialized, item.config)
+                            || openperf::message::push(
+                                serialized,
+                                std::make_unique<decltype(item.config)>(
+                                    std::move(item.config)))
                             || openperf::message::push(
                                 serialized, item.init_percent_complete);
                  },
@@ -201,7 +204,8 @@ tl::expected<api_reply, int> deserialize_reply(serialized_msg&& msg)
         reply::generator::item item{};
         item.id = openperf::message::pop_string(msg);
         item.is_running = openperf::message::pop<bool>(msg);
-        item.config = openperf::message::pop<decltype(item.config)>(msg);
+        item.config = std::move(*std::unique_ptr<decltype(item.config)>(
+            openperf::message::pop<decltype(item.config)*>(msg)));
         item.init_percent_complete = openperf::message::pop<int32_t>(msg);
         return item;
     }

--- a/src/modules/memory/buffer.cpp
+++ b/src/modules/memory/buffer.cpp
@@ -1,0 +1,165 @@
+#include "buffer.hpp"
+
+#include "framework/core/op_log.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstdlib>
+#include <cstring>
+#include <new>
+
+namespace openperf::memory::internal {
+
+// Constructors & Destructor
+buffer::buffer(std::size_t alignment)
+    : m_alignment(alignment)
+{}
+
+buffer::buffer(std::size_t size, std::size_t alignment)
+    : buffer(alignment)
+{
+    allocate(size);
+}
+
+buffer::buffer(const buffer& other) { *this = other; }
+
+buffer::buffer(buffer&& other) noexcept
+    : m_alignment(other.m_alignment)
+    , m_ptr(other.m_ptr)
+    , m_size(other.m_size)
+{
+    other.m_ptr = nullptr;
+    other.m_size = 0;
+}
+
+buffer::~buffer() { release(); }
+
+buffer& buffer::operator=(const buffer& other)
+{
+    if (this == &other) return *this;
+
+    release();
+    m_alignment = other.m_alignment;
+
+    if (other.m_size > 0) {
+        allocate(other.m_size);
+
+        // NOTE: if statement needs to supress NonNullParamChecker warning
+        if (m_ptr != nullptr) std::memcpy(m_ptr, other.m_ptr, m_size);
+    }
+
+    return *this;
+}
+
+// Methods : public
+void buffer::allocate(std::size_t size)
+{
+    assert(size > 0);
+    assert(m_ptr == nullptr);
+
+    if (m_alignment) return allocate(size, m_alignment.value());
+
+    OP_LOG(OP_LOG_TRACE, "Allocating buffer of %zu bytes\n", size);
+
+    auto ptr = std::malloc(size);
+    if (ptr == nullptr) {
+        OP_LOG(
+            OP_LOG_ERROR, "Failed to allocate %zu bytes memory buffer\n", size);
+        throw std::bad_alloc();
+    }
+
+    m_ptr = ptr;
+    m_size = size;
+}
+
+void buffer::resize(std::size_t size)
+{
+    assert(size >= 0);
+    if (size == m_size) return;
+
+    if (size == 0) return release();
+    if (m_size == 0) return allocate(size);
+    if (m_alignment) return resize(size, m_alignment.value());
+
+    OP_LOG(OP_LOG_TRACE, "Resizing buffer (%zu => %zu)\n", m_size, size);
+
+    auto ptr = std::realloc(m_ptr, size);
+    if (ptr == nullptr) {
+        OP_LOG(OP_LOG_ERROR,
+               "Failed to resize (%zu => %zu) memory buffer\n",
+               m_size,
+               size);
+        throw std::bad_alloc();
+    }
+
+    m_ptr = ptr;
+    m_size = size;
+}
+
+void buffer::release()
+{
+    if (m_ptr == nullptr) return;
+
+    OP_LOG(OP_LOG_TRACE, "Releasing buffer of %zu bytes\n", m_size);
+
+    std::free(m_ptr);
+
+    m_ptr = nullptr;
+    m_size = 0;
+}
+
+// Methods : private
+void buffer::allocate(std::size_t size, std::size_t alignment)
+{
+    assert(size > 0);
+    assert(alignment > 0);
+    assert(m_ptr == nullptr);
+
+    OP_LOG(OP_LOG_TRACE,
+           "Allocating buffer of %zu with alignment %zu\n",
+           size,
+           alignment);
+
+    auto ptr = std::aligned_alloc(alignment, size);
+    if (ptr == nullptr) {
+        OP_LOG(
+            OP_LOG_ERROR,
+            "Failed to allocate %zu bytes memory buffer with alignment %zu\n",
+            size,
+            alignment);
+        throw std::bad_alloc();
+    }
+
+    m_ptr = ptr;
+    m_size = size;
+}
+
+void buffer::resize(std::size_t size, std::size_t alignment)
+{
+    assert(alignment > 0);
+    if (size == m_size) return;
+
+    OP_LOG(OP_LOG_TRACE,
+           "Resizing buffer (%zu => %zu) with alignment %zu\n",
+           m_size,
+           size,
+           alignment);
+
+    auto ptr = std::aligned_alloc(alignment, size);
+    if (ptr == nullptr) {
+        OP_LOG(OP_LOG_ERROR,
+               "Failed to resize (%zu => %zu) buffer with alignment %zu\n",
+               m_size,
+               size,
+               alignment);
+        throw std::bad_alloc();
+    }
+
+    std::memcpy(ptr, m_ptr, std::min(m_size, size));
+    std::free(m_ptr);
+
+    m_ptr = ptr;
+    m_size = size;
+}
+
+} // namespace openperf::memory::internal

--- a/src/modules/memory/buffer.hpp
+++ b/src/modules/memory/buffer.hpp
@@ -1,0 +1,42 @@
+#ifndef _OP_MEMORY_BUFFER_HPP_
+#define _OP_MEMORY_BUFFER_HPP_
+
+#include <optional>
+
+namespace openperf::memory::internal {
+
+class buffer
+{
+private:
+    using size_t = std::size_t;
+
+    std::optional<std::size_t> m_alignment;
+    void* m_ptr = nullptr;
+    std::size_t m_size = 0;
+
+public:
+    buffer() = default;
+    explicit buffer(size_t alignment);
+    buffer(size_t size, size_t alignment);
+    buffer(const buffer&);
+    buffer(buffer&&) noexcept;
+    ~buffer();
+
+    buffer& operator=(const buffer&);
+
+    void allocate(size_t size);
+    void resize(size_t size);
+    void release();
+
+    bool is_allocated() const { return m_size == 0; }
+    size_t size() const { return m_size; }
+    void* data() const { return m_ptr; }
+
+private:
+    void allocate(size_t, size_t);
+    void resize(size_t, size_t);
+};
+
+} // namespace openperf::memory::internal
+
+#endif // _OP_MEMORY_BUFFER_HPP_

--- a/src/modules/memory/directory.mk
+++ b/src/modules/memory/directory.mk
@@ -33,6 +33,7 @@ $(MEMORY_OBJ_DIR)/init.o: OP_CPPFLAGS += \
 MEMORY_TEST_DEPENDS += framework timesync_test
 
 MEMORY_TEST_SOURCES += \
+	buffer.cpp \
 	generator.cpp \
 	info.cpp \
 	memory_stat.cpp \

--- a/src/modules/memory/directory.mk
+++ b/src/modules/memory/directory.mk
@@ -7,6 +7,7 @@ MEMORY_DEPENDS += api framework pistache swagger_model json versions timesync
 MEMORY_SOURCES += \
 	api_converters.cpp \
 	api_transmogrify.cpp \
+	buffer.cpp \
 	generator.cpp \
 	generator_collection.cpp \
 	handler.cpp \

--- a/src/modules/memory/generator.cpp
+++ b/src/modules/memory/generator.cpp
@@ -288,8 +288,9 @@ generator::config_t generator::config() const
 void generator::scrub_worker()
 {
     size_t current = 0;
+    auto page_size = sysconf(_SC_PAGESIZE);
     auto block_size =
-        ((m_buffer.size / 100 - 1) / getpagesize() + 1) * getpagesize();
+        ((m_buffer->size() / 100 - 1) / page_size + 1) * page_size;
     auto seed = utils::random_uniform<uint32_t>();
 
     while (!m_scrub_aborted.load() && current < m_buffer->size()) {

--- a/src/modules/memory/generator.cpp
+++ b/src/modules/memory/generator.cpp
@@ -256,6 +256,14 @@ void generator::config(const generator::config_t& cfg)
             + " bytes are available");
     }
 
+    if (std::max(cfg.read.block_size, cfg.write.block_size) > cfg.buffer_size) {
+        throw std::runtime_error(
+            "Requested block size is greater than buffer (buffer: "
+            + std::to_string(cfg.buffer_size)
+            + ", read_block: " + std::to_string(cfg.read.block_size)
+            + ", write_block: " + std::to_string(cfg.write.block_size));
+    }
+
     m_buffer_size = cfg.buffer_size;
     if (auto buffer = cfg.buffer.lock()) {
         assert(m_buffer_size <= buffer->size());

--- a/src/modules/memory/generator.hpp
+++ b/src/modules/memory/generator.hpp
@@ -4,6 +4,7 @@
 #include <future>
 #include <atomic>
 
+#include "buffer.hpp"
 #include "memory_stat.hpp"
 #include "task_memory.hpp"
 
@@ -43,11 +44,7 @@ private:
     std::thread m_scrub_thread;
     std::atomic_bool m_scrub_aborted;
 
-    struct buffer_t
-    {
-        void* ptr;
-        size_t size;
-    } m_buffer;
+    std::shared_ptr<buffer> m_buffer;
 
     struct operation_data
     {
@@ -100,8 +97,6 @@ public:
     bool is_paused() const { return m_paused; }
 
 private:
-    void free_buffer();
-    void resize_buffer(size_t);
     void scrub_worker();
 
     void init_index(operation_data& op);
@@ -131,11 +126,7 @@ void generator::configure_tasks(operation_data& op,
             .block_size = op.config.block_size,
             .op_per_sec = op.config.op_per_sec / op.config.threads,
             .pattern = op.config.pattern,
-            .buffer =
-                {
-                    .ptr = m_buffer.ptr,
-                    .size = m_buffer.size,
-                },
+            .buffer = m_buffer,
             .indexes = &op.indexes,
         });
 

--- a/src/modules/memory/generator.hpp
+++ b/src/modules/memory/generator.hpp
@@ -31,6 +31,7 @@ public:
     {
         size_t buffer_size = 0;
         operation_config read, write;
+        std::weak_ptr<buffer> buffer;
     };
 
     using index_vector = std::vector<uint64_t>;
@@ -44,6 +45,7 @@ private:
     std::thread m_scrub_thread;
     std::atomic_bool m_scrub_aborted;
 
+    size_t m_buffer_size = 0;
     std::shared_ptr<buffer> m_buffer;
 
     struct operation_data

--- a/src/modules/memory/server.cpp
+++ b/src/modules/memory/server.cpp
@@ -125,13 +125,12 @@ api_reply server::handle_request(const request::generator::bulk::create& req)
         try {
             auto id = m_generator_stack->create(data.id, data.config);
             const auto& gnr = m_generator_stack->generator(id);
-            reply::generator::item item_data{
+            list.push_back(reply::generator::item{
                 .id = id,
                 .is_running = false,
                 .config = gnr.config(),
                 .init_percent_complete = gnr.init_percent_complete(),
-            };
-            list.push_back(item_data);
+            });
         } catch (const std::invalid_argument&) {
             remove_created_items();
             return reply::error{.type = reply::error::EXISTS};

--- a/src/modules/memory/task_memory_read.cpp
+++ b/src/modules/memory/task_memory_read.cpp
@@ -8,10 +8,12 @@ namespace openperf::memory::internal {
 void task_memory_read::operation(uint64_t nb_ops)
 {
     assert(m_op_index < m_config.indexes->size());
+
+    auto* buffer_pointer = reinterpret_cast<uint8_t*>(m_buffer->data());
     for (size_t i = 0; i < nb_ops; ++i) {
-        uint64_t idx = m_config.indexes->at(m_op_index++);
-        std::memcpy(m_scratch.ptr,
-                    m_buffer + (idx * m_config.block_size),
+        auto idx = m_config.indexes->at(m_op_index++);
+        std::memcpy(m_scratch.data(),
+                    buffer_pointer + (idx * m_config.block_size),
                     m_config.block_size);
         if (m_op_index == m_config.indexes->size()) { m_op_index = 0; }
     }

--- a/src/modules/memory/task_memory_write.cpp
+++ b/src/modules/memory/task_memory_write.cpp
@@ -8,10 +8,12 @@ namespace openperf::memory::internal {
 void task_memory_write::operation(uint64_t nb_ops)
 {
     assert(m_op_index < m_config.indexes->size());
+
+    auto* buffer_pointer = reinterpret_cast<uint8_t*>(m_buffer->data());
     for (size_t i = 0; i < nb_ops; ++i) {
-        uint64_t idx = m_config.indexes->at(m_op_index++);
-        std::memcpy(m_buffer + (idx * m_config.block_size),
-                    m_scratch.ptr,
+        auto idx = m_config.indexes->at(m_op_index++);
+        std::memcpy(buffer_pointer + (idx * m_config.block_size),
+                    m_scratch.data(),
                     m_config.block_size);
         if (m_op_index == m_config.indexes->size()) { m_op_index = 0; }
     }

--- a/src/modules/tvlp/workers/memory.hpp
+++ b/src/modules/tvlp/workers/memory.hpp
@@ -2,11 +2,17 @@
 #define _OP_TVLP_MEMORY_WORKER_HPP_
 
 #include "tvlp/worker.hpp"
+#include "modules/memory/buffer.hpp"
 
 namespace openperf::tvlp::internal::worker {
 
 class memory_tvlp_worker_t : public tvlp_worker_t
 {
+private:
+    using buffer = memory::internal::buffer;
+
+    std::shared_ptr<buffer> m_buffer;
+
 public:
     memory_tvlp_worker_t() = delete;
     memory_tvlp_worker_t(const memory_tvlp_worker_t&) = delete;

--- a/tests/unit/modules/memory/directory.mk
+++ b/tests/unit/modules/memory/directory.mk
@@ -5,5 +5,6 @@
 TEST_DEPENDS += memory_test
 
 TEST_SOURCES += \
+	modules/memory/test_memory_buffer.cpp \
 	modules/memory/test_memory_stat.cpp \
 	modules/memory/test_memory_task.cpp

--- a/tests/unit/modules/memory/test_memory_buffer.cpp
+++ b/tests/unit/modules/memory/test_memory_buffer.cpp
@@ -1,0 +1,120 @@
+#include "catch.hpp"
+#include "memory/buffer.hpp"
+
+using openperf::memory::internal::buffer;
+
+void fill_buffer(buffer& buf, std::function<uint8_t(size_t)> filler)
+{
+    auto pointer = reinterpret_cast<uint8_t*>(buf.data());
+    for (size_t i = 0; i < buf.size(); i++) pointer[i] = filler(i);
+}
+
+void test_buffer(buffer& buf, std::function<void(uint8_t, size_t)> checker)
+{
+    auto pointer = reinterpret_cast<uint8_t*>(buf.data());
+    for (size_t i = 0; i < buf.size(); i++) checker(pointer[i], i);
+}
+
+TEST_CASE("Memory Buffer", "[buffer]")
+{
+    size_t size = 1024;
+
+    SECTION("allocating")
+    {
+        {
+            auto buf = buffer();
+            buf.allocate(size);
+
+            auto ptr = reinterpret_cast<uint8_t*>(buf.data());
+            for (size_t i = 0; i < size; i++) {
+                ptr[i] = i % 0xFF;
+                REQUIRE(ptr[i] == i % 0xFF);
+            }
+
+            buf.release();
+
+            REQUIRE(buf.size() == 0);
+            REQUIRE(buf.data() == nullptr);
+        }
+        {
+            auto buf = buffer(16);
+            buf.allocate(size);
+
+            auto ptr = reinterpret_cast<uint8_t*>(buf.data());
+            for (size_t i = 0; i < size; i++) {
+                ptr[i] = i % 0xFF;
+                REQUIRE(ptr[i] == i % 0xFF);
+            }
+
+            buf.release();
+
+            REQUIRE(buf.size() == 0);
+            REQUIRE(buf.data() == nullptr);
+        }
+    }
+
+    SECTION("resizing")
+    {
+        auto buf = buffer(16);
+        buf.allocate(size);
+        REQUIRE(buf.size() == size);
+
+        fill_buffer(buf, [](size_t i) { return i % 0xFF; });
+
+        buf.resize(size * 2);
+        REQUIRE(buf.size() == size * 2);
+
+        auto pointer = reinterpret_cast<uint8_t*>(buf.data());
+        for (size_t i = 0; i < size; i++) REQUIRE(pointer[i] == i % 0xFF);
+    }
+
+    SECTION("moving")
+    {
+        auto buffer0 = buffer();
+        buffer0.allocate(size);
+
+        fill_buffer(buffer0, [](size_t i) { return i % 0xFF; });
+
+        auto buffer1 = buffer(std::move(buffer0));
+        REQUIRE(buffer0.size() == 0);
+        REQUIRE(buffer0.data() == nullptr);
+        REQUIRE(buffer1.size() == size);
+        REQUIRE(buffer1.data() != nullptr);
+
+        test_buffer(buffer1,
+                    [](uint8_t item, size_t i) { REQUIRE(item == i % 0xFF); });
+    }
+
+    SECTION("copying")
+    {
+        auto buffer0 = buffer();
+        buffer0.allocate(size);
+
+        fill_buffer(buffer0, [](size_t i) { return i % 0xFF; });
+
+        auto buffer1 = buffer(buffer0);
+        REQUIRE(buffer0.size() == buffer1.size());
+        REQUIRE(buffer0.data() != buffer1.data());
+
+        test_buffer(buffer1,
+                    [](uint8_t item, size_t i) { REQUIRE(item == i % 0xFF); });
+    }
+
+    SECTION("assigning")
+    {
+        auto buffer0 = buffer();
+        buffer0.allocate(size);
+
+        fill_buffer(buffer0, [](size_t i) { return i % 0xFF; });
+
+        auto buffer1 = buffer();
+        REQUIRE(buffer0.size() != buffer1.size());
+
+        buffer1 = buffer0;
+        REQUIRE(buffer0.size() == buffer1.size());
+        REQUIRE(buffer0.data() != buffer1.data());
+
+        test_buffer(buffer1,
+                    [](uint8_t item, size_t i) { REQUIRE(item == i % 0xFF); });
+    }
+}


### PR DESCRIPTION
PR improves TVLP Memory Generator running.
Changes allow to allocate memory buffer once at TVLP creation time and using this buffer for all generators in the series of TVLP profile.

Closes #399.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/411)
<!-- Reviewable:end -->
