### PR TITLE
Add clock error property

### DIFF
--- a/api/schema/v1/modules/timesync.yaml
+++ b/api/schema/v1/modules/timesync.yaml
@@ -158,7 +158,9 @@ definitions:
         format: int64
       frequency_error:
         type: integer
-        description: The estimated error of the time counter frequency measurement, in Hz.
+        description: |
+          The estimated error of the time counter frequency measurement, in
+          Parts Per Billion (PPB).
         format: int64
       local_frequency:
         type: integer
@@ -170,7 +172,9 @@ definitions:
         format: int64
       local_frequency_error:
         type: integer
-        description: The estimated error of the local time counter frequency measurement, in Hz.
+        description: |
+          The estimated error of the local time counter frequency measurement,
+          int Parts Per Billion (PPB).
         format: int64
       offset:
         type: number
@@ -276,6 +280,10 @@ definitions:
       A combination of a time source and a time counter used to measure
       the passage of time, aka a clock
     properties:
+      maximum_error:
+        type: number
+        description: The current maximum error in the time calculation
+        format: double
       state:
         $ref: "#/definitions/TimeKeeperState"
       stats:
@@ -291,6 +299,7 @@ definitions:
         type: string
         description: time source used for wall-clock synchronization
     required:
+      - maximum_error
       - state
       - stats
       - time

--- a/src/modules/timesync/api.hpp
+++ b/src/modules/timesync/api.hpp
@@ -55,9 +55,9 @@ struct request_time_keeper
 struct time_keeper_info
 {
     std::optional<counter::hz> freq;
-    std::optional<counter::hz> freq_error;
+    std::optional<uint64_t> freq_error;
     std::optional<counter::hz> local_freq;
-    std::optional<counter::hz> local_freq_error;
+    std::optional<uint64_t> local_freq_error;
     bintime offset;
     std::optional<bintime> theta;
     bool synced;
@@ -89,6 +89,7 @@ struct time_keeper
     char counter_id[id_max_length];
     char source_id[id_max_length];
     time_point ts;
+    std::chrono::nanoseconds ts_error;
     time_keeper_info info;
     time_keeper_stats stats;
 };

--- a/src/modules/timesync/api_transmogrify.cpp
+++ b/src/modules/timesync/api_transmogrify.cpp
@@ -155,11 +155,9 @@ to_swagger(const time_keeper_info& src)
     auto dst = std::make_shared<TimeKeeperState>();
 
     if (src.freq) { dst->setFrequency(src.freq->count()); }
-    if (src.freq_error) { dst->setFrequencyError(src.freq_error->count()); }
+    if (src.freq_error) { dst->setFrequencyError(*src.freq_error); }
     if (src.local_freq) { dst->setLocalFrequency(src.local_freq->count()); }
-    if (src.local_freq) {
-        dst->setLocalFrequencyError(src.local_freq_error->count());
-    }
+    if (src.local_freq) { dst->setLocalFrequencyError(*src.local_freq_error); }
     dst->setOffset(to_double(src.offset));
     dst->setSynced(src.synced);
     if (src.theta) { dst->setTheta(to_double(*src.theta)); }
@@ -199,6 +197,9 @@ to_swagger(const time_keeper& src)
     using TimeKeeper = swagger::v1::model::TimeKeeper;
     auto dst = std::make_shared<TimeKeeper>();
 
+    dst->setMaximumError(
+        std::chrono::duration_cast<std::chrono::duration<double>>(src.ts_error)
+            .count());
     dst->setState(to_swagger(src.info));
     dst->setStats(to_swagger(src.stats));
     dst->setTime(to_rfc3339(src.ts.time_since_epoch()));

--- a/src/modules/timesync/chrono.hpp
+++ b/src/modules/timesync/chrono.hpp
@@ -56,6 +56,12 @@ inline std::pair<bintime, counter::ticks> monotime_ticks()
     return {now, ticks};
 }
 
