### PR TITLE
Makefile: generate a yaml api spec, not json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ api:
 	@mkdir -p build/api
 	$(strip deps/swagger-codegen/swagger-codegen generate \
 		-DoutputFile=openperf.yaml \
-		-l swagger \
+		-l swagger-yaml \
 		-i api/schema/v1/openperf.yaml \
 		-o build/api)
 


### PR DESCRIPTION
Oops. Output the combined schema as a YAML file instead of JSON.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/472)
<!-- Reviewable:end -->
