### PR TITLE
modules/socket: fix threaded client usage

### DIFF
--- a/src/modules/socket/client/channels_hashtab.hpp
+++ b/src/modules/socket/client/channels_hashtab.hpp
@@ -5,10 +5,10 @@
 
 #include "core/op_hashtab.h"
 #include "socket/client/io_channel_wrapper.hpp"
-#include "utils/singleton.hpp"
 
 namespace openperf::socket::api {
-class channels_hashtab : public utils::singleton<channels_hashtab>
+
+class channels_hashtab
 {
     using io_channel_wrapper = openperf::socket::client::io_channel_wrapper;
     struct ided_channel

--- a/targets/libopenperf-shim/openperf-shim.cpp
+++ b/targets/libopenperf-shim/openperf-shim.cpp
@@ -31,6 +31,12 @@ struct linux_sockaddr_ll
 
 static void openperf_shim_init() __attribute__((constructor));
 
+/*
+ * This flag is used to prevent libc calls from the client constructor
+ * from instantiating a new client instance. Intercepted socket
+ * calls MUST verify this variable is true before attempting to call
+ * functions in the client instance.
+ */
 static std::atomic_bool client_initialized = ATOMIC_VAR_INIT(false);
 
 static bool client_trace = false;


### PR DESCRIPTION
Since openperf clients may be threaded, the client code needs to handle
calls in a thread safe manner. This changelist fixes threaded client
usage in two ways:

1) Use a single global instance for the client hooks. Thread local
   instances can't actually construct themselves due to a catch 22
   situation with libc functions.

2) Add a lock (eww) to the RPC socket so that client theads can safely
   share it.

Additionally, change the channel hashtab to a client member instead of a
singleton. There's no reason for it to exist outside the client now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/463)
<!-- Reviewable:end -->
