### PR TITLE
Add computation Dynamic Results by periods

### DIFF
--- a/src/modules/dynamic/spool.hpp
+++ b/src/modules/dynamic/spool.hpp
@@ -234,11 +234,8 @@ template <typename T> double spool<T>::elapsed_periods(const T& stat) const
 {
     auto t = m_extractor(stat, "timestamp").value();
     auto last_t = m_extractor(m_last_stat, "timestamp").value();
-    auto period = std::chrono::duration_cast<std::chrono::nanoseconds>(
-                      m_computation_period)
-                      .count();
 
-    return (t - last_t) / period;
+    return (t - last_t) / m_computation_period.count();
 }
 
 template <typename T>

--- a/src/modules/dynamic/spool.hpp
+++ b/src/modules/dynamic/spool.hpp
@@ -35,12 +35,14 @@ private:
         tdigest tdigest;
     };
 
+    // Constants
+    static constexpr std::chrono::nanoseconds m_computation_period = 1s;
+
     // Attributes
     std::map<std::string, threshold_arg> m_thresholds;
     std::map<std::string, tdigest_arg> m_tdigests;
     extractor m_extractor;
     T m_last_stat;
-    std::chrono::nanoseconds m_computation_period = 1s;
 
 public:
     explicit spool(extractor&& f);

--- a/src/modules/dynamic/spool.hpp
+++ b/src/modules/dynamic/spool.hpp
@@ -12,6 +12,8 @@
 
 namespace openperf::dynamic {
 
+using namespace std::chrono_literals;
+
 template <typename T> class spool
 {
 public:
@@ -38,6 +40,7 @@ private:
     std::map<std::string, tdigest_arg> m_tdigests;
     extractor m_extractor;
     T m_last_stat;
+    std::chrono::nanoseconds m_computation_period = 1s;
 
 public:
     explicit spool(extractor&& f);
@@ -53,6 +56,7 @@ private:
     uint64_t weight(const argument_t&, const T&) const;
     double delta(const argument_t&, const T&) const;
     void argument_check(const argument_t&) const;
+    double elapsed_periods(const T&) const;
 };
 
 //
@@ -158,6 +162,8 @@ template <typename T> void spool<T>::reset()
 
 template <typename T> void spool<T>::add(const T& stat)
 {
+    if (elapsed_periods(stat) < 1) return;
+
     for (auto& th : m_thresholds) {
         auto& data = th.second;
         data.threshold.append(delta(data.argument, stat));
@@ -224,6 +230,17 @@ uint64_t spool<T>::weight(const argument_t& arg, const T& stat) const
     return weight;
 }
 
+template <typename T> double spool<T>::elapsed_periods(const T& stat) const
+{
+    auto t = m_extractor(stat, "timestamp").value();
+    auto last_t = m_extractor(m_last_stat, "timestamp").value();
+    auto period = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                      m_computation_period)
+                      .count();
+
+    return (t - last_t) / period;
+}
+
 template <typename T>
 double spool<T>::delta(const argument_t& arg, const T& stat) const
 {
@@ -238,9 +255,7 @@ double spool<T>::delta(const argument_t& arg, const T& stat) const
         break;
     }
     case argument_t::DXDT: {
-        auto t = m_extractor(stat, "timestamp").value();
-        auto last_t = m_extractor(m_last_stat, "timestamp").value();
-        auto delta_t = t - last_t;
+        auto delta_t = elapsed_periods(stat);
         delta = (delta_t != 0.0) ? delta_x / delta_t : 0.0;
         break;
     }


### PR DESCRIPTION
Current implementation of Dynamic Results has some disadvantages:
1. non-constant period of calculation, because of statistics data arrives after each load algorithm spin and Dynamic Results calculates after each spin.
2. zero values in some cases. As consequence of the first peculiarity and concurrent execution some fields of the statistics may be unchanged, thus delta values can be 0.

To resolve this two problems I add computation of Dynamic Results by statically periods. Now, Dynamic Results will be calculated after period of time is elapsed. Default period time is `1s`.
Resolves #493.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/495)
<!-- Reviewable:end -->