+/*
+ * Calculate the maximum clock error given the specified frequency error.
+ * Error should be in Parts Per Billion (PPB).
+ */
+std::chrono::nanoseconds maximum_clock_error(uint64_t ppb_freq_error);
+
 struct realtime
 {
     using duration = std::chrono::nanoseconds;

--- a/src/modules/timesync/clock.cpp
+++ b/src/modules/timesync/clock.cpp
@@ -191,11 +191,9 @@ static void accumulate_theta_hat(const timestamp& ts,
     }
 }
 
-static counter::hz calculate_tick_error(counter::ticks error,
-                                        counter::ticks delta,
-                                        counter::hz freq)
+static uint64_t calculate_tick_error(counter::ticks error, counter::ticks delta)
 {
-    return ((error * freq) / delta);
+    return (error * 1000000000 / delta);
 }
 
 static counter::hz to_hz(double d)
@@ -279,8 +277,8 @@ static clock::freq_result calculate_tick_freq(const timestamp& i,
                     .count());
     auto e_i = to_rtt(i) - min_rtt;
     auto e_j = to_rtt(j) - min_rtt;
-    auto e_up = calculate_tick_error(e_i + e_j, i.Ta - j.Ta, freq_up);
-    auto e_down = calculate_tick_error(e_i + e_j, i.Tf - j.Tf, freq_down);
+    auto e_up = calculate_tick_error(e_i + e_j, i.Ta - j.Ta);
+    auto e_down = calculate_tick_error(e_i + e_j, i.Tf - j.Tf);
 
     return (clock::freq_result((freq_up + freq_down) / 2, (e_up + e_down) / 2));
 }
@@ -552,7 +550,7 @@ std::optional<counter::hz> clock::frequency() const
     return (get_value(m_data.f_hat.current));
 }
 
-std::optional<counter::hz> clock::frequency_error() const
+std::optional<uint64_t> clock::frequency_error() const
 {
     if (!m_stats.f_hat_accept) { return (std::nullopt); }
 
@@ -566,7 +564,7 @@ std::optional<counter::hz> clock::local_frequency() const
     return (get_value(m_data.f_local.current));
 }
 
-std::optional<counter::hz> clock::local_frequency_error() const
+std::optional<uint64_t> clock::local_frequency_error() const
 {
     if (!m_stats.f_local_accept) { return (std::nullopt); }
 

--- a/src/modules/timesync/clock.hpp
+++ b/src/modules/timesync/clock.hpp
@@ -27,14 +27,14 @@ public:
                                    const bintime& Te,
                                    counter::ticks Tf);
 
-    /* Frequency calculations always involve a result and an error */
-    using freq_result = std::pair<counter::hz, counter::hz>;
+    /* Frequency calculations always involve a result and a ppb error */
+    using freq_result = std::pair<counter::hz, uint64_t>;
     using rtt_container = digestible::tdigest<counter::ticks, unsigned>;
 
     std::optional<counter::hz> frequency() const;
-    std::optional<counter::hz> frequency_error() const;
+    std::optional<uint64_t> frequency_error() const; /* ppb */
     std::optional<counter::hz> local_frequency() const;
-    std::optional<counter::hz> local_frequency_error() const;
+    std::optional<uint64_t> local_frequency_error() const; /* ppb */
     bintime offset() const;
     std::optional<bintime> theta() const;
 
@@ -64,12 +64,12 @@ private:
     {
         struct
         {
-            freq_result current = {counter::hz{0}, counter::hz{0}};
+            freq_result current = {counter::hz{0}, 0};
             counter::ticks last_update = 0;
         } f_hat;
         struct
         {
-            freq_result current = {counter::hz{0}, counter::hz{0}};
+            freq_result current = {counter::hz{0}, 0};
             counter::ticks last_update = 0;
         } f_local;
         struct

--- a/src/modules/timesync/history.cpp
+++ b/src/modules/timesync/history.cpp
@@ -39,9 +39,22 @@ bool history::contains(const timestamp& ts) const noexcept
         [&ntp_ts](const auto& item) { return (ntp_ts == item.Tb); }));
 }
 
