### PR TITLE
Minor update to packet generator learning code

### DIFF
--- a/src/modules/packet/generator/learning.cpp
+++ b/src/modules/packet/generator/learning.cpp
@@ -73,7 +73,7 @@ static err_t send_ipv4_learning_requests(start_learning_params& slp)
                 OP_LOG(OP_LOG_ERROR,
                        "Error (%s) encountered while requesting ARP for "
                        "address: %s",
-                       lwip_strerr(result),
+                       strerror(err_to_errno(result)),
                        to_string(addr_pair.first).c_str());
                 overall_result = result;
             }


### PR DESCRIPTION
Remove lwip_strerr() since it's a no-op unless LWIP_DEBUG
is defined.
Replaced with LwIP's internal error code -> errno mapping
and a call to good ol strerror().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/508)
<!-- Reviewable:end -->
