### PR TITLE
api: fix int definitions for timesync module

### DIFF
--- a/api/schema/v1/modules/timesync.yaml
+++ b/api/schema/v1/modules/timesync.yaml
@@ -150,18 +150,18 @@ definitions:
     description: TimeKeeper internal state information
     properties:
       frequency:
-        type: number
+        type: integer
         description: |
           The time counter frequency as measured by the interval between the
           two best timestamp exchanges with the time source over the past two
           hours, in Hz.
         format: int64
       frequency_error:
-        type: number
+        type: integer
         description: The estimated error of the time counter frequency measurement, in Hz.
         format: int64
       local_frequency:
-        type: number
+        type: integer
         description: |
           The time counter frequency as measured by the interval between the
           two best timestamp exchanges with the time source over the past hour,
@@ -169,7 +169,7 @@ definitions:
           time counter frequency drift.
         format: int64
       local_frequency_error:
-        type: number
+        type: integer
         description: The estimated error of the local time counter frequency measurement, in Hz.
         format: int64
       offset:
@@ -198,21 +198,21 @@ definitions:
     description: TimeKeeper statistics
     properties:
       frequency_accept:
-        type: number
+        type: integer
         description: The number of times the frequency calculation has been updated.
         format: int64
       frequency_reject:
-        type: number
+        type: integer
         description: |
           The number of times the frequency calculation has been rejected due
           to an excessive delta between old and new values.
         format: int64
       local_frequency_accept:
-        type: number
+        type: integer
         description: The number of times the local frequency calculation has been updated.
         format: int64
       local_frequency_reject:
-        type: number
+        type: integer
         description: |
           The number of times the local frequency calculation has been rejected
           due to an excessive delta between old and new values.
@@ -238,23 +238,23 @@ definitions:
             description: The minimum round trip time, in seconds.
             format: double
           size:
-            type: number
+            type: integer
             description: The number of round trip times in the data set.
             format: int64
         required:
           - size
       theta_accept:
-        type: number
+        type: integer
         description: The number of times the theta calculation has been updated.
         format: int64
       theta_reject:
-        type: number
+        type: integer
         description: |
           Then umber of times the theta calculation has been rejected due to
           excessive delta between old and new values.
         format: int64
       timestamps:
-        type: number
+        type: integer
         description: |
           The number of timestamps in the current working set of timestamps.
           Old timestamps are dropped from the history of timestamps as they