-void history::prune(time_t time)
+void history::prune_before(time_t time)
 {
     m_history.erase(std::begin(m_history), lower_bound(time));
+}
+
+void history::prune_rtts(counter::ticks min_rtt)
+{
+    auto cursor = std::begin(m_history);
+    while (cursor != std::end(m_history)) {
+        /*
+         * Conveniently, offset_Tf is the delta between Ta and Tf,
+         * which is the round trip time (rtt).
+         */
+        cursor =
+            cursor->offset_Tf < min_rtt ? m_history.erase(cursor) : ++cursor;
+    }
 }
 
 void history::insert(const timestamp& ts, counter::hz f_local)

--- a/src/modules/timesync/history.hpp
+++ b/src/modules/timesync/history.hpp
@@ -83,7 +83,8 @@ public:
     history_container::iterator lower_bound(time_t time) const;
     history_container::iterator upper_bound(time_t time) const;
 
-    void prune(time_t time);
+    void prune_before(time_t time);
+    void prune_rtts(counter::ticks min_rtt);
 
     using history_range =
         std::pair<history_container::iterator, history_container::iterator>;

--- a/src/modules/timesync/server.cpp
+++ b/src/modules/timesync/server.cpp
@@ -133,10 +133,19 @@ reply_msg server::handle_request(const request_time_counters& request)
     return (reply);
 }
 
