### PR TITLE
src: fix x86 instruction set detection

### DIFF
--- a/src/lib/regurgitate/instruction_set_x86.cpp
+++ b/src/lib/regurgitate/instruction_set_x86.cpp
@@ -230,14 +230,17 @@ struct xcr0_bits
         uint64_t data;
     };
 
-    xcr0_bits() { data = read_xcr(0); }
+    xcr0_bits(const cpuid_feature_bits& features)
+    {
+        data = features.ecx.osxsave ? read_xcr(0) : 0;
+    }
 };
 
 bool available(type t)
 {
     auto features = cpuid_feature_bits();
     auto extended = cpuid_extended_bits();
-    auto xcr0 = xcr0_bits();
+    auto xcr0 = xcr0_bits(features);
 
     /*
      * In addition to verifying that the CPU has the necessary instructions,
@@ -255,10 +258,9 @@ bool available(type t)
         /* No checks are needed for auto code */
         return (true);
     case type::SSE2:
-        return (features.ecx.osxsave && xcr0.sse && features.edx.sse2);
+        return (features.edx.sse2);
     case type::SSE4:
-        return (features.ecx.osxsave && xcr0.sse && features.ecx.sse41
-                && features.ecx.sse42);
+        return (features.ecx.sse42);
     case type::AVX:
         return (features.ecx.osxsave && xcr0.sse && xcr0.avx
                 && features.ecx.avx);

--- a/src/lib/spirent_pga/instruction_set_x86.cpp
+++ b/src/lib/spirent_pga/instruction_set_x86.cpp
@@ -230,14 +230,17 @@ struct xcr0_bits
         uint64_t data;
     };
 
-    xcr0_bits() { data = read_xcr(0); }
+    xcr0_bits(const cpuid_feature_bits& features)
+    {
+        data = features.ecx.osxsave ? read_xcr(0) : 0;
+    }
 };
 
 bool available(type t)
 {
     auto features = cpuid_feature_bits();
     auto extended = cpuid_extended_bits();
-    auto xcr0 = xcr0_bits();
+    auto xcr0 = xcr0_bits(features);
 
     /*
      * In addition to verifying that the CPU has the necessary instructions,
@@ -256,10 +259,9 @@ bool available(type t)
         /* No checks are needed for scalar or auto code */
         return (true);
     case type::SSE2:
-        return (features.ecx.osxsave && xcr0.sse && features.edx.sse2);
+        return (features.edx.sse2);
     case type::SSE4:
-        return (features.ecx.osxsave && xcr0.sse && features.ecx.sse41
-                && features.ecx.sse42);
+        return (features.ecx.sse42);
     case type::AVX:
         return (features.ecx.osxsave && xcr0.sse && xcr0.avx
                 && features.ecx.avx);

--- a/src/modules/cpu/instruction_set_x86.cpp
+++ b/src/modules/cpu/instruction_set_x86.cpp
@@ -230,14 +230,18 @@ struct xcr0_bits
         uint64_t data;
     };
 
-    xcr0_bits() { data = read_xcr(0); }
+    xcr0_bits(const cpuid_feature_bits& features)
+    {
+        /* Use the OSXSAVE bit as a proxy for `xgetbv` */
+        data = features.ecx.osxsave ? read_xcr(0) : 0;
+    }
 };
 
 bool available(type t)
 {
     auto features = cpuid_feature_bits();
     auto extended = cpuid_extended_bits();
-    auto xcr0 = xcr0_bits();
+    auto xcr0 = xcr0_bits(features);
 
     /*
      * In addition to verifying that the CPU has the necessary instructions,
@@ -255,10 +259,9 @@ bool available(type t)
         /* No checks are needed for scalar or auto code */
         return (true);
     case type::SSE2:
-        return (features.ecx.osxsave && xcr0.sse && features.edx.sse2);
+        return (features.edx.sse2);
     case type::SSE4:
-        return (features.ecx.osxsave && xcr0.sse && features.ecx.sse41
-                && features.ecx.sse42);
+        return (features.ecx.sse42);
     case type::AVX:
         return (features.ecx.osxsave && xcr0.sse && xcr0.avx
                 && features.ecx.avx);


### PR DESCRIPTION
The `xgetbv` instruction necessary for determining AVX support isn't
available on all processors. Use the OSXSAVE bit as a proxy to determine
if the host CPU supports it or not before attempting to execute it.

Update SSE2/SSE4 detection to not require OSXSAVE, since it could be
unset on platforms with support SSE instructions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/497)
<!-- Reviewable:end -->
