### PR TITLE
packet/generator: fix octet load calculation

### DIFF
--- a/src/modules/packet/generator/source_transmogrify.cpp
+++ b/src/modules/packet/generator/source_transmogrify.cpp
@@ -416,7 +416,7 @@ source_load to_load(const swagger::v1::model::TrafficLoad& load,
 
     if (api::to_load_type(load.getUnits()) == api::load_type::octets) {
         /* Divide rate value by average frame size to get frames/hour */
-        rate = rate * sequence.sum_packet_lengths() / sequence.size();
+        rate = rate * sequence.size() / sequence.sum_packet_lengths();
     }
 
     using burst_type = decltype(std::declval<source_load>().burst_size);


### PR DESCRIPTION
Oops. When using octets for the load specification units, the code
multiplied by the average frame size instead of dividing. Fix it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/517)
<!-- Reviewable:end -->