--- a/src/swagger/v1/model/TimeKeeperState.cpp
+++ b/src/swagger/v1/model/TimeKeeperState.cpp
@@ -19,13 +19,13 @@ namespace model {
 
 TimeKeeperState::TimeKeeperState()
 {
-    m_Frequency = 0.0;
+    m_Frequency = 0L;
     m_FrequencyIsSet = false;
-    m_Frequency_error = 0.0;
+    m_Frequency_error = 0L;
     m_Frequency_errorIsSet = false;
-    m_Local_frequency = 0.0;
+    m_Local_frequency = 0L;
     m_Local_frequencyIsSet = false;
-    m_Local_frequency_error = 0.0;
+    m_Local_frequency_error = 0L;
     m_Local_frequency_errorIsSet = false;
     m_Offset = 0.0;
     m_Synced = false;
@@ -102,11 +102,11 @@ void TimeKeeperState::fromJson(nlohmann::json& val)
 }
 
 
-double TimeKeeperState::getFrequency() const
+int64_t TimeKeeperState::getFrequency() const
 {
     return m_Frequency;
 }
-void TimeKeeperState::setFrequency(double value)
+void TimeKeeperState::setFrequency(int64_t value)
 {
     m_Frequency = value;
     m_FrequencyIsSet = true;
@@ -119,11 +119,11 @@ void TimeKeeperState::unsetFrequency()
 {
     m_FrequencyIsSet = false;
 }
-double TimeKeeperState::getFrequencyError() const
+int64_t TimeKeeperState::getFrequencyError() const
 {
     return m_Frequency_error;
 }
-void TimeKeeperState::setFrequencyError(double value)
+void TimeKeeperState::setFrequencyError(int64_t value)
 {
     m_Frequency_error = value;
     m_Frequency_errorIsSet = true;
@@ -136,11 +136,11 @@ void TimeKeeperState::unsetFrequency_error()
 {
     m_Frequency_errorIsSet = false;
 }
-double TimeKeeperState::getLocalFrequency() const
+int64_t TimeKeeperState::getLocalFrequency() const
 {
     return m_Local_frequency;
 }
-void TimeKeeperState::setLocalFrequency(double value)
+void TimeKeeperState::setLocalFrequency(int64_t value)
 {
     m_Local_frequency = value;
     m_Local_frequencyIsSet = true;
@@ -153,11 +153,11 @@ void TimeKeeperState::unsetLocal_frequency()
 {
     m_Local_frequencyIsSet = false;
 }
-double TimeKeeperState::getLocalFrequencyError() const
+int64_t TimeKeeperState::getLocalFrequencyError() const
 {
     return m_Local_frequency_error;
 }
-void TimeKeeperState::setLocalFrequencyError(double value)
+void TimeKeeperState::setLocalFrequencyError(int64_t value)
 {
     m_Local_frequency_error = value;
     m_Local_frequency_errorIsSet = true;

--- a/src/swagger/v1/model/TimeKeeperState.h
+++ b/src/swagger/v1/model/TimeKeeperState.h
@@ -50,29 +50,29 @@ public:
     /// <summary>
     /// The time counter frequency as measured by the interval between the two best timestamp exchanges with the time source over the past two hours, in Hz. 
     /// </summary>
-    double getFrequency() const;
-    void setFrequency(double value);
+    int64_t getFrequency() const;
+    void setFrequency(int64_t value);
     bool frequencyIsSet() const;
     void unsetFrequency();
     /// <summary>
     /// The estimated error of the time counter frequency measurement, in Hz.
     /// </summary>
-    double getFrequencyError() const;
-    void setFrequencyError(double value);
+    int64_t getFrequencyError() const;
+    void setFrequencyError(int64_t value);
     bool frequencyErrorIsSet() const;
     void unsetFrequency_error();
     /// <summary>
     /// The time counter frequency as measured by the interval between the two best timestamp exchanges with the time source over the past hour, in Hz. This value is used to help determine time stamp error due to time counter frequency drift. 
     /// </summary>
-    double getLocalFrequency() const;
-    void setLocalFrequency(double value);
+    int64_t getLocalFrequency() const;
+    void setLocalFrequency(int64_t value);
     bool localFrequencyIsSet() const;
     void unsetLocal_frequency();
     /// <summary>
     /// The estimated error of the local time counter frequency measurement, in Hz.
     /// </summary>
-    double getLocalFrequencyError() const;
-    void setLocalFrequencyError(double value);
+    int64_t getLocalFrequencyError() const;
+    void setLocalFrequencyError(int64_t value);
     bool localFrequencyErrorIsSet() const;
     void unsetLocal_frequency_error();
     /// <summary>
@@ -94,13 +94,13 @@ public:
     void unsetTheta();
 
 protected:
-    double m_Frequency;
+    int64_t m_Frequency;
     bool m_FrequencyIsSet;
-    double m_Frequency_error;
+    int64_t m_Frequency_error;
     bool m_Frequency_errorIsSet;
-    double m_Local_frequency;
+    int64_t m_Local_frequency;
     bool m_Local_frequencyIsSet;
-    double m_Local_frequency_error;
+    int64_t m_Local_frequency_error;
     bool m_Local_frequency_errorIsSet;
     double m_Offset;
 

--- a/src/swagger/v1/model/TimeKeeperStats.cpp
+++ b/src/swagger/v1/model/TimeKeeperStats.cpp
@@ -19,13 +19,13 @@ namespace model {
 
 TimeKeeperStats::TimeKeeperStats()
 {
-    m_Frequency_accept = 0.0;
-    m_Frequency_reject = 0.0;
-    m_Local_frequency_accept = 0.0;
-    m_Local_frequency_reject = 0.0;
-    m_Theta_accept = 0.0;
-    m_Theta_reject = 0.0;
-    m_Timestamps = 0.0;
+    m_Frequency_accept = 0L;
+    m_Frequency_reject = 0L;
+    m_Local_frequency_accept = 0L;
+    m_Local_frequency_reject = 0L;
+    m_Theta_accept = 0L;
+    m_Theta_reject = 0L;
+    m_Timestamps = 0L;
     
 }
 
@@ -68,38 +68,38 @@ void TimeKeeperStats::fromJson(nlohmann::json& val)
 }
 
 
-double TimeKeeperStats::getFrequencyAccept() const
+int64_t TimeKeeperStats::getFrequencyAccept() const
 {
     return m_Frequency_accept;
 }
-void TimeKeeperStats::setFrequencyAccept(double value)
+void TimeKeeperStats::setFrequencyAccept(int64_t value)
 {
     m_Frequency_accept = value;
     
 }
-double TimeKeeperStats::getFrequencyReject() const
+int64_t TimeKeeperStats::getFrequencyReject() const
 {
     return m_Frequency_reject;
 }
-void TimeKeeperStats::setFrequencyReject(double value)
+void TimeKeeperStats::setFrequencyReject(int64_t value)
 {
     m_Frequency_reject = value;
     
 }
-double TimeKeeperStats::getLocalFrequencyAccept() const
+int64_t TimeKeeperStats::getLocalFrequencyAccept() const
 {
     return m_Local_frequency_accept;
 }
-void TimeKeeperStats::setLocalFrequencyAccept(double value)
+void TimeKeeperStats::setLocalFrequencyAccept(int64_t value)
 {
     m_Local_frequency_accept = value;
     
 }
-double TimeKeeperStats::getLocalFrequencyReject() const
+int64_t TimeKeeperStats::getLocalFrequencyReject() const
 {
     return m_Local_frequency_reject;
 }
-void TimeKeeperStats::setLocalFrequencyReject(double value)
+void TimeKeeperStats::setLocalFrequencyReject(int64_t value)
 {
     m_Local_frequency_reject = value;
     
@@ -113,29 +113,29 @@ void TimeKeeperStats::setRoundTripTimes(std::shared_ptr<TimeKeeperStats_round_tr
     m_Round_trip_times = value;
     
 }
-double TimeKeeperStats::getThetaAccept() const
+int64_t TimeKeeperStats::getThetaAccept() const
 {
     return m_Theta_accept;
 }
-void TimeKeeperStats::setThetaAccept(double value)
+void TimeKeeperStats::setThetaAccept(int64_t value)
 {
     m_Theta_accept = value;
     
 }
-double TimeKeeperStats::getThetaReject() const
+int64_t TimeKeeperStats::getThetaReject() const
 {
     return m_Theta_reject;
 }
-void TimeKeeperStats::setThetaReject(double value)
+void TimeKeeperStats::setThetaReject(int64_t value)
 {
     m_Theta_reject = value;
     
 }
-double TimeKeeperStats::getTimestamps() const
+int64_t TimeKeeperStats::getTimestamps() const
 {
     return m_Timestamps;
 }
-void TimeKeeperStats::setTimestamps(double value)
+void TimeKeeperStats::setTimestamps(int64_t value)
 {
     m_Timestamps = value;
     

--- a/src/swagger/v1/model/TimeKeeperStats.h
+++ b/src/swagger/v1/model/TimeKeeperStats.h
@@ -51,23 +51,23 @@ public:
     /// <summary>
     /// The number of times the frequency calculation has been updated.
     /// </summary>
-    double getFrequencyAccept() const;
-    void setFrequencyAccept(double value);
+    int64_t getFrequencyAccept() const;
+    void setFrequencyAccept(int64_t value);
         /// <summary>
     /// The number of times the frequency calculation has been rejected due to an excessive delta between old and new values. 
     /// </summary>
-    double getFrequencyReject() const;
-    void setFrequencyReject(double value);
+    int64_t getFrequencyReject() const;
+    void setFrequencyReject(int64_t value);
         /// <summary>
     /// The number of times the local frequency calculation has been updated.
     /// </summary>
-    double getLocalFrequencyAccept() const;
-    void setLocalFrequencyAccept(double value);
+    int64_t getLocalFrequencyAccept() const;
+    void setLocalFrequencyAccept(int64_t value);
         /// <summary>
     /// The number of times the local frequency calculation has been rejected due to an excessive delta between old and new values. 
     /// </summary>
-    double getLocalFrequencyReject() const;
-    void setLocalFrequencyReject(double value);
+    int64_t getLocalFrequencyReject() const;
+    void setLocalFrequencyReject(int64_t value);
         /// <summary>
     /// 
     /// </summary>
@@ -76,35 +76,35 @@ public:
         /// <summary>
     /// The number of times the theta calculation has been updated.
     /// </summary>
-    double getThetaAccept() const;
-    void setThetaAccept(double value);
+    int64_t getThetaAccept() const;
+    void setThetaAccept(int64_t value);
         /// <summary>
     /// Then umber of times the theta calculation has been rejected due to excessive delta between old and new values. 
     /// </summary>
-    double getThetaReject() const;
-    void setThetaReject(double value);
+    int64_t getThetaReject() const;
+    void setThetaReject(int64_t value);
         /// <summary>
     /// The number of timestamps in the current working set of timestamps. Old timestamps are dropped from the history of timestamps as they become irrelevant. 
     /// </summary>
-    double getTimestamps() const;
-    void setTimestamps(double value);
+    int64_t getTimestamps() const;
+    void setTimestamps(int64_t value);
     
 protected:
-    double m_Frequency_accept;
+    int64_t m_Frequency_accept;
 
-    double m_Frequency_reject;
+    int64_t m_Frequency_reject;
 
-    double m_Local_frequency_accept;
+    int64_t m_Local_frequency_accept;
 
-    double m_Local_frequency_reject;
+    int64_t m_Local_frequency_reject;
 
     std::shared_ptr<TimeKeeperStats_round_trip_times> m_Round_trip_times;
 
-    double m_Theta_accept;
+    int64_t m_Theta_accept;
 
-    double m_Theta_reject;
+    int64_t m_Theta_reject;
 
-    double m_Timestamps;
+    int64_t m_Timestamps;
 
 };
 

--- a/src/swagger/v1/model/TimeKeeperStats_round_trip_times.cpp
+++ b/src/swagger/v1/model/TimeKeeperStats_round_trip_times.cpp
@@ -25,7 +25,7 @@ TimeKeeperStats_round_trip_times::TimeKeeperStats_round_trip_times()
     m_MaxIsSet = false;
     m_Min = 0.0;
     m_MinIsSet = false;
-    m_Size = 0.0;
+    m_Size = 0L;
     
 }
 
@@ -130,11 +130,11 @@ void TimeKeeperStats_round_trip_times::unsetMin()
 {
     m_MinIsSet = false;
 }
-double TimeKeeperStats_round_trip_times::getSize() const
+int64_t TimeKeeperStats_round_trip_times::getSize() const
 {
     return m_Size;
 }
-void TimeKeeperStats_round_trip_times::setSize(double value)
+void TimeKeeperStats_round_trip_times::setSize(int64_t value)
 {
     m_Size = value;
     

--- a/src/swagger/v1/model/TimeKeeperStats_round_trip_times.h
+++ b/src/swagger/v1/model/TimeKeeperStats_round_trip_times.h
@@ -71,8 +71,8 @@ public:
     /// <summary>
     /// The number of round trip times in the data set.
     /// </summary>
-    double getSize() const;
-    void setSize(double value);
+    int64_t getSize() const;
+    void setSize(int64_t value);
     
 protected:
     double m_Avg;
@@ -81,7 +81,7 @@ protected:
     bool m_MaxIsSet;
     double m_Min;
     bool m_MinIsSet;
-    double m_Size;
+    int64_t m_Size;
 
 };
 

--- a/tests/aat/api/v1/client/models/time_keeper_state.py
+++ b/tests/aat/api/v1/client/models/time_keeper_state.py
@@ -31,10 +31,10 @@ class TimeKeeperState(object):
                             and the value is json key in definition.
     """
     swagger_types = {
-        'frequency': 'float',
-        'frequency_error': 'float',
-        'local_frequency': 'float',
-        'local_frequency_error': 'float',
+        'frequency': 'int',
+        'frequency_error': 'int',
+        'local_frequency': 'int',
+        'local_frequency_error': 'int',
         'offset': 'float',
         'synced': 'bool',
         'theta': 'float'
@@ -82,7 +82,7 @@ class TimeKeeperState(object):
         The time counter frequency as measured by the interval between the two best timestamp exchanges with the time source over the past two hours, in Hz.   # noqa: E501
 
         :return: The frequency of this TimeKeeperState.  # noqa: E501
-        :rtype: float
+        :rtype: int
         """
         return self._frequency
 
@@ -93,7 +93,7 @@ class TimeKeeperState(object):
         The time counter frequency as measured by the interval between the two best timestamp exchanges with the time source over the past two hours, in Hz.   # noqa: E501
 
         :param frequency: The frequency of this TimeKeeperState.  # noqa: E501
-        :type: float
+        :type: int
         """
         self._frequency = frequency
 
@@ -104,7 +104,7 @@ class TimeKeeperState(object):
         The estimated error of the time counter frequency measurement, in Hz.  # noqa: E501
 
         :return: The frequency_error of this TimeKeeperState.  # noqa: E501
-        :rtype: float
+        :rtype: int
         """
         return self._frequency_error
 
@@ -115,7 +115,7 @@ class TimeKeeperState(object):
         The estimated error of the time counter frequency measurement, in Hz.  # noqa: E501
 
         :param frequency_error: The frequency_error of this TimeKeeperState.  # noqa: E501
-        :type: float
+        :type: int
         """
         self._frequency_error = frequency_error
 
@@ -126,7 +126,7 @@ class TimeKeeperState(object):
         The time counter frequency as measured by the interval between the two best timestamp exchanges with the time source over the past hour, in Hz. This value is used to help determine time stamp error due to time counter frequency drift.   # noqa: E501
 
         :return: The local_frequency of this TimeKeeperState.  # noqa: E501
-        :rtype: float
+        :rtype: int
         """
         return self._local_frequency
 
@@ -137,7 +137,7 @@ class TimeKeeperState(object):
         The time counter frequency as measured by the interval between the two best timestamp exchanges with the time source over the past hour, in Hz. This value is used to help determine time stamp error due to time counter frequency drift.   # noqa: E501
 
         :param local_frequency: The local_frequency of this TimeKeeperState.  # noqa: E501
-        :type: float
+        :type: int
         """
         self._local_frequency = local_frequency
 
@@ -148,7 +148,7 @@ class TimeKeeperState(object):
         The estimated error of the local time counter frequency measurement, in Hz.  # noqa: E501
 
         :return: The local_frequency_error of this TimeKeeperState.  # noqa: E501
-        :rtype: float
+        :rtype: int
         """
         return self._local_frequency_error
 
@@ -159,7 +159,7 @@ class TimeKeeperState(object):
         The estimated error of the local time counter frequency measurement, in Hz.  # noqa: E501
 
         :param local_frequency_error: The local_frequency_error of this TimeKeeperState.  # noqa: E501
-        :type: float
+        :type: int
         """
         self._local_frequency_error = local_frequency_error
 

--- a/tests/aat/api/v1/client/models/time_keeper_stats.py
+++ b/tests/aat/api/v1/client/models/time_keeper_stats.py
@@ -31,14 +31,14 @@ class TimeKeeperStats(object):
                             and the value is json key in definition.
     """
     swagger_types = {
-        'frequency_accept': 'float',
-        'frequency_reject': 'float',
-        'local_frequency_accept': 'float',
-        'local_frequency_reject': 'float',
+        'frequency_accept': 'int',
+        'frequency_reject': 'int',
+        'local_frequency_accept': 'int',
+        'local_frequency_reject': 'int',
         'round_trip_times': 'TimeKeeperStatsRoundTripTimes',
-        'theta_accept': 'float',
-        'theta_reject': 'float',
-        'timestamps': 'float'
+        'theta_accept': 'int',
+        'theta_reject': 'int',
+        'timestamps': 'int'
     }
 
     attribute_map = {
@@ -81,7 +81,7 @@ class TimeKeeperStats(object):
         The number of times the frequency calculation has been updated.  # noqa: E501
 
         :return: The frequency_accept of this TimeKeeperStats.  # noqa: E501
-        :rtype: float
+        :rtype: int
         """
         return self._frequency_accept
 
@@ -92,7 +92,7 @@ class TimeKeeperStats(object):
         The number of times the frequency calculation has been updated.  # noqa: E501
 
         :param frequency_accept: The frequency_accept of this TimeKeeperStats.  # noqa: E501
-        :type: float
+        :type: int
         """
         self._frequency_accept = frequency_accept
 
@@ -103,7 +103,7 @@ class TimeKeeperStats(object):
         The number of times the frequency calculation has been rejected due to an excessive delta between old and new values.   # noqa: E501
 
         :return: The frequency_reject of this TimeKeeperStats.  # noqa: E501
-        :rtype: float
+        :rtype: int
         """
         return self._frequency_reject
 
@@ -114,7 +114,7 @@ class TimeKeeperStats(object):
         The number of times the frequency calculation has been rejected due to an excessive delta between old and new values.   # noqa: E501
 
         :param frequency_reject: The frequency_reject of this TimeKeeperStats.  # noqa: E501
-        :type: float
+        :type: int
         """
         self._frequency_reject = frequency_reject
 
@@ -125,7 +125,7 @@ class TimeKeeperStats(object):
         The number of times the local frequency calculation has been updated.  # noqa: E501
 
         :return: The local_frequency_accept of this TimeKeeperStats.  # noqa: E501
-        :rtype: float
+        :rtype: int
         """
         return self._local_frequency_accept
 
@@ -136,7 +136,7 @@ class TimeKeeperStats(object):
         The number of times the local frequency calculation has been updated.  # noqa: E501
 
         :param local_frequency_accept: The local_frequency_accept of this TimeKeeperStats.  # noqa: E501
-        :type: float
+        :type: int
         """
         self._local_frequency_accept = local_frequency_accept
 
@@ -147,7 +147,7 @@ class TimeKeeperStats(object):
         The number of times the local frequency calculation has been rejected due to an excessive delta between old and new values.   # noqa: E501
 
         :return: The local_frequency_reject of this TimeKeeperStats.  # noqa: E501
-        :rtype: float
+        :rtype: int
         """
         return self._local_frequency_reject
 
@@ -158,7 +158,7 @@ class TimeKeeperStats(object):
         The number of times the local frequency calculation has been rejected due to an excessive delta between old and new values.   # noqa: E501
 
         :param local_frequency_reject: The local_frequency_reject of this TimeKeeperStats.  # noqa: E501
-        :type: float
+        :type: int
         """
         self._local_frequency_reject = local_frequency_reject
 
@@ -189,7 +189,7 @@ class TimeKeeperStats(object):
         The number of times the theta calculation has been updated.  # noqa: E501
 
         :return: The theta_accept of this TimeKeeperStats.  # noqa: E501
-        :rtype: float
+        :rtype: int
         """
         return self._theta_accept
 
@@ -200,7 +200,7 @@ class TimeKeeperStats(object):
         The number of times the theta calculation has been updated.  # noqa: E501
 
         :param theta_accept: The theta_accept of this TimeKeeperStats.  # noqa: E501
-        :type: float
+        :type: int
         """
         self._theta_accept = theta_accept
 
@@ -211,7 +211,7 @@ class TimeKeeperStats(object):
         Then umber of times the theta calculation has been rejected due to excessive delta between old and new values.   # noqa: E501
 
         :return: The theta_reject of this TimeKeeperStats.  # noqa: E501
-        :rtype: float
+        :rtype: int
         """
         return self._theta_reject
 
@@ -222,7 +222,7 @@ class TimeKeeperStats(object):
         Then umber of times the theta calculation has been rejected due to excessive delta between old and new values.   # noqa: E501
 
         :param theta_reject: The theta_reject of this TimeKeeperStats.  # noqa: E501
-        :type: float
+        :type: int
         """
         self._theta_reject = theta_reject
 
@@ -233,7 +233,7 @@ class TimeKeeperStats(object):
         The number of timestamps in the current working set of timestamps. Old timestamps are dropped from the history of timestamps as they become irrelevant.   # noqa: E501
 
         :return: The timestamps of this TimeKeeperStats.  # noqa: E501
-        :rtype: float
+        :rtype: int
         """
         return self._timestamps
 
@@ -244,7 +244,7 @@ class TimeKeeperStats(object):
         The number of timestamps in the current working set of timestamps. Old timestamps are dropped from the history of timestamps as they become irrelevant.   # noqa: E501
 
         :param timestamps: The timestamps of this TimeKeeperStats.  # noqa: E501
-        :type: float
+        :type: int
         """
         self._timestamps = timestamps
 

--- a/tests/aat/api/v1/client/models/time_keeper_stats_round_trip_times.py
+++ b/tests/aat/api/v1/client/models/time_keeper_stats_round_trip_times.py
@@ -34,7 +34,7 @@ class TimeKeeperStatsRoundTripTimes(object):
         'avg': 'float',
         'max': 'float',
         'min': 'float',
-        'size': 'float'
+        'size': 'int'
     }
 
     attribute_map = {
@@ -134,7 +134,7 @@ class TimeKeeperStatsRoundTripTimes(object):
         The number of round trip times in the data set.  # noqa: E501
 
         :return: The size of this TimeKeeperStatsRoundTripTimes.  # noqa: E501
-        :rtype: float
+        :rtype: int
         """
         return self._size
 
@@ -145,7 +145,7 @@ class TimeKeeperStatsRoundTripTimes(object):
         The number of round trip times in the data set.  # noqa: E501
 
         :param size: The size of this TimeKeeperStatsRoundTripTimes.  # noqa: E501
-        :type: float
+        :type: int
         """
         self._size = size
 

--- a/tests/aat/api/v1/docs/TimeKeeperState.md
+++ b/tests/aat/api/v1/docs/TimeKeeperState.md
@@ -3,10 +3,10 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**frequency** | **float** | The time counter frequency as measured by the interval between the two best timestamp exchanges with the time source over the past two hours, in Hz.  | [optional] 
-**frequency_error** | **float** | The estimated error of the time counter frequency measurement, in Hz. | [optional] 
-**local_frequency** | **float** | The time counter frequency as measured by the interval between the two best timestamp exchanges with the time source over the past hour, in Hz. This value is used to help determine time stamp error due to time counter frequency drift.  | [optional] 
-**local_frequency_error** | **float** | The estimated error of the local time counter frequency measurement, in Hz. | [optional] 
+**frequency** | **int** | The time counter frequency as measured by the interval between the two best timestamp exchanges with the time source over the past two hours, in Hz.  | [optional] 
+**frequency_error** | **int** | The estimated error of the time counter frequency measurement, in Hz. | [optional] 
+**local_frequency** | **int** | The time counter frequency as measured by the interval between the two best timestamp exchanges with the time source over the past hour, in Hz. This value is used to help determine time stamp error due to time counter frequency drift.  | [optional] 
+**local_frequency_error** | **int** | The estimated error of the local time counter frequency measurement, in Hz. | [optional] 
 **offset** | **float** | The offset applied to time counter derived timestamp values, in seconds.  This value comes from the system host clock.  | 
 **synced** | **bool** | The time keeper is considered to be synced to the time source if a clock offset, theta, has been calculated and applied within the past 20 minutes.  | 
 **theta** | **float** | The calculated correction to apply to the offset, based on the measured time counter frequency and time source timestamps.  | [optional] 

--- a/tests/aat/api/v1/docs/TimeKeeperStats.md
+++ b/tests/aat/api/v1/docs/TimeKeeperStats.md
@@ -3,14 +3,14 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**frequency_accept** | **float** | The number of times the frequency calculation has been updated. | 
-**frequency_reject** | **float** | The number of times the frequency calculation has been rejected due to an excessive delta between old and new values.  | 
-**local_frequency_accept** | **float** | The number of times the local frequency calculation has been updated. | 
-**local_frequency_reject** | **float** | The number of times the local frequency calculation has been rejected due to an excessive delta between old and new values.  | 
+**frequency_accept** | **int** | The number of times the frequency calculation has been updated. | 
+**frequency_reject** | **int** | The number of times the frequency calculation has been rejected due to an excessive delta between old and new values.  | 
+**local_frequency_accept** | **int** | The number of times the local frequency calculation has been updated. | 
+**local_frequency_reject** | **int** | The number of times the local frequency calculation has been rejected due to an excessive delta between old and new values.  | 
 **round_trip_times** | [**TimeKeeperStatsRoundTripTimes**](TimeKeeperStatsRoundTripTimes.md) |  | 
-**theta_accept** | **float** | The number of times the theta calculation has been updated. | 
-**theta_reject** | **float** | Then umber of times the theta calculation has been rejected due to excessive delta between old and new values.  | 
-**timestamps** | **float** | The number of timestamps in the current working set of timestamps. Old timestamps are dropped from the history of timestamps as they become irrelevant.  | 
+**theta_accept** | **int** | The number of times the theta calculation has been updated. | 
+**theta_reject** | **int** | Then umber of times the theta calculation has been rejected due to excessive delta between old and new values.  | 
+**timestamps** | **int** | The number of timestamps in the current working set of timestamps. Old timestamps are dropped from the history of timestamps as they become irrelevant.  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/tests/aat/api/v1/docs/TimeKeeperStatsRoundTripTimes.md
+++ b/tests/aat/api/v1/docs/TimeKeeperStatsRoundTripTimes.md
@@ -6,7 +6,7 @@ Name | Type | Description | Notes
 **avg** | **float** | the average round trip time, in seconds. | [optional] 
 **max** | **float** | The maximum round trip time, in seconds. | [optional] 
 **min** | **float** | The minimum round trip time, in seconds. | [optional] 
-**size** | **float** | The number of round trip times in the data set. | 
+**size** | **int** | The number of round trip times in the data set. | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 


### PR DESCRIPTION
The timesync swagger specification had numerous properties
(mis)identified as numbers when they should have been integers. Fix
them and update the generated code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/491)
<!-- Reviewable:end -->
