### PR TITLE
packet/analyzer: fix frame counter addition

### DIFF
--- a/src/modules/packet/analyzer/statistics/flow/counters.hpp
+++ b/src/modules/packet/analyzer/statistics/flow/counters.hpp
@@ -49,7 +49,7 @@ struct frame_counter : timestamp_clock<clock_t>
     {
         count += rhs.count;
         first_ = std::min(first_, rhs.first_);
-        last_ = std::max(first_, rhs.last_);
+        last_ = std::max(last_, rhs.last_);
         errors.fcs += rhs.errors.fcs;
         errors.ipv4_checksum += rhs.errors.ipv4_checksum;
         errors.tcp_checksum += rhs.errors.tcp_checksum;


### PR DESCRIPTION
The frame counter struct incorrectly summed the last timestamp value.
Fix it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/479)
<!-- Reviewable:end -->
