### PR TITLE
Update the dockerfile for ARM64 cross compiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,9 @@ ENV LLVM_VERSION 7
 RUN apt-get clean && \
     apt-get update && \
     apt-get install -y --no-install-recommends autoconf automake \
-    bison build-essential ca-certificates debhelper devscripts flex \
-    git libcap-dev libcap2-bin libibverbs-dev libnuma-dev libtool lintian netcat-openbsd \
+    bison build-essential ca-certificates crossbuild-essential-arm64 \
+    debhelper devscripts flex git libcap-dev libcap2-bin libibverbs-dev \
+    libnuma-dev libtool lintian netcat-openbsd \
     pkg-config python sudo virtualenv wget \
     clang-${LLVM_VERSION} clang-format-${LLVM_VERSION} \
     clang-tidy-${LLVM_VERSION} \
@@ -21,7 +22,7 @@ RUN apt-get clean && \
     lld-${LLVM_VERSION} bear
 
 # Install Intel SPMD Program Compiler (ISPC)
-ENV ISPC_VERSION 1.13.0
+ENV ISPC_VERSION 1.15.0
 RUN wget -q -O - https://github.com/ispc/ispc/releases/download/v${ISPC_VERSION}/ispc-v${ISPC_VERSION}-linux.tar.gz \
     | tar -C /opt -xvz && \
     chown -R root:root /opt/ispc-v${ISPC_VERSION}-linux/bin/ispc && \
@@ -33,6 +34,7 @@ RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${LLVM_VER
     update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-${LLVM_VERSION} ${LLVM_VERSION} && \
     update-alternatives --install /usr/bin/run-clang-tidy run-clang-tidy /usr/bin/run-clang-tidy-${LLVM_VERSION} ${LLVM_VERSION} && \
     update-alternatives --install /usr/bin/llvm-ar llvm-ar /usr/bin/llvm-ar-${LLVM_VERSION} ${LLVM_VERSION} && \
+    update-alternatives --install /usr/bin/llvm-objcopy llvm-objcopy /usr/bin/llvm-objcopy-${LLVM_VERSION} ${LLVM_VERSION} && \
     update-alternatives --install /usr/bin/lld lld /usr/bin/lld-${LLVM_VERSION} ${LLVM_VERSION}
 
 # Install other Circle CI dependencies


### PR DESCRIPTION
* Add ARM64 cross compile tools
* Update ISPC to version 1.15
* Create llvm-objcopy alternative

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/483)
<!-- Reviewable:end -->
