### PR TITLE
modules/packetio: fix off by 1 error

### DIFF
--- a/src/modules/packetio/memory/dpdk/primary/mempool.cpp
+++ b/src/modules/packetio/memory/dpdk/primary/mempool.cpp
@@ -208,12 +208,16 @@ static rte_mempool* acquire_shared(uint16_t port_id,
         std::begin(snapshot), std::end(snapshot), [&](auto& entry) {
             auto guard = mempool_entry_guard(entry);
 
+            /*
+             * Note: need to compare the adjusted pool size, as that is what
+             * is used when creating the pool.
+             */
             auto match =
                 (entry.pool != nullptr && port_id == entry.port_id
                  && queue_id == entry.queue_id
                  && numa_node == static_cast<unsigned>(entry.pool->socket_id)
                  && packet_length <= entry.pool->elt_size
-                 && packet_count <= entry.pool->size
+                 && pool_size_adjust(packet_count) <= entry.pool->size
                  && cache_size <= entry.pool->cache_size);
 
             if (match) {


### PR DESCRIPTION
Oops. DPDK packet pools are constrained to a Mersenne number in size. If
a client requests a power of two size, then the actual size might be 1
less instead of doubling the pool size. As a result, we need to use the
actual size of the resulting pool instead of the requested size when
looking for compatible memory pools to share.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/461)
<!-- Reviewable:end -->
