### PR TITLE
Improve CPU type mapping for DPDK builds

### DIFF
--- a/mk/dpdk.mk
+++ b/mk/dpdk.mk
@@ -41,7 +41,7 @@ else
 endif
 
 ifeq (,$(wildcard $(DPDK_SRC_DIR)/mk/machine/$(OP_MACHINE_ARCH)))
-	DPDK_MACHINE := default # No explicit match
+	DPDK_MACHINE := $(shell $(OP_ROOT)/mk/dpdk_cpu.sh $(OP_MACHINE_ARCH))
 else
 	DPDK_MACHINE := $(OP_MACHINE_ARCH)
 endif

--- a/mk/dpdk_cpu.sh
+++ b/mk/dpdk_cpu.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Script to map -march values to DPDK machine types.
+# DPDK supports a limited subset of values.
+# See contents of deps/dpdk/mk/machine.
+
+arch=`echo "$1" | tr '[:upper:]' '[:lower:]'`
+
+case $arch in
+
+    sandybridge)
+        echo "snb" ;;
+    ivybridge)
+        echo "ivb" ;;
+    haswell | broadwell)
+        echo "hsw" ;;
+    native)
+        echo "native" ;;
+
+    *)
+        echo "default" ;;
+
+esac


### PR DESCRIPTION
DPDK uses a unique set of CPU identifiers.
This change maps "standard" -march values to DPDK's unique values.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/511)
<!-- Reviewable:end -->
