### PR TITLE
api: clarify error units for time-keeper object

### DIFF
--- a/api/client/golang/models/time_keeper.go
+++ b/api/client/golang/models/time_keeper.go
@@ -21,7 +21,7 @@ import (
 // swagger:model TimeKeeper
 type TimeKeeper struct {
 
-	// The current maximum error in the time calculation
+	// The current maximum error in the time calculation, in seconds.
 	// Required: true
 	MaximumError *float64 `json:"maximum_error"`
 

--- a/api/client/golang/models/time_source_stats.go
+++ b/api/client/golang/models/time_source_stats.go
@@ -105,6 +105,9 @@ func (m *TimeSourceStats) UnmarshalBinary(b []byte) error {
 // swagger:model TimeSourceStatsNtp
 type TimeSourceStatsNtp struct {
 
+	// Current NTP server poll period, in seconds
+	PollPeriod int64 `json:"poll_period,omitempty"`
+
 	// Received packets
 	// Required: true
 	RxPackets *int64 `json:"rx_packets"`

--- a/api/schema/v1/modules/timesync.yaml
+++ b/api/schema/v1/modules/timesync.yaml
@@ -282,7 +282,7 @@ definitions:
     properties:
       maximum_error:
         type: number
-        description: The current maximum error in the time calculation
+        description: The current maximum error in the time calculation, in seconds.
         format: double
       state:
         $ref: "#/definitions/TimeKeeperState"

--- a/src/swagger/v1/model/TimeKeeper.h
+++ b/src/swagger/v1/model/TimeKeeper.h
@@ -51,7 +51,7 @@ public:
     /// TimeKeeper members
 
     /// <summary>
-    /// The current maximum error in the time calculation
+    /// The current maximum error in the time calculation, in seconds.
     /// </summary>
     double getMaximumError() const;
     void setMaximumError(double value);

--- a/tests/aat/api/v1/client/models/time_keeper.py
+++ b/tests/aat/api/v1/client/models/time_keeper.py
@@ -70,7 +70,7 @@ class TimeKeeper(object):
     def maximum_error(self):
         """Gets the maximum_error of this TimeKeeper.  # noqa: E501
 
-        The current maximum error in the time calculation  # noqa: E501
+        The current maximum error in the time calculation, in seconds.  # noqa: E501
 
         :return: The maximum_error of this TimeKeeper.  # noqa: E501
         :rtype: float
@@ -81,7 +81,7 @@ class TimeKeeper(object):
     def maximum_error(self, maximum_error):
         """Sets the maximum_error of this TimeKeeper.
 
-        The current maximum error in the time calculation  # noqa: E501
+        The current maximum error in the time calculation, in seconds.  # noqa: E501
 
         :param maximum_error: The maximum_error of this TimeKeeper.  # noqa: E501
         :type: float

--- a/tests/aat/api/v1/docs/TimeKeeper.md
+++ b/tests/aat/api/v1/docs/TimeKeeper.md
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**maximum_error** | **float** | The current maximum error in the time calculation | 
+**maximum_error** | **float** | The current maximum error in the time calculation, in seconds. | 
 **state** | [**TimeKeeperState**](TimeKeeperState.md) |  | 
 **stats** | [**TimeKeeperStats**](TimeKeeperStats.md) |  | 
 **time** | **datetime** | The current time and date in ISO8601 format | 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/507)
<!-- Reviewable:end -->
