### PR TITLE
modules/packetio: change pool allocation scheme

### DIFF
--- a/src/modules/packetio/memory/dpdk/mempool.hpp
+++ b/src/modules/packetio/memory/dpdk/mempool.hpp
@@ -8,6 +8,8 @@ struct rte_mempool;
 
 namespace openperf::packetio::dpdk::mempool {
 
+enum class mempool_type { none = 0, unique, shared };
+
 /*
  * The next two functions are intended for acquiring/releasing memory pools for
  * transmit purposes.
@@ -17,7 +19,8 @@ rte_mempool* acquire(uint16_t port_id,
                      unsigned numa_node,
                      uint16_t packet_length,
                      uint16_t packet_count,
-                     uint16_t cache_size);
+                     uint16_t cache_size,
+                     mempool_type pool_type);
 
 void release(const rte_mempool*);
 

--- a/src/modules/packetio/memory/dpdk/secondary/mempool.cpp
+++ b/src/modules/packetio/memory/dpdk/secondary/mempool.cpp
@@ -31,7 +31,8 @@ rte_mempool* acquire([[maybe_unused]] uint16_t port_id,
                      unsigned numa_node,
                      uint16_t packet_length,
                      uint16_t packet_count,
-                     [[maybe_unused]] uint16_t cache_size)
+                     [[maybe_unused]] uint16_t cache_size,
+                     [[maybe_unused]] mempool_type pool_type)
 {
     static rte_mempool* pool = get_mempool();
     if (!pool) { throw std::runtime_error("No memory pool available"); }


### PR DESCRIPTION
Update the memory pool allocation scheme to support two distinct types
of memory pools: shared and unique. Unique pools are used when we can be
confident that the source is going to overwrite the payload for each
transmitted packet. Unique pools are used when that doesn't happen.

This prevents the case where payload data from previously used packet
buffers appears in packets without any user generated payload.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/457)
<!-- Reviewable:end -->
