### PR TITLE
Add DPDK secondary process build to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,17 @@ jobs:
           paths:
             - project
 
+  build_secondary:
+    docker:
+      - image: spirentorion/openperf:latest
+    steps:
+      - checkout
+      - run:
+          name: Build and generate compilation database
+          command: .circleci/run_build.sh OP_PACKETIO_DPDK_PROCESS_TYPE=secondary
+      - store_artifacts:
+          path: ~/project/build/openperf-linux-x86_64-testing/bin
+
   cross_compile_aarch64:
     docker:
       - image: spirentorion/openperf:latest
@@ -80,6 +91,7 @@ workflows:
   ci_build:
     jobs:
       - build
+      - build_secondary
       - cross_compile_aarch64
       - acceptance_tests:
           requires:

--- a/.circleci/run_build.sh
+++ b/.circleci/run_build.sh
@@ -14,5 +14,6 @@ CI_CORES=$(if [ $(nproc) -gt ${MAX_CORES} ]; then echo ${MAX_CORES}; else echo $
 # compile options will use, if available.
 CI_BUILD_OPTS='-Os -gline-tables-only -march=core-avx2'
 
-# Use bear to generate the compilation database
-bear make -j${CI_CORES} OP_COPTS="${CI_BUILD_OPTS}" all
+# Use bear to generate the compilation database.
+# Treat first CLI argument to this script as additional parameter(s) to make.
+bear make -j${CI_CORES} OP_COPTS="${CI_BUILD_OPTS}" $1 all


### PR DESCRIPTION
Downstream now depends on building OpenPerf as a secondary DPDK process.
Make sure this doesn't break silently.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/502)
<!-- Reviewable:end -->
