### PR TITLE
framework: op_event_loop ignore epoll_wait() EINTR

### DIFF
--- a/src/framework/core/op_event_loop_epoll.c
+++ b/src/framework/core/op_event_loop_epoll.c
@@ -664,9 +664,11 @@ int op_event_loop_run_timeout(struct op_event_loop* loop, int timeout)
                 _do_event_handling(loop, events, nb_events);
                 _do_event_removals(loop);
             } else if (nb_events < 0) {
-                /* epoll error */
-                op_event_loop_exit(loop);
-                return (-errno);
+                if (errno != EINTR) {
+                    /* epoll error */
+                    op_event_loop_exit(loop);
+                    return (-errno);
+                }
             } else if (SLIST_EMPTY(&loop->always_list)) {
                 /* no ready epoll events and empty always list; must be a
                  * timeout */


### PR DESCRIPTION
This was causing all threads using op_event_loop to exit
when breaking and continuing with gdb.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/475)
<!-- Reviewable:end -->
