### PR TITLE
modules/tvlp: delete scaling read/write size

### DIFF
--- a/doc/modules/tvlp.md
+++ b/doc/modules/tvlp.md
@@ -68,15 +68,11 @@ Start options:
 The load scale multiplier is a floating point value that will be applied to next load parameters of generators.
 
 Memory Generator:
-* **read_size**
 * **reads_per_sec**
-* **write_size**
 * **writes_per_sec**
 
 Block Generator:
-* **read_size**
 * **reads_per_sec**
-* **write_size**
 * **writes_per_sec**
 
 CPU Generator:
@@ -84,9 +80,7 @@ CPU Generator:
 * **cores[_N_].utilization**
 
 Network Generator:
-* **read_size**
 * **reads_per_sec**
-* **write_size**
 * **writes_per_sec**
 
 Packet Generator:

--- a/src/modules/tvlp/workers/block.cpp
+++ b/src/modules/tvlp/workers/block.cpp
@@ -27,12 +27,8 @@ block_tvlp_worker_t::send_create(const model::tvlp_profile_t::entry& entry,
     config->fromJson(const_cast<nlohmann::json&>(entry.config));
 
     // Apply Load Scale to generator configuration
-    config->setReadSize(
-        static_cast<uint32_t>(config->getReadSize() * load_scale));
     config->setReadsPerSec(
         static_cast<uint32_t>(config->getReadsPerSec() * load_scale));
-    config->setWriteSize(
-        static_cast<uint32_t>(config->getWriteSize() * load_scale));
     config->setWritesPerSec(
         static_cast<uint32_t>(config->getWritesPerSec() * load_scale));
 

--- a/src/modules/tvlp/workers/memory.cpp
+++ b/src/modules/tvlp/workers/memory.cpp
@@ -38,12 +38,8 @@ memory_tvlp_worker_t::send_create(const model::tvlp_profile_t::entry& entry,
     config.fromJson(const_cast<nlohmann::json&>(entry.config));
 
     // Apply Load Scale to generator configuration
-    config.setReadSize(
-        static_cast<uint32_t>(config.getReadSize() * load_scale));
     config.setReadsPerSec(
         static_cast<uint32_t>(config.getReadsPerSec() * load_scale));
-    config.setWriteSize(
-        static_cast<uint32_t>(config.getWriteSize() * load_scale));
     config.setWritesPerSec(
         static_cast<uint32_t>(config.getWritesPerSec() * load_scale));
 

--- a/src/modules/tvlp/workers/network.cpp
+++ b/src/modules/tvlp/workers/network.cpp
@@ -27,12 +27,8 @@ network_tvlp_worker_t::send_create(const model::tvlp_profile_t::entry& entry,
     config->fromJson(const_cast<nlohmann::json&>(entry.config));
 
     // Apply Load Scale to generator configuration
-    config->setReadSize(
-        static_cast<uint32_t>(config->getReadSize() * load_scale));
     config->setReadsPerSec(
         static_cast<uint32_t>(config->getReadsPerSec() * load_scale));
-    config->setWriteSize(
-        static_cast<uint32_t>(config->getWriteSize() * load_scale));
     config->setWritesPerSec(
         static_cast<uint32_t>(config->getWritesPerSec() * load_scale));
 


### PR DESCRIPTION
Delete scaling {read,write}_size configuration values
for Block, Memory and Network generators

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/445)
<!-- Reviewable:end -->
