### PR TITLE
packet/statistics: fix typo in template code

### DIFF
--- a/src/modules/packet/statistics/api_transmogrify.hpp
+++ b/src/modules/packet/statistics/api_transmogrify.hpp
@@ -49,7 +49,7 @@ void populate_counters(
 
         dst->setIp(p_dst);
     }
-    if (src.holds<ip>()) {
+    if (src.holds<transport>()) {
         const auto& p_src = src.get<transport>();
         auto p_dst = std::make_shared<
             swagger::v1::model::PacketTransportProtocolCounters>();


### PR DESCRIPTION
Oops.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/465)
<!-- Reviewable:end -->
