### PR TITLE
packet/analyzer: add header key to translation code

### DIFF
--- a/src/modules/packet/analyzer/statistics/utils.cpp
+++ b/src/modules/packet/analyzer/statistics/utils.cpp
@@ -42,6 +42,7 @@ static constexpr auto flow_counter_pairs =
     associative_array<flow_counter_flags, std::string_view>(
         std::pair(flow_counter_flags::frame_count, "frame_count"),
         std::pair(flow_counter_flags::frame_length, "frame_length"),
+        std::pair(flow_counter_flags::header, "header"),
         std::pair(flow_counter_flags::interarrival, "interarrival_time"),
         std::pair(flow_counter_flags::jitter_ipdv, "jitter_ipdv"),
         std::pair(flow_counter_flags::jitter_rfc, "jitter_rfc"),

--- a/tests/aat/common/matcher/packet_analyzer.py
+++ b/tests/aat/common/matcher/packet_analyzer.py
@@ -64,6 +64,10 @@ class _be_valid_packet_analyzer_flow_counter(Matcher):
                          + counters.sequence.reordered
                          + counters.sequence.in_order)
                 expect(total).to(equal(counters.frame_count))
+            if counters.headers:
+                expect(counters.headers).not_to(be_empty)
+                for header in counters.headers:
+                    expect(header).to(be_a(client.models.PacketAnalyzerFlowHeader))
 
         if counters.frame_count > 1:
             if counters.interarrival:

--- a/tests/aat/spec/packet_back_to_back_spec.py
+++ b/tests/aat/spec/packet_back_to_back_spec.py
@@ -193,7 +193,7 @@ ANALYZER_CONFIG_NO_SIGS = {
 
 ANALYZER_CONFIG_SIGS = {
     'protocol': ['ethernet', 'ip', 'transport'],
-    'counters': ['frame_count', 'frame_length', 'interarrival_time',
+    'counters': ['frame_count', 'frame_length', 'header', 'interarrival_time',
                  'jitter_ipdv', 'jitter_rfc', 'latency', 'advanced_sequencing'],
     'digests': ['frame_length', 'interarrival_time', 'jitter_ipdv',
                 'jitter_rfc', 'latency', 'sequence_run_length']


### PR DESCRIPTION
Oops. The digest merge inadvertently removed the header string to enum
mapping required to configure header flow counters from swagger. Hence,
add the missing mapping back.

Additionally, update the AAT tests to actually use the header result so
we can't inadvertently drop it again. Update the matcher to check for
valid headers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/505)
<!-- Reviewable:end -->
