### PR TITLE
modules/timesync: improve NTP client behavior

### DIFF
--- a/api/schema/v1/modules/timesync.yaml
+++ b/api/schema/v1/modules/timesync.yaml
@@ -332,6 +332,10 @@ definitions:
         type: object
         description: NTP statistics
         properties:
+          poll_period:
+            type: integer
+            description: Current NTP server poll period, in seconds
+            format: int64
           rx_packets:
             type: integer
             description: Received packets

--- a/src/modules/timesync/api.hpp
+++ b/src/modules/timesync/api.hpp
@@ -107,6 +107,7 @@ struct time_source_config_ntp
 
 struct time_source_stats_ntp
 {
+    std::chrono::seconds poll_period;
     int64_t rx_packets;
     int64_t tx_packets;
     std::optional<uint8_t> stratum;

--- a/src/modules/timesync/api_transmogrify.cpp
+++ b/src/modules/timesync/api_transmogrify.cpp
@@ -230,6 +230,7 @@ to_swagger(const time_source_stats_ntp& src)
     using TimeSourceStats_ntp = swagger::v1::model::TimeSourceStats_ntp;
     auto ntp_stats = std::make_shared<TimeSourceStats_ntp>();
 
+    ntp_stats->setPollPeriod(src.poll_period.count());
     ntp_stats->setRxPackets(src.rx_packets);
     ntp_stats->setTxPackets(src.tx_packets);
     if (src.stratum) { ntp_stats->setStratum(*src.stratum); }

--- a/src/modules/timesync/ntp.hpp
+++ b/src/modules/timesync/ntp.hpp
@@ -28,6 +28,12 @@ enum class mode {
     MODE_MODE7 = 7,
 };
 
+enum class kiss_code {
+    KISS_DENY = 0x44454e59,
+    KISS_RATE = 0x52415445,
+    KISS_RSTR = 0x52535452,
+};
+
 struct packet
 {
     leap_status leap;

--- a/src/modules/timesync/server.hpp
+++ b/src/modules/timesync/server.hpp
@@ -26,6 +26,7 @@ struct ntp_server_state
     unsigned poll_loop_id = 0;
     struct
     {
+        std::chrono::seconds poll_period = 64s;
         unsigned rx = 0;
         unsigned tx = 0;
         std::optional<uint8_t> stratum = std::nullopt; /* unsynchronized */

--- a/src/swagger/v1/model/TimeSourceStats_ntp.cpp
+++ b/src/swagger/v1/model/TimeSourceStats_ntp.cpp
@@ -19,6 +19,8 @@ namespace model {
 
 TimeSourceStats_ntp::TimeSourceStats_ntp()
 {
+    m_Poll_period = 0L;
+    m_Poll_periodIsSet = false;
     m_Rx_packets = 0L;
     m_Tx_packets = 0L;
     m_Stratum = 0;
@@ -39,6 +41,10 @@ nlohmann::json TimeSourceStats_ntp::toJson() const
 {
     nlohmann::json val = nlohmann::json::object();
 
+    if(m_Poll_periodIsSet)
+    {
+        val["poll_period"] = m_Poll_period;
+    }
     val["rx_packets"] = m_Rx_packets;
     val["tx_packets"] = m_Tx_packets;
     if(m_StratumIsSet)
@@ -52,6 +58,10 @@ nlohmann::json TimeSourceStats_ntp::toJson() const
 
 void TimeSourceStats_ntp::fromJson(nlohmann::json& val)
 {
+    if(val.find("poll_period") != val.end())
+    {
+        setPollPeriod(val.at("poll_period"));
+    }
     setRxPackets(val.at("rx_packets"));
     setTxPackets(val.at("tx_packets"));
     if(val.find("stratum") != val.end())
@@ -62,6 +72,23 @@ void TimeSourceStats_ntp::fromJson(nlohmann::json& val)
 }
 
 
+int64_t TimeSourceStats_ntp::getPollPeriod() const
+{
+    return m_Poll_period;
+}
+void TimeSourceStats_ntp::setPollPeriod(int64_t value)
+{
+    m_Poll_period = value;
+    m_Poll_periodIsSet = true;
+}
+bool TimeSourceStats_ntp::pollPeriodIsSet() const
+{
+    return m_Poll_periodIsSet;
+}
+void TimeSourceStats_ntp::unsetPoll_period()
+{
+    m_Poll_periodIsSet = false;
+}
 int64_t TimeSourceStats_ntp::getRxPackets() const
 {
     return m_Rx_packets;

--- a/src/swagger/v1/model/TimeSourceStats_ntp.h
+++ b/src/swagger/v1/model/TimeSourceStats_ntp.h
@@ -48,6 +48,13 @@ public:
     /// TimeSourceStats_ntp members
 
     /// <summary>
+    /// Current NTP server poll period, in seconds
+    /// </summary>
+    int64_t getPollPeriod() const;
+    void setPollPeriod(int64_t value);
+    bool pollPeriodIsSet() const;
+    void unsetPoll_period();
+    /// <summary>
     /// Received packets
     /// </summary>
     int64_t getRxPackets() const;
@@ -66,6 +73,8 @@ public:
     void unsetStratum();
 
 protected:
+    int64_t m_Poll_period;
+    bool m_Poll_periodIsSet;
     int64_t m_Rx_packets;
 
     int64_t m_Tx_packets;

--- a/tests/aat/api/v1/client/models/time_source_stats_ntp.py
+++ b/tests/aat/api/v1/client/models/time_source_stats_ntp.py
@@ -31,29 +31,56 @@ class TimeSourceStatsNtp(object):
                             and the value is json key in definition.
     """
     swagger_types = {
+        'poll_period': 'int',
         'rx_packets': 'int',
         'tx_packets': 'int',
         'stratum': 'int'
     }
 
     attribute_map = {
+        'poll_period': 'poll_period',
         'rx_packets': 'rx_packets',
         'tx_packets': 'tx_packets',
         'stratum': 'stratum'
     }
 
-    def __init__(self, rx_packets=None, tx_packets=None, stratum=None):  # noqa: E501
+    def __init__(self, poll_period=None, rx_packets=None, tx_packets=None, stratum=None):  # noqa: E501
         """TimeSourceStatsNtp - a model defined in Swagger"""  # noqa: E501
 
+        self._poll_period = None
         self._rx_packets = None
         self._tx_packets = None
         self._stratum = None
         self.discriminator = None
 
+        if poll_period is not None:
+            self.poll_period = poll_period
         self.rx_packets = rx_packets
         self.tx_packets = tx_packets
         if stratum is not None:
             self.stratum = stratum
+
+    @property
+    def poll_period(self):
+        """Gets the poll_period of this TimeSourceStatsNtp.  # noqa: E501
+
+        Current NTP server poll period, in seconds  # noqa: E501
+
+        :return: The poll_period of this TimeSourceStatsNtp.  # noqa: E501
+        :rtype: int
+        """
+        return self._poll_period
+
+    @poll_period.setter
+    def poll_period(self, poll_period):
+        """Sets the poll_period of this TimeSourceStatsNtp.
+
+        Current NTP server poll period, in seconds  # noqa: E501
+
+        :param poll_period: The poll_period of this TimeSourceStatsNtp.  # noqa: E501
+        :type: int
+        """
+        self._poll_period = poll_period
 
     @property
     def rx_packets(self):

--- a/tests/aat/api/v1/docs/TimeSourceStatsNtp.md
+++ b/tests/aat/api/v1/docs/TimeSourceStatsNtp.md
@@ -3,6 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**poll_period** | **int** | Current NTP server poll period, in seconds | [optional] 
 **rx_packets** | **int** | Received packets | 
 **tx_packets** | **int** | Transmitted packets | 
 **stratum** | **int** | Time source distance from a NTP reference clock, in network hops.  | [optional] 


### PR DESCRIPTION
Update the NTP client to respond appropriately to server KISS codes, as
specified in RFC 5905.

Add the current poll period to ntp source stats.

Resolves issue #503.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/504)
<!-- Reviewable:end -->
