### PR TITLE
modules/memory: improve async buffer initialization

### DIFF
--- a/src/modules/memory/task_memory.cpp
+++ b/src/modules/memory/task_memory.cpp
@@ -81,9 +81,10 @@ task_memory::task_memory(const task_memory_config& conf)
 
 void task_memory::config(const task_memory_config& msg)
 {
+    assert(msg.indexes.valid());
     assert(msg.pattern != io_pattern::NONE);
 
-    m_op_index = utils::random_uniform(msg.indexes->size());
+    m_op_index = utils::random_uniform(msg.indexes.get().size());
     m_config.pattern = msg.pattern;
 
     m_buffer = msg.buffer.lock();
@@ -117,8 +118,10 @@ void task_memory::reset()
 
 memory_stat task_memory::spin()
 {
+    auto indexes = m_config.indexes.get();
+
     /* If we have a rate to generate, then we need indexes */
-    assert(m_rate == 0 || m_config.indexes->size() > 0);
+    assert(m_rate == 0 || indexes.size() > 0);
 
     m_pid.start();
 

--- a/src/modules/memory/task_memory.hpp
+++ b/src/modules/memory/task_memory.hpp
@@ -1,8 +1,9 @@
 #ifndef _OP_MEMORY_TASK_MEMORY_HPP_
 #define _OP_MEMORY_TASK_MEMORY_HPP_
 
-#include <vector>
 #include <chrono>
+#include <future>
+#include <vector>
 
 #include "framework/generator/task.hpp"
 #include "framework/generator/pid_control.hpp"
@@ -14,13 +15,15 @@
 
 namespace openperf::memory::internal {
 
+using index_vector = std::vector<uint64_t>;
+
 struct task_memory_config
 {
     size_t block_size = 0;
     size_t op_per_sec = 0;
     io_pattern pattern = io_pattern::NONE;
     std::weak_ptr<buffer> buffer;
-    std::vector<uint64_t>* indexes = nullptr;
+    std::shared_future<index_vector> indexes;
 };
 
 class task_memory : public openperf::framework::generator::task<memory_stat>

--- a/src/modules/memory/task_memory_read.cpp
+++ b/src/modules/memory/task_memory_read.cpp
@@ -7,15 +7,18 @@ namespace openperf::memory::internal {
 
 void task_memory_read::operation(uint64_t nb_ops)
 {
-    assert(m_op_index < m_config.indexes->size());
-
+    auto indexes = m_config.indexes.get();
     auto* buffer_pointer = reinterpret_cast<uint8_t*>(m_buffer->data());
+
+    assert(m_op_index < indexes.size());
+    assert(buffer_pointer != nullptr);
+
     for (size_t i = 0; i < nb_ops; ++i) {
-        auto idx = m_config.indexes->at(m_op_index++);
+        auto idx = indexes.at(m_op_index++);
         std::memcpy(m_scratch.data(),
                     buffer_pointer + (idx * m_config.block_size),
                     m_config.block_size);
-        if (m_op_index == m_config.indexes->size()) { m_op_index = 0; }
+        if (m_op_index == indexes.size()) { m_op_index = 0; }
     }
 }
 

--- a/src/modules/memory/task_memory_write.cpp
+++ b/src/modules/memory/task_memory_write.cpp
@@ -7,15 +7,18 @@ namespace openperf::memory::internal {
 
 void task_memory_write::operation(uint64_t nb_ops)
 {
-    assert(m_op_index < m_config.indexes->size());
-
+    auto indexes = m_config.indexes.get();
     auto* buffer_pointer = reinterpret_cast<uint8_t*>(m_buffer->data());
+
+    assert(m_op_index < indexes.size());
+    assert(buffer_pointer != nullptr);
+
     for (size_t i = 0; i < nb_ops; ++i) {
-        auto idx = m_config.indexes->at(m_op_index++);
+        auto idx = indexes.at(m_op_index++);
         std::memcpy(buffer_pointer + (idx * m_config.block_size),
                     m_scratch.data(),
                     m_config.block_size);
-        if (m_op_index == m_config.indexes->size()) { m_op_index = 0; }
+        if (m_op_index == indexes.size()) { m_op_index = 0; }
     }
 }
 

--- a/tests/unit/modules/memory/test_memory_task.cpp
+++ b/tests/unit/modules/memory/test_memory_task.cpp
@@ -6,7 +6,7 @@
 #include "modules/memory/generator.hpp"
 
 namespace openperf::memory::internal {
-generator::index_vector generate_index_vector(size_t size, io_pattern pattern);
+index_vector generate_index_vector(size_t size, io_pattern pattern);
 } // namespace openperf::memory::internal
 
 TEST_CASE("Memory Generator Task", "[memory]")


### PR DESCRIPTION
Replaced `std::future` to `std::shared_future` for index vector initialization.
Removed excess preliminary allocating index vector, thus removed unnecessary memory allocation.
Removed copying one index vector to another index vector.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/430)
<!-- Reviewable:end -->
