### PR TITLE
modules/packet: fix serialization dependency

### DIFF
--- a/src/modules/packet/generator/directory.mk
+++ b/src/modules/packet/generator/directory.mk
@@ -57,7 +57,7 @@ $(PG_EXPAND_OBJ_DIR)/vlan.o: $(PG_EXPAND_OBJ_DIR)/mpls.o
 $(PG_EXPAND_OBJ_DIR)/ipv4.o: $(PG_EXPAND_OBJ_DIR)/vlan.o
 $(PG_EXPAND_OBJ_DIR)/ipv6.o: $(PG_EXPAND_OBJ_DIR)/ipv4.o
 $(PG_EXPAND_OBJ_DIR)/tcp.o: $(PG_EXPAND_OBJ_DIR)/ipv6.o
-$(PG_EXPAND_OBJ_DIR)/udp.o: $(PG_EXPAND_OBJ_DIR)/udp.o
+$(PG_EXPAND_OBJ_DIR)/udp.o: $(PG_EXPAND_OBJ_DIR)/tcp.o
 
 PG_TEST_DEPENDS += expected framework json range_v3 packet_protocol
 


### PR DESCRIPTION
Oops!  A file can't depend on itself.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/482)
<!-- Reviewable:end -->
