### PR TITLE
lib/spirent_pga: optimize CRC calculation

### DIFF
--- a/src/lib/spirent_pga/common/crc.h
+++ b/src/lib/spirent_pga/common/crc.h
@@ -8,28 +8,12 @@
 /* Use the pclmulqdq instruction to crunch CRC values */
 #include "x86_64/crc.h"
 
-inline uint16_t calculate_crc16(const uint8_t data[], uint16_t length)
-{
-    static constexpr DECLARE_ALIGNED(
-        struct crc_pclmulqdq_ctx spirent_crc16_clmul, 16) = {
-        0x45630000, /**< remainder X^128 / P(X) */
-        0xd5f60000, /**< remainder X^192 / P(X) */
-        0xaa510000, /**< remainder  X^64 / P(X) */
-        0x11303471, /**< quotient   X^64 / P(X) */
-        0x10210000, /**< polynomial */
-        0ULL        /**< reserved */
-    };
-
-    return (~(crc32_calc_pclmulqdq(data, length, 0xffff, &spirent_crc16_clmul)
-              >> 16));
-}
-
 #else
 
 #include <algorithm>
 
 /* Just use a lookup table */
-inline uint16_t calculate_crc16(const uint8_t data[], uint16_t length)
+inline uint16_t calculate_signature_crc16(const uint8_t data[])
 {
     static constexpr uint16_t ccitt16[256] = {
         0x0000, 0x1021, 0x2042, 0x3063, 0x4084, 0x50A5, 0x60C6, 0x70E7, 0x8108,
@@ -63,7 +47,7 @@ inline uint16_t calculate_crc16(const uint8_t data[], uint16_t length)
         0x2E93, 0x3EB2, 0x0ED1, 0x1EF0};
 
     uint16_t crc16 = 0xffff;
-    std::for_each(data, data + length, [&](auto&& x) {
+    std::for_each(data, data + 16, [&](auto&& x) {
         crc16 = ccitt16[((crc16 >> 8) ^ x) & 0xff] ^ (crc16 << 8);
     });
 

--- a/src/lib/spirent_pga/common/x86_64/crc.h
+++ b/src/lib/spirent_pga/common/x86_64/crc.h
@@ -46,32 +46,50 @@
 #include <cstdint>
 #include <utility>
 
-template<class T, size_t... N>
-constexpr T bswap_impl(T i, std::index_sequence<N...>) {
-    return (((i >> N * CHAR_BIT & uint8_t(-1)) << (sizeof(T) - 1 - N) * CHAR_BIT) | ...);
-}
-
-template<class T, class U = std::make_unsigned_t<T>>
-constexpr U bswap(T i) {
-  return bswap_impl<U>(i, std::make_index_sequence<sizeof(T)>{});
-}
-
 /* Declare variable at address aligned to a boundary */
-#define DECLARE_ALIGNED(_declaration, _boundary)         \
-        _declaration __attribute__((aligned(_boundary)))
+#define DECLARE_ALIGNED(_declaration, _boundary)                               \
+    _declaration __attribute__((aligned(_boundary)))
 
 /* Likely & unliekly hints for the compiler */
-#define likely(x)   __builtin_expect(!!(x), 1)
+#define likely(x) __builtin_expect(!!(x), 1)
 #define unlikely(x) __builtin_expect(!!(x), 0)
 
 static constexpr DECLARE_ALIGNED(uint8_t crc_xmm_shift_tab[48], 16) = {
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
-    0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+    0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+
+/**
+ * PCLMULQDQ CRC computation context structure
+ */
+struct crc_pclmulqdq_ctx
+{
+    /**
+     * K1 = reminder X^128 / P(X) : 0-63
+     * K2 = reminder X^192 / P(X) : 64-127
+     */
+    uint64_t k1;
+    uint64_t k2;
+
+    /**
+     * K3 = reminder X^64 / P(X) : 0-63
+     * q  = quotient X^64 / P(X) : 64-127
+     */
+    uint64_t k3;
+    uint64_t q;
+
+    /**
+     * p   = polynomial / P(X) : 0-63
+     * res = reserved : 64-127
+     */
+    uint64_t p;
+    uint64_t res;
 };
+
+/**
+ * Functions and prototypes
+ */
 
 /**
  * @brief Shifts right 128 bit register by specified number of bytes
@@ -81,11 +99,11 @@ static constexpr DECLARE_ALIGNED(uint8_t crc_xmm_shift_tab[48], 16) = {
  *
  * @return \a reg >> (\a num * 8)
  */
-__m128i xmm_shift_right(__m128i reg, const unsigned int num)
+inline __m128i xmm_shift_right(__m128i reg, const unsigned int num)
 {
-        const __m128i *p = (const __m128i *)(crc_xmm_shift_tab + 16 + num);
+    const __m128i* p = (const __m128i*)(crc_xmm_shift_tab + 16 + num);
 
-        return _mm_shuffle_epi8(reg, _mm_loadu_si128(p));
+    return _mm_shuffle_epi8(reg, _mm_loadu_si128(p));
 }
 
 /**
@@ -96,43 +114,12 @@ __m128i xmm_shift_right(__m128i reg, const unsigned int num)
  *
  * @return \a reg << (\a num * 8)
  */
-__m128i xmm_shift_left(__m128i reg, const unsigned int num)
+inline __m128i xmm_shift_left(__m128i reg, const unsigned int num)
 {
-        const __m128i *p = (const __m128i *)(crc_xmm_shift_tab + 16 - num);
+    const __m128i* p = (const __m128i*)(crc_xmm_shift_tab + 16 - num);
 
-        return _mm_shuffle_epi8(reg, _mm_loadu_si128(p));
+    return _mm_shuffle_epi8(reg, _mm_loadu_si128(p));
 }
-
-/**
- * PCLMULQDQ CRC computation context structure
- */
-struct crc_pclmulqdq_ctx {
-        /**
-         * K1 = reminder X^128 / P(X) : 0-63
-         * K2 = reminder X^192 / P(X) : 64-127
-         */
-        uint64_t k1;
-        uint64_t k2;
-
-        /**
-         * K3 = reminder X^64 / P(X) : 0-63
-         * q  = quotient X^64 / P(X) : 64-127
-         */
-        uint64_t k3;
-        uint64_t q;
-
-        /**
-         * p   = polynomial / P(X) : 0-63
-         * res = reserved : 64-127
-         */
-        uint64_t p;
-        uint64_t res;
-};
-
-/**
- * Functions and prototypes
- */
-
 
 /**
  * @brief Performs one folding round
@@ -151,14 +138,14 @@ struct crc_pclmulqdq_ctx {
  *
  * @return New 16 byte folded data
  */
-__m128i crc32_folding_round(const __m128i data_block,
-                            const __m128i k1_k2,
-                            const __m128i fold)
+inline __m128i crc32_folding_round(const __m128i data_block,
+                                   const __m128i k1_k2,
+                                   const __m128i fold)
 {
-        __m128i tmp = _mm_clmulepi64_si128(fold, k1_k2, 0x11);
+    __m128i tmp = _mm_clmulepi64_si128(fold, k1_k2, 0x11);
 
-        return _mm_xor_si128(_mm_clmulepi64_si128(fold, k1_k2, 0x00),
-                             _mm_xor_si128(data_block, tmp));
+    return _mm_xor_si128(_mm_clmulepi64_si128(fold, k1_k2, 0x00),
+                         _mm_xor_si128(data_block, tmp));
 }
 
 /**
@@ -169,17 +156,17 @@ __m128i crc32_folding_round(const __m128i data_block,
  *
  * @return data reduced to 64 bits
  */
-__m128i crc32_reduce_128_to_64(__m128i data128, const __m128i k3_q)
+inline __m128i crc32_reduce_128_to_64(__m128i data128, const __m128i k3_q)
 {
-        __m128i tmp;
+    __m128i tmp;
 
-        tmp = _mm_xor_si128(_mm_clmulepi64_si128(data128, k3_q, 0x01 /* k3 */),
-                            data128);
+    tmp = _mm_xor_si128(_mm_clmulepi64_si128(data128, k3_q, 0x01 /* k3 */),
+                        data128);
 
-        data128 = _mm_xor_si128(_mm_clmulepi64_si128(tmp, k3_q, 0x01 /* k3 */),
-                                data128);
+    data128 =
+        _mm_xor_si128(_mm_clmulepi64_si128(tmp, k3_q, 0x01 /* k3 */), data128);
 
-        return _mm_srli_si128(_mm_slli_si128(data128, 8), 8);
+    return _mm_srli_si128(_mm_slli_si128(data128, 8), 8);
 }
 
 /**
@@ -191,182 +178,102 @@ __m128i crc32_reduce_128_to_64(__m128i data128, const __m128i k3_q)
  *
  * @return data reduced to 32 bits
  */
-uint32_t
+inline uint32_t
 crc32_reduce_64_to_32(__m128i fold, const __m128i k3_q, const __m128i p_res)
 {
-        __m128i temp;
+    __m128i temp;
 
-        temp = _mm_clmulepi64_si128(_mm_srli_si128(fold, 4),
-                                    k3_q, 0x10 /* Q */);
-        temp = _mm_srli_si128(_mm_xor_si128(temp, fold), 4);
-        temp = _mm_clmulepi64_si128(temp, p_res, 0 /* P */);
-        return _mm_extract_epi32(_mm_xor_si128(temp, fold), 0);
+    temp = _mm_clmulepi64_si128(_mm_srli_si128(fold, 4), k3_q, 0x10 /* Q */);
+    temp = _mm_srli_si128(_mm_xor_si128(temp, fold), 4);
+    temp = _mm_clmulepi64_si128(temp, p_res, 0 /* P */);
+    return _mm_extract_epi32(_mm_xor_si128(temp, fold), 0);
 }
 
 /**
- * @brief Calculates 32 bit CRC for given \a data block by applying folding and
- *        reduction methods.
+ * @brief Calculate CRC16 for a 16 byte chunk of data, e.g. the signature
  *
  * Algorithm operates on 32 bit CRCs so polynomials and initial values may
  * need to be promoted to 32 bits where required.
  *
- * @param crc initial CRC value (32 bit value)
  * @param data pointer to data block
- * @param data_len length of \a data block in bytes
- * @param params pointer to PCLMULQDQ CRC calculation context
  *
- * @return CRC for given \a data block (32 bits wide).
+ * @return CRC for given block
  */
-uint32_t
-crc32_calc_pclmulqdq(const uint8_t *data,
-                     uint32_t data_len, uint32_t crc,
-                     const struct crc_pclmulqdq_ctx *params)
+inline uint32_t calculate_signature_crc16(const uint8_t data[])
 {
-        __m128i temp, fold, k, swap;
-        uint32_t n;
+    /* Spirent CRC16 constants */
+    static constexpr DECLARE_ALIGNED(
+        struct crc_pclmulqdq_ctx spirent_crc16_clmul, 16) = {
+        0x45630000, /**< remainder X^128 / P(X) */
+        0xd5f60000, /**< remainder X^192 / P(X) */
+        0xaa510000, /**< remainder  X^64 / P(X) */
+        0x11303471, /**< quotient   X^64 / P(X) */
+        0x10210000, /**< polynomial */
+        0ULL        /**< reserved */
+    };
 
-        if (unlikely(data == NULL || data_len == 0 || params == NULL))
-                return crc;
+    /**
+     * Load first 16 data bytes in \a fold and
+     * set \a swap BE<->LE 16 byte conversion variable
+     */
+    __m128i fold = _mm_loadu_si128((__m128i*)data);
+    __m128i swap =
+        _mm_setr_epi32(0x0c0d0e0f, 0x08090a0b, 0x04050607, 0x00010203);
 
-        /**
-         * Add 4 bytes to data block size
-         * This is to secure the following:
-         *     CRC32 = M(X)^32 mod P(X)
-         * M(X) - message to compute CRC on
-         * P(X) - CRC polynomial
-         */
-        data_len += 4;
+    /**
+     * n = number of bytes required to align \a data_len
+     *     to multiple of 16. We need 4 extra bytes of 0's
+     *     to properly calculate the CRC, so this is based
+     *     on a length of 20, not 16.
+     */
+    uint32_t n = 12;
 
-        /**
-         * Load first 16 data bytes in \a fold and
-         * set \a swap BE<->LE 16 byte conversion variable
-         */
-        fold = _mm_loadu_si128((__m128i *)data);
-        swap = _mm_setr_epi32(0x0c0d0e0f, 0x08090a0b,
-                              0x04050607, 0x00010203);
+    /**
+     * Apply CRC initial value and
+     * get \a fold to BE format
+     */
+    fold =
+        _mm_xor_si128(fold, _mm_insert_epi32(_mm_setzero_si128(), 0xffff, 0));
+    fold = _mm_shuffle_epi8(fold, swap);
 
-        /**
-         * -------------------------------------------------
-         * Folding all data into single 16 byte data block
-         * Assumes: \a fold holds first 16 bytes of data
-         */
+    /**
+     * We don't have any more data to load, so just fold in 0's
+     */
+    __m128i next_data = {0, 0};
+    next_data = _mm_or_si128(xmm_shift_right(next_data, n),
+                             xmm_shift_left(fold, 16 - n));
+    fold = xmm_shift_right(fold, n);
 
-        if (unlikely(data_len <= 16)) {
-                /**
-                 * Data block fits into 16 byte block
-                 * - adjust data block
-                 * - 4 least significant bytes need to be zero
-                 */
-                fold = _mm_shuffle_epi8(fold, swap);
-                fold = _mm_slli_si128(xmm_shift_right(fold, 20 - data_len), 4);
+    /**
+     * Clear the 4 least significant bytes
+     */
+    next_data = _mm_slli_si128(_mm_srli_si128(next_data, 4), 4);
 
-                /**
-                 * Apply CRC init value
-                 */
-                temp = _mm_insert_epi32(_mm_setzero_si128(), bswap(crc), 0);
-                temp = xmm_shift_left(temp, data_len - 4);
-                fold = _mm_xor_si128(fold, temp);
-        } else {
-                /**
-                 * There are 2x16 data blocks or more
-                 */
-                __m128i next_data;
+    /**
+     * Fold our 2 x 16 byte chunks
+     */
+    __m128i k = _mm_load_si128((__m128i*)(&spirent_crc16_clmul.k1));
+    fold = crc32_folding_round(next_data, k, fold);
 
-                /**
-                 * n = number of bytes required to align \a data_len
-                 *     to multiple of 16
-                 */
-                n = ((~data_len) + 1) & 15;
+    /**
+     * -------------------------------------------------
+     * Reduction 128 -> 32
+     * Assumes: \a fold holds 128bit folded data
+     */
 
-                /**
-                 * Apply CRC initial value and
-                 * get \a fold to BE format
-                 */
-                fold = _mm_xor_si128(fold,
-                                     _mm_insert_epi32(_mm_setzero_si128(),
-                                                      crc, 0));
-                fold = _mm_shuffle_epi8(fold, swap);
+    /**
+     * REDUCTION 128 -> 64
+     */
+    k = _mm_load_si128((__m128i*)(&spirent_crc16_clmul.k3));
+    fold = crc32_reduce_128_to_64(fold, k);
 
-                /**
-                 * Load next 16 bytes of data and
-                 * adjust \a fold & \a next_data as follows:
-                 *
-                 * CONCAT(fold,next_data) >> (n*8)
-                 */
-                next_data = _mm_loadu_si128((__m128i *)&data[16]);
-                next_data = _mm_shuffle_epi8(next_data, swap);
-                next_data = _mm_or_si128(xmm_shift_right(next_data, n),
-                                         xmm_shift_left(fold, 16 - n));
-                fold = xmm_shift_right(fold, n);
+    /**
+     * REDUCTION 64 -> 32
+     */
+    n = crc32_reduce_64_to_32(
+        fold, k, _mm_load_si128((__m128i*)(&spirent_crc16_clmul.p)));
 
-                if (unlikely(data_len <= 32))
-                        /**
-                         * In such unlikely case clear 4 least significant bytes
-                         */
-                        next_data =
-                                _mm_slli_si128(_mm_srli_si128(next_data, 4), 4);
-
-                /**
-                 * Do the initial folding round on 2 first 16 byte chunks
-                 */
-                k = _mm_load_si128((__m128i *)(&params->k1));
-                fold = crc32_folding_round(next_data, k, fold);
-
-                if (likely(data_len > 32)) {
-                        /**
-                         * \a data_block needs to be at least 48 bytes long
-                         * in order to get here
-                         */
-                        __m128i new_data;
-
-                        /**
-                         * Main folding loop
-                         * - n is adjusted to point to next 16 data block
-                         *   to read
-                         *   (16+16) = 2x16; represents 2 first data blocks
-                         *                   processed above
-                         *   (- n) is the number of zero bytes padded to
-                         *   the message in order to align it to 16 bytes
-                         * - the last 16 bytes is processed separately
-                         */
-                        for (n = 16 + 16 - n; n < (data_len - 16); n += 16) {
-                                new_data = _mm_loadu_si128((__m128i *)&data[n]);
-                                new_data = _mm_shuffle_epi8(new_data, swap);
-                                fold = crc32_folding_round(new_data, k, fold);
-                        }
-
-                        /**
-                         * The last folding round works always on 12 bytes
-                         * (12 bytes of data and 4 zero bytes)
-                         * Read from offset -4 is to avoid one
-                         * shift right operation.
-                         */
-                        new_data = _mm_loadu_si128((__m128i *)&data[n - 4]);
-                        new_data = _mm_shuffle_epi8(new_data, swap);
-                        new_data = _mm_slli_si128(new_data, 4);
-                        fold = crc32_folding_round(new_data, k, fold);
-                } /* if (data_len > 32) */
-        }
-
-        /**
-         * -------------------------------------------------
-         * Reduction 128 -> 32
-         * Assumes: \a fold holds 128bit folded data
-         */
-
-        /**
-         * REDUCTION 128 -> 64
-         */
-        k = _mm_load_si128((__m128i *)(&params->k3));
-        fold = crc32_reduce_128_to_64(fold, k);
-
-        /**
-         * REDUCTION 64 -> 32
-         */
-        n = crc32_reduce_64_to_32(fold, k,
-                                  _mm_load_si128((__m128i *)(&params->p)));
-
-        return n;
+    return (~n >> 16);
 }
 
 #endif /* __CRC_H__ */


### PR DESCRIPTION
Our CRC calculation is always over the same data size. Hence, update the
calculation functions to only support that one data size and remove any
unnecessary loads and branches. This makes a small, but observable
performance improvement.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/490)
<!-- Reviewable:end -->
