### PR TITLE
Change datatype of the Dynamic Results weight

### DIFF
--- a/api/schema/v1/modules/dynamic.yaml
+++ b/api/schema/v1/modules/dynamic.yaml
@@ -5,7 +5,7 @@ parameters:
     description: Dynamic results configuration
     required: false
     schema:
-      $ref: "#/definitions/DynamicResults"
+      $ref: "#/definitions/DynamicResultsConfig"
 
 definitions:
   DynamicResultsConfig:

--- a/api/schema/v1/modules/dynamic.yaml
+++ b/api/schema/v1/modules/dynamic.yaml
@@ -200,6 +200,7 @@ definitions:
         description: The average value of this centroid
       weight:
         type: integer
+        format: int64
         description: The weight of this centroid
     required:
       - mean

--- a/src/modules/dynamic/api.hpp
+++ b/src/modules/dynamic/api.hpp
@@ -31,7 +31,7 @@ struct argument_t
 
 struct results
 {
-    using centroid = std::pair<double, uint32_t>;
+    using centroid = std::pair<double, uint64_t>;
 
     struct threshold
     {

--- a/src/modules/dynamic/spool.hpp
+++ b/src/modules/dynamic/spool.hpp
@@ -16,7 +16,7 @@ template <typename T> class spool
 {
 public:
     using extractor = std::optional<double> (*)(const T&, std::string_view);
-    using tdigest = ::digestible::tdigest<double, uint32_t>;
+    using tdigest = ::digestible::tdigest<double, uint64_t>;
 
 private:
     // Internal Types
@@ -50,7 +50,7 @@ public:
     void add(const T& stat);
 
 private:
-    uint32_t weight(const argument_t&, const T&) const;
+    uint64_t weight(const argument_t&, const T&) const;
     double delta(const argument_t&, const T&) const;
     void argument_check(const argument_t&) const;
 };
@@ -206,14 +206,14 @@ template <typename T> results spool<T>::result() const
 
 // Methods : private
 template <typename T>
-uint32_t spool<T>::weight(const argument_t& arg, const T& stat) const
+uint64_t spool<T>::weight(const argument_t& arg, const T& stat) const
 {
-    int weight = 1;
+    uint64_t weight = 1;
     switch (arg.function) {
     case argument_t::DXDY: {
         auto y = m_extractor(stat, arg.y).value();
         auto last_y = m_extractor(m_last_stat, arg.y).value();
-        weight = static_cast<uint32_t>(y - last_y);
+        weight = static_cast<uint64_t>(y - last_y);
         break;
     }
     default:

--- a/src/swagger/v1/model/TDigestCentroid.cpp
+++ b/src/swagger/v1/model/TDigestCentroid.cpp
@@ -20,7 +20,7 @@ namespace model {
 TDigestCentroid::TDigestCentroid()
 {
     m_Mean = 0.0;
-    m_Weight = 0;
+    m_Weight = 0L;
     
 }
 
@@ -61,11 +61,11 @@ void TDigestCentroid::setMean(double value)
     m_Mean = value;
     
 }
-int32_t TDigestCentroid::getWeight() const
+int64_t TDigestCentroid::getWeight() const
 {
     return m_Weight;
 }
-void TDigestCentroid::setWeight(int32_t value)
+void TDigestCentroid::setWeight(int64_t value)
 {
     m_Weight = value;
     

--- a/src/swagger/v1/model/TDigestCentroid.h
+++ b/src/swagger/v1/model/TDigestCentroid.h
@@ -55,13 +55,13 @@ public:
         /// <summary>
     /// The weight of this centroid
     /// </summary>
-    int32_t getWeight() const;
-    void setWeight(int32_t value);
+    int64_t getWeight() const;
+    void setWeight(int64_t value);
     
 protected:
     double m_Mean;
 
-    int32_t m_Weight;
+    int64_t m_Weight;
 
 };
 

--- a/tests/aat/api/v1/client/api/block_generator_api.py
+++ b/tests/aat/api/v1/client/api/block_generator_api.py
@@ -1891,7 +1891,7 @@ class BlockGeneratorApi(object):
 
         :param async_req bool
         :param str id: Unique resource identifier (required)
-        :param DynamicResults dynamic_results: Dynamic results configuration
+        :param DynamicResultsConfig dynamic_results: Dynamic results configuration
         :return: BlockGeneratorResult
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1914,7 +1914,7 @@ class BlockGeneratorApi(object):
 
         :param async_req bool
         :param str id: Unique resource identifier (required)
-        :param DynamicResults dynamic_results: Dynamic results configuration
+        :param DynamicResultsConfig dynamic_results: Dynamic results configuration
         :return: BlockGeneratorResult
                  If the method is called asynchronously,
                  returns the request thread.

--- a/tests/aat/api/v1/client/api/cpu_generator_api.py
+++ b/tests/aat/api/v1/client/api/cpu_generator_api.py
@@ -1206,7 +1206,7 @@ class CpuGeneratorApi(object):
 
         :param async_req bool
         :param str id: Unique resource identifier (required)
-        :param DynamicResults dynamic_results: Dynamic results configuration
+        :param DynamicResultsConfig dynamic_results: Dynamic results configuration
         :return: CpuGeneratorResult
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1229,7 +1229,7 @@ class CpuGeneratorApi(object):
 
         :param async_req bool
         :param str id: Unique resource identifier (required)
-        :param DynamicResults dynamic_results: Dynamic results configuration
+        :param DynamicResultsConfig dynamic_results: Dynamic results configuration
         :return: CpuGeneratorResult
                  If the method is called asynchronously,
                  returns the request thread.

--- a/tests/aat/api/v1/client/api/memory_generator_api.py
+++ b/tests/aat/api/v1/client/api/memory_generator_api.py
@@ -1206,7 +1206,7 @@ class MemoryGeneratorApi(object):
 
         :param async_req bool
         :param str id: Unique resource identifier (required)
-        :param DynamicResults dynamic_results: Dynamic results configuration
+        :param DynamicResultsConfig dynamic_results: Dynamic results configuration
         :return: MemoryGeneratorResult
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1229,7 +1229,7 @@ class MemoryGeneratorApi(object):
 
         :param async_req bool
         :param str id: Unique resource identifier (required)
-        :param DynamicResults dynamic_results: Dynamic results configuration
+        :param DynamicResultsConfig dynamic_results: Dynamic results configuration
         :return: MemoryGeneratorResult
                  If the method is called asynchronously,
                  returns the request thread.

--- a/tests/aat/api/v1/docs/BlockGeneratorApi.md
+++ b/tests/aat/api/v1/docs/BlockGeneratorApi.md
@@ -933,7 +933,7 @@ from pprint import pprint
 # create an instance of the API class
 api_instance = client.BlockGeneratorApi()
 id = 'id_example' # str | Unique resource identifier
-dynamic_results = client.DynamicResults() # DynamicResults | Dynamic results configuration (optional)
+dynamic_results = client.DynamicResultsConfig() # DynamicResultsConfig | Dynamic results configuration (optional)
 
 try:
     # Start a block generator
@@ -948,7 +948,7 @@ except ApiException as e:
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **id** | **str**| Unique resource identifier | 
- **dynamic_results** | [**DynamicResults**](DynamicResults.md)| Dynamic results configuration | [optional] 
+ **dynamic_results** | [**DynamicResultsConfig**](DynamicResultsConfig.md)| Dynamic results configuration | [optional] 
 
 ### Return type
 

--- a/tests/aat/api/v1/docs/CpuGeneratorApi.md
+++ b/tests/aat/api/v1/docs/CpuGeneratorApi.md
@@ -596,7 +596,7 @@ from pprint import pprint
 # create an instance of the API class
 api_instance = client.CpuGeneratorApi()
 id = 'id_example' # str | Unique resource identifier
-dynamic_results = client.DynamicResults() # DynamicResults | Dynamic results configuration (optional)
+dynamic_results = client.DynamicResultsConfig() # DynamicResultsConfig | Dynamic results configuration (optional)
 
 try:
     # Start a CPU generator
@@ -611,7 +611,7 @@ except ApiException as e:
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **id** | **str**| Unique resource identifier | 
- **dynamic_results** | [**DynamicResults**](DynamicResults.md)| Dynamic results configuration | [optional] 
+ **dynamic_results** | [**DynamicResultsConfig**](DynamicResultsConfig.md)| Dynamic results configuration | [optional] 
 
 ### Return type
 

--- a/tests/aat/api/v1/docs/MemoryGeneratorApi.md
+++ b/tests/aat/api/v1/docs/MemoryGeneratorApi.md
@@ -596,7 +596,7 @@ from pprint import pprint
 # create an instance of the API class
 api_instance = client.MemoryGeneratorApi()
 id = 'id_example' # str | Unique resource identifier
-dynamic_results = client.DynamicResults() # DynamicResults | Dynamic results configuration (optional)
+dynamic_results = client.DynamicResultsConfig() # DynamicResultsConfig | Dynamic results configuration (optional)
 
 try:
     # Start a memory generator
@@ -611,7 +611,7 @@ except ApiException as e:
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **id** | **str**| Unique resource identifier | 
- **dynamic_results** | [**DynamicResults**](DynamicResults.md)| Dynamic results configuration | [optional] 
+ **dynamic_results** | [**DynamicResultsConfig**](DynamicResultsConfig.md)| Dynamic results configuration | [optional] 
 
 ### Return type
 


### PR DESCRIPTION
Change datatype of the Dynamic Results weight from `uint32_t` to `uint64_t`.

Closes #400.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/420)
<!-- Reviewable:end -->
