### PR TITLE
Minor API changes to fix issue with Golang Client

### DIFF
--- a/api/schema/v1/modules/block.yaml
+++ b/api/schema/v1/modules/block.yaml
@@ -8,7 +8,7 @@ parameters:
     required: true
 
   dynamic_results:
-    $ref: "./dynamic.yaml#/parameters/dynamic_results"
+    $ref: "../openperf.yaml#/parameters/dynamic_results"
 
 paths:
   /block-devices:

--- a/api/schema/v1/modules/cpu.yaml
+++ b/api/schema/v1/modules/cpu.yaml
@@ -8,7 +8,7 @@ parameters:
     required: true
 
   dynamic_results:
-    $ref: "./dynamic.yaml#/parameters/dynamic_results"
+    $ref: "../openperf.yaml#/parameters/dynamic_results"
 
 paths:
   /cpu-generators:

--- a/api/schema/v1/modules/dynamic.yaml
+++ b/api/schema/v1/modules/dynamic.yaml
@@ -1,12 +1,3 @@
-parameters:
-  dynamic_results:
-    name: dynamic_results
-    in: body
-    description: Dynamic results configuration
-    required: false
-    schema:
-      $ref: "#/definitions/DynamicResultsConfig"
-
 definitions:
   DynamicResultsConfig:
     type: object

--- a/api/schema/v1/modules/memory.yaml
+++ b/api/schema/v1/modules/memory.yaml
@@ -8,7 +8,7 @@ parameters:
     required: true
 
   dynamic_results:
-    $ref: "./dynamic.yaml#/parameters/dynamic_results"
+    $ref: "../openperf.yaml#/parameters/dynamic_results"
 
 paths:
   /memory-generators:

--- a/api/schema/v1/modules/network.yaml
+++ b/api/schema/v1/modules/network.yaml
@@ -8,7 +8,7 @@ parameters:
     required: true
 
   dynamic_results:
-    $ref: "./dynamic.yaml#/parameters/dynamic_results"
+    $ref: "../openperf.yaml#/parameters/dynamic_results"
 
 paths:
   /network/servers:
@@ -372,7 +372,7 @@ paths:
         will be in the stopped state and all active TCP/UDP sessions will be transferred
         to the newly running generator.
         If the original network generator had a read/write load and the new network generator
-        does not have this type of load, these sessions will be immediately stopped. 
+        does not have this type of load, these sessions will be immediately stopped.
       parameters:
         - name: toggle
           in: body

--- a/api/schema/v1/openperf.yaml
+++ b/api/schema/v1/openperf.yaml
@@ -35,7 +35,12 @@ parameters:
     required: true
 
   dynamic_results:
-    $ref: ./modules/dynamic.yaml#/parameters/dynamic_results
+    name: dynamic_results
+    in: body
+    description: Dynamic results configuration
+    required: false
+    schema:
+      $ref: "#/definitions/DynamicResultsConfig"
 
 tags:
   - name: Interfaces
@@ -626,6 +631,15 @@ definitions:
 
   RxFlow:
     $ref: ./modules/packet/analyzer.yaml#/definitions/RxFlow
+
+  ###
+  # Packet Capture definitions
+  ###
+  PacketCapture:
+    $ref: ./modules/packet/capture.yaml#/definitions/PacketCapture
+
+  PacketCaptureResult:
+    $ref: ./modules/packet/capture.yaml#/definitions/PacketCaptureResult
 
   ###
   # Packet Generator definitions

--- a/tests/aat/api/v1/client/api/network_generator_api.py
+++ b/tests/aat/api/v1/client/api/network_generator_api.py
@@ -1895,7 +1895,7 @@ class NetworkGeneratorApi(object):
     def toggle_network_generators(self, toggle, **kwargs):  # noqa: E501
         """Replace a running network generator with a stopped network generator  # noqa: E501
 
-        Swap a running network generator with an idle network generator. Upon success, the idle generator will be in the run state, the running generator will be in the stopped state and all active TCP/UDP sessions will be transferred to the newly running generator. If the original network generator had a read/write load and the new network generator does not have this type of load, these sessions will be immediately stopped.    # noqa: E501
+        Swap a running network generator with an idle network generator. Upon success, the idle generator will be in the run state, the running generator will be in the stopped state and all active TCP/UDP sessions will be transferred to the newly running generator. If the original network generator had a read/write load and the new network generator does not have this type of load, these sessions will be immediately stopped.   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
         >>> thread = api.toggle_network_generators(toggle, async_req=True)
@@ -1917,7 +1917,7 @@ class NetworkGeneratorApi(object):
     def toggle_network_generators_with_http_info(self, toggle, **kwargs):  # noqa: E501
         """Replace a running network generator with a stopped network generator  # noqa: E501
 
-        Swap a running network generator with an idle network generator. Upon success, the idle generator will be in the run state, the running generator will be in the stopped state and all active TCP/UDP sessions will be transferred to the newly running generator. If the original network generator had a read/write load and the new network generator does not have this type of load, these sessions will be immediately stopped.    # noqa: E501
+        Swap a running network generator with an idle network generator. Upon success, the idle generator will be in the run state, the running generator will be in the stopped state and all active TCP/UDP sessions will be transferred to the newly running generator. If the original network generator had a read/write load and the new network generator does not have this type of load, these sessions will be immediately stopped.   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
         >>> thread = api.toggle_network_generators_with_http_info(toggle, async_req=True)

--- a/tests/aat/api/v1/docs/NetworkGeneratorApi.md
+++ b/tests/aat/api/v1/docs/NetworkGeneratorApi.md
@@ -924,7 +924,7 @@ No authorization required
 
 Replace a running network generator with a stopped network generator
 
-Swap a running network generator with an idle network generator. Upon success, the idle generator will be in the run state, the running generator will be in the stopped state and all active TCP/UDP sessions will be transferred to the newly running generator. If the original network generator had a read/write load and the new network generator does not have this type of load, these sessions will be immediately stopped.  
+Swap a running network generator with an idle network generator. Upon success, the idle generator will be in the run state, the running generator will be in the stopped state and all active TCP/UDP sessions will be transferred to the newly running generator. If the original network generator had a read/write load and the new network generator does not have this type of load, these sessions will be immediately stopped. 
 
 ### Example
 ```python


### PR DESCRIPTION
Golang client generator chokes with how dynamic field
was defined in a subfile then referenced by the top-level
openperf.yaml schema file.

Note: Golang client generated by go-swagger because swagger-codegen
generates broken Golang code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/478)
<!-- Reviewable:end -->
