### PR TITLE
Minor fix for building as a DPDK secondary process

### DIFF
--- a/src/modules/packetio/drivers/dpdk/secondary/driver_factory.cpp
+++ b/src/modules/packetio/drivers/dpdk/secondary/driver_factory.cpp
@@ -1,6 +1,6 @@
 #include "packetio/generic_driver.hpp"
 #include "packetio/drivers/dpdk/driver.tcc"
-#include "packetio/drivers/dummy_driver.hpp"
+#include "packetio/drivers/dpdk/dummy_driver.hpp"
 #include "packetio/drivers/dpdk/secondary/eal_process.hpp"
 
 namespace openperf::packetio {
@@ -11,7 +11,7 @@ namespace openperf::packetio::driver {
 
 std::unique_ptr<generic_driver> make()
 {
-    if (config::dpdk::dpdk_disabled()) {
+    if (dpdk::config::dpdk_disabled()) {
         return (std::make_unique<generic_driver>(dpdk::dummy_driver()));
     }
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/499)
<!-- Reviewable:end -->