+static std::chrono::nanoseconds get_clock_error(const clock& c)
+{
+    auto error = c.local_frequency_error();
+    if (!error) { error = c.frequency_error(); }
+
+    return (chrono::maximum_clock_error(error.value_or(0)));
+}
+
 reply_msg server::handle_request(const request_time_keeper&)
 {
     auto keeper = time_keeper{
         .ts = chrono::realtime::now(),
+        .ts_error = get_clock_error(*m_clock),
         .info = {.freq = m_clock->frequency(),
                  .freq_error = m_clock->frequency_error(),
                  .local_freq = m_clock->local_frequency(),

--- a/src/swagger/v1/model/TimeKeeper.cpp
+++ b/src/swagger/v1/model/TimeKeeper.cpp
@@ -19,6 +19,7 @@ namespace model {
 
 TimeKeeper::TimeKeeper()
 {
+    m_Maximum_error = 0.0;
     m_Time = "";
     m_Time_counter_id = "";
     m_Time_source_id = "";
@@ -38,6 +39,7 @@ nlohmann::json TimeKeeper::toJson() const
 {
     nlohmann::json val = nlohmann::json::object();
 
+    val["maximum_error"] = m_Maximum_error;
     val["state"] = ModelBase::toJson(m_State);
     val["stats"] = ModelBase::toJson(m_Stats);
     val["time"] = ModelBase::toJson(m_Time);
@@ -50,6 +52,7 @@ nlohmann::json TimeKeeper::toJson() const
 
 void TimeKeeper::fromJson(nlohmann::json& val)
 {
+    setMaximumError(val.at("maximum_error"));
     setTime(val.at("time"));
     setTimeCounterId(val.at("time_counter_id"));
     setTimeSourceId(val.at("time_source_id"));
@@ -57,6 +60,15 @@ void TimeKeeper::fromJson(nlohmann::json& val)
 }
 
 
+double TimeKeeper::getMaximumError() const
+{
+    return m_Maximum_error;
+}
+void TimeKeeper::setMaximumError(double value)
+{
+    m_Maximum_error = value;
+    
+}
 std::shared_ptr<TimeKeeperState> TimeKeeper::getState() const
 {
     return m_State;

--- a/src/swagger/v1/model/TimeKeeper.h
+++ b/src/swagger/v1/model/TimeKeeper.h
@@ -51,6 +51,11 @@ public:
     /// TimeKeeper members
 
     /// <summary>
+    /// The current maximum error in the time calculation
+    /// </summary>
+    double getMaximumError() const;
+    void setMaximumError(double value);
+        /// <summary>
     /// 
     /// </summary>
     std::shared_ptr<TimeKeeperState> getState() const;
@@ -77,6 +82,8 @@ public:
     void setTimeSourceId(std::string value);
     
 protected:
+    double m_Maximum_error;
+
     std::shared_ptr<TimeKeeperState> m_State;
 
     std::shared_ptr<TimeKeeperStats> m_Stats;

--- a/src/swagger/v1/model/TimeKeeperState.h
+++ b/src/swagger/v1/model/TimeKeeperState.h
@@ -55,7 +55,7 @@ public:
     bool frequencyIsSet() const;
     void unsetFrequency();
     /// <summary>
-    /// The estimated error of the time counter frequency measurement, in Hz.
+    /// The estimated error of the time counter frequency measurement, in Parts Per Billion (PPB). 
     /// </summary>
     int64_t getFrequencyError() const;
     void setFrequencyError(int64_t value);
@@ -69,7 +69,7 @@ public:
     bool localFrequencyIsSet() const;
     void unsetLocal_frequency();
     /// <summary>
-    /// The estimated error of the local time counter frequency measurement, in Hz.
+    /// The estimated error of the local time counter frequency measurement, int Parts Per Billion (PPB). 
     /// </summary>
     int64_t getLocalFrequencyError() const;
     void setLocalFrequencyError(int64_t value);

--- a/tests/aat/api/v1/client/models/time_keeper.py
+++ b/tests/aat/api/v1/client/models/time_keeper.py
@@ -31,6 +31,7 @@ class TimeKeeper(object):
                             and the value is json key in definition.
     """
     swagger_types = {
+        'maximum_error': 'float',
         'state': 'TimeKeeperState',
         'stats': 'TimeKeeperStats',
         'time': 'datetime',
@@ -39,6 +40,7 @@ class TimeKeeper(object):
     }
 
     attribute_map = {
+        'maximum_error': 'maximum_error',
         'state': 'state',
         'stats': 'stats',
         'time': 'time',
@@ -46,9 +48,10 @@ class TimeKeeper(object):
         'time_source_id': 'time_source_id'
     }
 
-    def __init__(self, state=None, stats=None, time=None, time_counter_id=None, time_source_id=None):  # noqa: E501
+    def __init__(self, maximum_error=None, state=None, stats=None, time=None, time_counter_id=None, time_source_id=None):  # noqa: E501
         """TimeKeeper - a model defined in Swagger"""  # noqa: E501
 
+        self._maximum_error = None
         self._state = None
         self._stats = None
         self._time = None
@@ -56,11 +59,34 @@ class TimeKeeper(object):
         self._time_source_id = None
         self.discriminator = None
 
+        self.maximum_error = maximum_error
         self.state = state
         self.stats = stats
         self.time = time
         self.time_counter_id = time_counter_id
         self.time_source_id = time_source_id
+
+    @property
+    def maximum_error(self):
+        """Gets the maximum_error of this TimeKeeper.  # noqa: E501
+
+        The current maximum error in the time calculation  # noqa: E501
+
+        :return: The maximum_error of this TimeKeeper.  # noqa: E501
+        :rtype: float
+        """
+        return self._maximum_error
+
+    @maximum_error.setter
+    def maximum_error(self, maximum_error):
+        """Sets the maximum_error of this TimeKeeper.
+
+        The current maximum error in the time calculation  # noqa: E501
+
+        :param maximum_error: The maximum_error of this TimeKeeper.  # noqa: E501
+        :type: float
+        """
+        self._maximum_error = maximum_error
 
     @property
     def state(self):

--- a/tests/aat/api/v1/client/models/time_keeper_state.py
+++ b/tests/aat/api/v1/client/models/time_keeper_state.py
@@ -101,7 +101,7 @@ class TimeKeeperState(object):
     def frequency_error(self):
         """Gets the frequency_error of this TimeKeeperState.  # noqa: E501
 
-        The estimated error of the time counter frequency measurement, in Hz.  # noqa: E501
+        The estimated error of the time counter frequency measurement, in Parts Per Billion (PPB).   # noqa: E501
 
         :return: The frequency_error of this TimeKeeperState.  # noqa: E501
         :rtype: int
@@ -112,7 +112,7 @@ class TimeKeeperState(object):
     def frequency_error(self, frequency_error):
         """Sets the frequency_error of this TimeKeeperState.
 
-        The estimated error of the time counter frequency measurement, in Hz.  # noqa: E501
+        The estimated error of the time counter frequency measurement, in Parts Per Billion (PPB).   # noqa: E501
 
         :param frequency_error: The frequency_error of this TimeKeeperState.  # noqa: E501
         :type: int
@@ -145,7 +145,7 @@ class TimeKeeperState(object):
     def local_frequency_error(self):
         """Gets the local_frequency_error of this TimeKeeperState.  # noqa: E501
 
-        The estimated error of the local time counter frequency measurement, in Hz.  # noqa: E501
+        The estimated error of the local time counter frequency measurement, int Parts Per Billion (PPB).   # noqa: E501
 
         :return: The local_frequency_error of this TimeKeeperState.  # noqa: E501
         :rtype: int
@@ -156,7 +156,7 @@ class TimeKeeperState(object):
     def local_frequency_error(self, local_frequency_error):
         """Sets the local_frequency_error of this TimeKeeperState.
 
-        The estimated error of the local time counter frequency measurement, in Hz.  # noqa: E501
+        The estimated error of the local time counter frequency measurement, int Parts Per Billion (PPB).   # noqa: E501
 
         :param local_frequency_error: The local_frequency_error of this TimeKeeperState.  # noqa: E501
         :type: int

--- a/tests/aat/api/v1/docs/TimeKeeper.md
+++ b/tests/aat/api/v1/docs/TimeKeeper.md
@@ -3,6 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**maximum_error** | **float** | The current maximum error in the time calculation | 
 **state** | [**TimeKeeperState**](TimeKeeperState.md) |  | 
 **stats** | [**TimeKeeperStats**](TimeKeeperStats.md) |  | 
 **time** | **datetime** | The current time and date in ISO8601 format | 

--- a/tests/aat/api/v1/docs/TimeKeeperState.md
+++ b/tests/aat/api/v1/docs/TimeKeeperState.md
@@ -4,9 +4,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **frequency** | **int** | The time counter frequency as measured by the interval between the two best timestamp exchanges with the time source over the past two hours, in Hz.  | [optional] 
-**frequency_error** | **int** | The estimated error of the time counter frequency measurement, in Hz. | [optional] 
+**frequency_error** | **int** | The estimated error of the time counter frequency measurement, in Parts Per Billion (PPB).  | [optional] 
 **local_frequency** | **int** | The time counter frequency as measured by the interval between the two best timestamp exchanges with the time source over the past hour, in Hz. This value is used to help determine time stamp error due to time counter frequency drift.  | [optional] 
-**local_frequency_error** | **int** | The estimated error of the local time counter frequency measurement, in Hz. | [optional] 
+**local_frequency_error** | **int** | The estimated error of the local time counter frequency measurement, int Parts Per Billion (PPB).  | [optional] 
 **offset** | **float** | The offset applied to time counter derived timestamp values, in seconds.  This value comes from the system host clock.  | 
 **synced** | **bool** | The time keeper is considered to be synced to the time source if a clock offset, theta, has been calculated and applied within the past 20 minutes.  | 
 **theta** | **float** | The calculated correction to apply to the offset, based on the measured time counter frequency and time source timestamps.  | [optional] 


### PR DESCRIPTION
Add a new property, `maximum-error` to the time-keeper API object so clients can see how accurate the clock thinks it is.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/496)
<!-- Reviewable:end -->
