### PR TITLE
circleci: limit memory consumption while building

### DIFF
--- a/.circleci/run_build.sh
+++ b/.circleci/run_build.sh
@@ -1,9 +1,11 @@
 set -xe
 
-# The container apparently sees the correct amount of memory, but not
-# not the correct number of cores.  If we use more than ~6 cores, we
-# seem to hit the memory limit and our build commands can get killed.
-CI_CORES=$(if [ $(nproc) -gt 6 ]; then echo 6; else echo $(nproc); fi)
+# If we build too many files in parallel, we'll hit the CircleCI
+# container's memory limit. Hence, we artificially limit the number
+# of parallel builds here.
+MAX_CORES=12
+
+CI_CORES=$(if [ $(nproc) -gt ${MAX_CORES} ]; then echo ${MAX_CORES}; else echo $(nproc); fi)
 
 # Force optimizations to target avx2; all of the CircleCI machines seem
 # to support it and we don't want to get illegal instruction errors when

--- a/src/modules/packet/generator/directory.mk
+++ b/src/modules/packet/generator/directory.mk
@@ -46,6 +46,19 @@ $(PG_OBJ_DIR)/init.o: OP_CPPFLAGS += \
 	-DBUILD_NUMBER="\"$(BUILD_NUMBER)\"" \
 	-DBUILD_TIMESTAMP="\"$(TIMESTAMP)\""
 
+#
+# XXX: Serialize building expand files as the template expansion
+# takes lots of memory that our CircleCI instance doesn't have.
+#
+PG_EXPAND_OBJ_DIR = $(PG_OBJ_DIR)/traffic/header/expand_impl
+$(PG_EXPAND_OBJ_DIR)/ethernet.o: $(PG_EXPAND_OBJ_DIR)/custom.o
+$(PG_EXPAND_OBJ_DIR)/mpls.o: $(PG_EXPAND_OBJ_DIR)/ethernet.o
+$(PG_EXPAND_OBJ_DIR)/vlan.o: $(PG_EXPAND_OBJ_DIR)/mpls.o
+$(PG_EXPAND_OBJ_DIR)/ipv4.o: $(PG_EXPAND_OBJ_DIR)/vlan.o
+$(PG_EXPAND_OBJ_DIR)/ipv6.o: $(PG_EXPAND_OBJ_DIR)/ipv4.o
+$(PG_EXPAND_OBJ_DIR)/tcp.o: $(PG_EXPAND_OBJ_DIR)/ipv6.o
+$(PG_EXPAND_OBJ_DIR)/udp.o: $(PG_EXPAND_OBJ_DIR)/udp.o
+
 PG_TEST_DEPENDS += expected framework json range_v3 packet_protocol
 
 PG_TEST_SOURCES += \


### PR DESCRIPTION
The CircleCI build machines will kill processes if the build exceeds the
container's memory limit. Artificially limit our memory usage by

1) Force packet generator template heavy expansion files to build
   sequentially.
2) Use a hard cap on the number of cores used by the CirceCI build

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/481)
<!-- Reviewable:end -->
