### PR TITLE
Packetio fixups

### DIFF
--- a/src/framework/utils/associative_array.hpp
+++ b/src/framework/utils/associative_array.hpp
@@ -1,0 +1,53 @@
+#ifndef _OP_UTILS_ASSOCIATIVE_ARRAY_HPP_
+#define _OP_UTILS_ASSOCIATIVE_ARRAY_HPP_
+
+#include <array>
+#include <optional>
+#include <utility>
+
+namespace openperf::utils {
+
+template <typename Key, typename Value, typename... Pairs>
+constexpr auto associative_array(Pairs&&... pairs)
+    -> std::array<std::pair<Key, Value>, sizeof...(pairs)>
+{
+    return {{std::forward<Pairs>(pairs)...}};
+}
+
+template <typename AssociativeArray,
+          typename Key = decltype(
+              std::declval<typename AssociativeArray::value_type>().first),
+          typename Value = decltype(
+              std::declval<typename AssociativeArray::value_type>().second)>
+constexpr std::optional<Value> key_to_value(const AssociativeArray& array,
+                                            const Key& key)
+{
+    auto cursor = std::begin(array), end = std::end(array);
+    while (cursor != end) {
+        if (cursor->first == key) { return (cursor->second); }
+        cursor++;
+    }
+
+    return (std::nullopt);
+}
+
+template <typename AssociativeArray,
+          typename Key = decltype(
+              std::declval<typename AssociativeArray::value_type>().first),
+          typename Value = decltype(
+              std::declval<typename AssociativeArray::value_type>().second)>
+constexpr std::optional<Key> value_to_key(const AssociativeArray& array,
+                                          const Value& value)
+{
+    auto cursor = std::begin(array), end = std::end(array);
+    while (cursor != end) {
+        if (cursor->second == value) { return (cursor->first); }
+        cursor++;
+    }
+
+    return (std::nullopt);
+}
+
+} // namespace openperf::utils
+
+#endif /* _OP_UTILS_ASSOCIATIVE_ARRAY_HPP_ */

--- a/src/modules/packetio/drivers/dpdk/arg_parser.hpp
+++ b/src/modules/packetio/drivers/dpdk/arg_parser.hpp
@@ -57,6 +57,9 @@ inline void add_dpdk_argument(std::vector<std::string>& args,
     }
 }
 
+bool dpdk_disable_lro();
+bool dpdk_disable_rx_irq();
+
 } /* namespace openperf::packetio::dpdk::config */
 
 #endif /* _OP_PACKETIO_DPDK_ARG_PARSER_HPP_ */

--- a/src/modules/packetio/drivers/dpdk/directory.mk
+++ b/src/modules/packetio/drivers/dpdk/directory.mk
@@ -20,6 +20,7 @@ PIO_DRIVER_SOURCES += \
 	port/signature_utils.cpp \
 	port/timestamper.cpp \
 	queue_utils.cpp \
+	quirks.cpp \
 	topology_utils.cpp
 
 ifeq ($(OP_PACKETIO_DPDK_PROCESS_TYPE),primary)

--- a/src/modules/packetio/drivers/dpdk/driver.hpp
+++ b/src/modules/packetio/drivers/dpdk/driver.hpp
@@ -41,9 +41,6 @@ public:
     create_port(std::string_view id, const port::config_data& config);
     tl::expected<void, std::string> delete_port(std::string_view id);
 
-    void start_all_ports();
-    void stop_all_ports();
-
     bool is_usable();
 
     using port_id_map = std::map<uint16_t, std::string>;

--- a/src/modules/packetio/drivers/dpdk/driver.tcc
+++ b/src/modules/packetio/drivers/dpdk/driver.tcc
@@ -303,17 +303,25 @@ template <typename ProcessType> driver<ProcessType>::driver()
                   std::end(m_ethdev_ports),
                   [](const auto& item) { log_port(item.first, item.second); });
 
-    /* Finally, setup mbuf signature/offload flags */
+    /* Setup mbuf signature/offload flags */
     mbuf_signature_init();
     mbuf_rx_prbs_init();
     mbuf_tx_init();
+
+    /* Finally, start all ports */
+    std::for_each(
+        std::begin(m_ethdev_ports),
+        std::end(m_ethdev_ports),
+        [this](const auto& pair) { m_process->start_port(pair.first); });
 }
 
 template <typename ProcessType> driver<ProcessType>::~driver()
 {
-    if (m_ethdev_ports.empty()) { return; }
-
-    stop_all_ports();
+    /* Stop all ports */
+    std::for_each(
+        std::begin(m_ethdev_ports),
+        std::end(m_ethdev_ports),
+        [this](const auto& pair) { m_process->stop_port(pair.first); });
 }
 
 template <typename ProcessType>
@@ -479,22 +487,6 @@ driver<ProcessType>::delete_port(std::string_view id)
     m_bonded_ports.erase(port_idx);
     m_ethdev_ports.erase(port_idx);
     return {};
-}
-
-template <typename ProcessType> void driver<ProcessType>::start_all_ports()
-{
-    std::for_each(
-        std::begin(m_ethdev_ports),
-        std::end(m_ethdev_ports),
-        [this](const auto& pair) { m_process->start_port(pair.first); });
-}
-
-template <typename ProcessType> void driver<ProcessType>::stop_all_ports()
-{
-    std::for_each(
-        std::begin(m_ethdev_ports),
-        std::end(m_ethdev_ports),
-        [this](const auto& pair) { m_process->stop_port(pair.first); });
 }
 
 template <typename ProcessType> bool driver<ProcessType>::is_usable()

--- a/src/modules/packetio/drivers/dpdk/dummy_driver.hpp
+++ b/src/modules/packetio/drivers/dpdk/dummy_driver.hpp
@@ -39,10 +39,6 @@ public:
             tl::make_unexpected("Dummy driver does not support port deletion"));
     }
 
-    void start_all_ports() {}
-
-    void stop_all_ports() {}
-
     bool is_usable() { return (false); }
 };
 

--- a/src/modules/packetio/drivers/dpdk/names.hpp
+++ b/src/modules/packetio/drivers/dpdk/names.hpp
@@ -1,0 +1,14 @@
+#ifndef _OP_PACKETIO_DRIVER_DPDK_NAMES_HPP_
+#define _OP_PACKETIO_DRIVER_DPDK_NAMES_HPP_
+
+#include <string>
+
+namespace openperf::packetio::dpdk::driver_names {
+
+inline constexpr std::string_view ring = "net_ring";
+inline constexpr std::string_view virtio = "net_virtio";
+inline constexpr std::string_view mlx5 = "net_mlx5";
+
+} // namespace openperf::packetio::dpdk::driver_names
+
+#endif /* _OP_PACKETIO_DRIVER_DPDK_NAMES_HPP_ */

--- a/src/modules/packetio/drivers/dpdk/port/net_ring_fixup.cpp
+++ b/src/modules/packetio/drivers/dpdk/port/net_ring_fixup.cpp
@@ -1,8 +1,9 @@
 #include <cstring>
 
+#include "packetio/drivers/dpdk/mbuf_tx.hpp"
+#include "packetio/drivers/dpdk/names.hpp"
 #include "packetio/drivers/dpdk/port/net_ring_fixup.hpp"
 #include "packetio/drivers/dpdk/port_info.hpp"
-#include "packetio/drivers/dpdk/mbuf_tx.hpp"
 
 namespace openperf::packetio::dpdk::port {
 

--- a/src/modules/packetio/drivers/dpdk/port_info.cpp
+++ b/src/modules/packetio/drivers/dpdk/port_info.cpp
@@ -5,6 +5,7 @@
 #include <net/if.h>
 
 #include "packetio/drivers/dpdk/port_info.hpp"
+#include "packetio/drivers/dpdk/quirks.hpp"
 
 namespace openperf::packetio::dpdk::port_info {
 
@@ -48,18 +49,21 @@ libpacket::type::mac_address mac_address(uint16_t port_id)
 
 uint32_t max_rx_pktlen(uint16_t port_id)
 {
-    /*
-     * XXX: The E1000 driver can't actually use the maximum value, 16383, it
-     * advertises. So, we just clamp the value here to prevent issues.
-     * If 9k frames are insufficient, adjust as necessary.
-     */
-    return (std::min(
-        9 * 1024U, get_info_field(port_id, &rte_eth_dev_info::max_rx_pktlen)));
+    return (
+        std::min(quirks::sane_max_rx_pktlen(port_id),
+                 get_info_field(port_id, &rte_eth_dev_info::max_rx_pktlen)));
 }
 
 uint32_t max_lro_pkt_size(uint16_t port_id)
 {
-    return (get_info_field(port_id, &rte_eth_dev_info::max_lro_pkt_size));
+    /*
+     * If the driver doesn't property offload scatter, then we need
+     * to limit LRO size to the packet size in order to preserve
+     * fast packet processing.
+     */
+    return (rx_offloads(port_id) & DEV_RX_OFFLOAD_SCATTER
+                ? get_info_field(port_id, &rte_eth_dev_info::max_lro_pkt_size)
+                : max_rx_pktlen(port_id));
 }
 
 uint32_t max_mac_addrs(uint16_t port_id)
@@ -109,32 +113,26 @@ uint32_t max_speed(uint16_t port_id)
 
 uint64_t rx_offloads(uint16_t port_id)
 {
-    return (get_info_field(port_id, &rte_eth_dev_info::rx_offload_capa));
+    return (get_info_field(port_id, &rte_eth_dev_info::rx_offload_capa)
+            & ~quirks::slow_rx_offloads(port_id));
 }
 
 uint64_t tx_offloads(uint16_t port_id)
 {
-    auto driver = driver_name(port_id);
-    if (driver == driver_names::virtio) {
-        // virtio doesn't handle Tx TCP/UDP checksum offloads correctly
-        return 0;
-    }
-    return (get_info_field(port_id, &rte_eth_dev_info::tx_offload_capa));
+    return (get_info_field(port_id, &rte_eth_dev_info::tx_offload_capa)
+            & ~quirks::slow_tx_offloads(port_id));
 }
 
 uint64_t rss_offloads(uint16_t port_id)
 {
-    return (get_info_field(port_id, &rte_eth_dev_info::flow_type_rss_offloads));
+    return (rx_offloads(port_id) & DEV_RX_OFFLOAD_RSS_HASH ? get_info_field(
+                port_id, &rte_eth_dev_info::flow_type_rss_offloads)
+                                                           : 0);
 }
 
 enum rte_eth_rx_mq_mode rx_mq_mode(uint16_t port_id)
 {
-    auto driver = driver_name(port_id);
-    if (driver == driver_names::virtio) {
-        return ETH_MQ_RX_NONE;
-    } else {
-        return ETH_MQ_RX_RSS;
-    }
+    return (rx_queue_max(port_id) == 1 ? ETH_MQ_RX_NONE : ETH_MQ_RX_RSS);
 }
 
 uint16_t rx_queue_count(uint16_t port_id)

--- a/src/modules/packetio/drivers/dpdk/port_info.hpp
+++ b/src/modules/packetio/drivers/dpdk/port_info.hpp
@@ -8,13 +8,6 @@
 #include "lib/packet/type/mac_address.hpp"
 #include "packetio/drivers/dpdk/dpdk.h"
 
-namespace openperf::packetio::dpdk::driver_names {
-
-inline constexpr std::string_view ring = "net_ring";
-inline constexpr std::string_view virtio = "net_virtio";
-
-} // namespace openperf::packetio::dpdk::driver_names
-
 namespace openperf::packetio::dpdk::port_info {
 
 unsigned socket_id(uint16_t port_id);
@@ -53,7 +46,6 @@ rte_eth_txconf default_txconf(uint16_t port_id);
 uint16_t tx_tso_segment_max(uint16_t port_id);
 
 bool lsc_interrupt(uint16_t port_id);
-bool rxq_interrupt(uint16_t port_id);
 
 template <typename T>
 static T get_info_field(int id, T rte_eth_dev_info::*field)

--- a/src/modules/packetio/drivers/dpdk/primary/arg_parser.cpp
+++ b/src/modules/packetio/drivers/dpdk/primary/arg_parser.cpp
@@ -34,4 +34,20 @@ bool dpdk_test_mode()
     return (result.value_or(false));
 }
 
+bool dpdk_disable_lro()
+{
+    auto no_lro = config::file::op_config_get_param<OP_OPTION_TYPE_NONE>(
+                      op_packetio_dpdk_no_lro)
+                      .value_or(false);
+    return (no_lro);
+}
+
+bool dpdk_disable_rx_irq()
+{
+    auto no_rx_irqs = config::file::op_config_get_param<OP_OPTION_TYPE_NONE>(
+                          op_packetio_dpdk_no_rx_irqs)
+                          .value_or(false);
+    return (no_rx_irqs);
+}
+
 } // namespace openperf::packetio::dpdk::config

--- a/src/modules/packetio/drivers/dpdk/primary/port_info.cpp
+++ b/src/modules/packetio/drivers/dpdk/primary/port_info.cpp
@@ -37,27 +37,14 @@ uint16_t tx_queue_default(uint16_t port_id)
 
 bool lsc_interrupt(uint16_t port_id)
 {
-    auto result =
+    auto no_lsc_irq =
         openperf::config::file::op_config_get_param<OP_OPTION_TYPE_NONE>(
-            op_packetio_dpdk_no_link_irqs);
-    if (result.value_or(false)) return false;
+            op_packetio_dpdk_no_link_irqs)
+            .value_or(false);
+    if (no_lsc_irq) { return (false); }
+
     return (*(get_info_field(port_id, &rte_eth_dev_info::dev_flags))
             & RTE_ETH_DEV_INTR_LSC);
-}
-
-bool rxq_interrupt(uint16_t)
-{
-    /*
-     * There seems to be no programatic way to determine whether a device
-     * supports rx queue interrupts or not, so we attempt to enable them on
-     * everything, unless the user says otherwise.  Run-time errors will disable
-     * them.
-     */
-    auto result =
-        openperf::config::file::op_config_get_param<OP_OPTION_TYPE_NONE>(
-            op_packetio_dpdk_no_rx_irqs);
-    /* XXX: A negative times a negative equals a positive. Say it! */
-    return (!result.value_or(false));
 }
 
 } // namespace openperf::packetio::dpdk::port_info

--- a/src/modules/packetio/drivers/dpdk/primary/utils.cpp
+++ b/src/modules/packetio/drivers/dpdk/primary/utils.cpp
@@ -1,6 +1,7 @@
 #include "config/op_config_file.hpp"
 #include "packetio/drivers/dpdk/dpdk.h"
 #include "packetio/drivers/dpdk/port_info.hpp"
+#include "packetio/drivers/dpdk/quirks.hpp"
 #include "packetio/drivers/dpdk/primary/arg_parser.hpp"
 #include "packetio/drivers/dpdk/primary/utils.hpp"
 
@@ -97,11 +98,7 @@ static uint32_t eth_link_speed_flag(port::link_speed speed,
 
 static uint64_t lro_flag()
 {
-    auto disable_lro =
-        openperf::config::file::op_config_get_param<OP_OPTION_TYPE_NONE>(
-            op_packetio_dpdk_no_lro)
-            .value_or(false);
-    return (disable_lro ? 0 : DEV_RX_OFFLOAD_TCP_LRO);
+    return (config::dpdk_disable_lro() ? 0 : DEV_RX_OFFLOAD_TCP_LRO);
 }
 
 static uint64_t filter_rx_offloads(uint64_t rx_capa)
@@ -126,8 +123,10 @@ static rte_eth_conf make_rte_eth_conf(uint16_t port_id)
         .rxmode =
             {
                 .mq_mode = port_info::rx_mq_mode(port_id),
-                .max_rx_pkt_len = port_info::max_rx_pktlen(port_id),
-                .max_lro_pkt_size = port_info::max_lro_pkt_size(port_id),
+                .max_rx_pkt_len = port_info::max_rx_pktlen(port_id)
+                                  - quirks::adjust_max_rx_pktlen(port_id),
+                .max_lro_pkt_size = port_info::max_lro_pkt_size(port_id)
+                                    - quirks::adjust_max_rx_pktlen(port_id),
                 .offloads = filter_rx_offloads(port_info::rx_offloads(port_id)),
             },
         .txmode =
@@ -145,7 +144,7 @@ static rte_eth_conf make_rte_eth_conf(uint16_t port_id)
         .tx_adv_conf = {},
         .fdir_conf = {},
         .intr_conf = {.lsc = !!port_info::lsc_interrupt(port_id),
-                      .rxq = !!port_info::rxq_interrupt(port_id)}};
+                      .rxq = !config::dpdk_disable_rx_irq()}};
 }
 
 static tl::expected<void, std::string>

--- a/src/modules/packetio/drivers/dpdk/quirks.cpp
+++ b/src/modules/packetio/drivers/dpdk/quirks.cpp
@@ -1,0 +1,58 @@
+#include "packetio/drivers/dpdk/names.hpp"
+#include "packetio/drivers/dpdk/port_info.hpp"
+#include "packetio/drivers/dpdk/quirks.hpp"
+#include "utils/associative_array.hpp"
+
+namespace openperf::packetio::dpdk::quirks {
+
+namespace detail {
+
+constexpr auto adjust_rx_pktlens =
+    utils::associative_array<std::string_view, uint16_t>(
+        std::pair(driver_names::mlx5, RTE_PKTMBUF_HEADROOM));
+
+constexpr auto sane_rx_pktlens =
+    utils::associative_array<std::string_view, uint32_t>(
+        std::pair(driver_names::ring, RTE_MBUF_DEFAULT_BUF_SIZE));
+
+constexpr auto slow_rx_offloads =
+    utils::associative_array<std::string_view, uint64_t>(
+        std::pair(driver_names::mlx5, DEV_RX_OFFLOAD_SCATTER),
+        std::pair(driver_names::virtio, DEV_RX_OFFLOAD_RSS_HASH));
+
+constexpr auto slow_tx_offloads =
+    utils::associative_array<std::string_view, uint64_t>(
+        std::pair(driver_names::virtio,
+                  DEV_TX_OFFLOAD_TCP_CKSUM | DEV_TX_OFFLOAD_UDP_CKSUM));
+
+} // namespace detail
+
+uint16_t adjust_max_rx_pktlen(uint16_t port_id)
+{
+    return (utils::key_to_value(detail::adjust_rx_pktlens,
+                                port_info::driver_name(port_id))
+                .value_or(0));
+}
+
+uint32_t sane_max_rx_pktlen(uint16_t port_id)
+{
+    return (utils::key_to_value(detail::sane_rx_pktlens,
+                                port_info::driver_name(port_id))
+                .value_or(1024 * 9));
+}
+
+uint64_t slow_rx_offloads(uint16_t port_id)
+{
+    return (utils::key_to_value(detail::slow_rx_offloads,
+                                port_info::driver_name(port_id))
+                .value_or(0));
+}
+
+uint64_t slow_tx_offloads(uint16_t port_id)
+{
+    return (utils::key_to_value(detail::slow_tx_offloads,
+                                port_info::driver_name(port_id))
+                .value_or(0));
+}
+
+} // namespace openperf::packetio::dpdk::quirks

--- a/src/modules/packetio/drivers/dpdk/quirks.hpp
+++ b/src/modules/packetio/drivers/dpdk/quirks.hpp
@@ -1,0 +1,38 @@
+#ifndef _OP_PACKETIO_DRIVER_DPDK_QUIRKS_HPP_
+#define _OP_PACKETIO_DRIVER_DPDK_QUIRKS_HPP_
+
+#include <cstdint>
+
+namespace openperf::packetio::dpdk::quirks {
+
+/*
+ * Provide a single location for enumerating problematic
+ * driver behavior. While drivers have a common API, they
+ * tend to have quirky behavior which requires adjustment.
+ * The intent is to capture all of this quirkiness here.
+ */
+
+/*
+ * Adjust configured packet lengths when configuring queues.
+ * Drivers don't use the dataroom/headroom split in DPDK consistently.
+ */
+uint16_t adjust_max_rx_pktlen(uint16_t port_id);
+
+/*
+ * Override the reported max packet length. Some drivers outright lie
+ * about the packet sizes they support while others report ridiculous
+ * values.
+ */
+uint32_t sane_max_rx_pktlen(uint16_t port_id);
+
+/*
+ * Specify offloads that are technically supported by the driver
+ * but are undesirable, e.g. an offload that disables vectorized
+ * packet processing.
+ */
+uint64_t slow_rx_offloads(uint16_t port_id);
+uint64_t slow_tx_offloads(uint16_t port_id);
+
+} // namespace openperf::packetio::dpdk::quirks
+
+#endif /* _OP_PACKETIO_DRIVER_DPDK_QUIRKS_HPP_ */

--- a/src/modules/packetio/drivers/dpdk/secondary/arg_parser.cpp
+++ b/src/modules/packetio/drivers/dpdk/secondary/arg_parser.cpp
@@ -103,4 +103,8 @@ std::map<uint16_t, std::vector<uint16_t>> tx_port_queues()
     return (get_port_queues(op_packetio_dpdk_tx_queues));
 }
 
+bool dpdk_disable_lro() { return (true); }
+
+bool dpdk_disable_rx_irq() { return (true); }
+
 } // namespace openperf::packetio::dpdk::config

--- a/src/modules/packetio/drivers/dpdk/secondary/port_info.cpp
+++ b/src/modules/packetio/drivers/dpdk/secondary/port_info.cpp
@@ -24,8 +24,6 @@ uint16_t tx_queue_default(uint16_t port_id)
     return (tx_queue_count(port_id));
 }
 
-bool lsc_interrupt(uint16_t port_id) { return (false); }
-
-bool rxq_interrupt(uint16_t) { return (false); }
+bool lsc_interrupt(uint16_t) { return (false); }
 
 } // namespace openperf::packetio::dpdk::port_info

--- a/src/modules/packetio/generic_driver.hpp
+++ b/src/modules/packetio/generic_driver.hpp
@@ -43,10 +43,6 @@ public:
         return m_self->delete_port(id);
     }
 
-    void start_all_ports() { return m_self->start_all_ports(); }
-
-    void stop_all_ports() { return m_self->stop_all_ports(); }
-
     bool is_usable() { return m_self->is_usable(); }
 
 private:
@@ -61,8 +57,6 @@ private:
         create_port(std::string_view id, const port::config_data& config) = 0;
         virtual tl::expected<void, std::string>
         delete_port(std::string_view id) = 0;
-        virtual void start_all_ports() = 0;
-        virtual void stop_all_ports() = 0;
         virtual bool is_usable() = 0;
     };
 
@@ -100,10 +94,6 @@ private:
         {
             return m_driver.delete_port(id);
         }
-
-        void start_all_ports() override { return m_driver.start_all_ports(); }
-
-        void stop_all_ports() override { return m_driver.stop_all_ports(); }
 
         bool is_usable() override { return m_driver.is_usable(); }
 

--- a/src/modules/packetio/workers/dpdk/worker_controller.cpp
+++ b/src/modules/packetio/workers/dpdk/worker_controller.cpp
@@ -251,7 +251,6 @@ worker_controller::worker_controller(void* context,
         portq_descriptors, m_tx_schedulers, m_tx_workers, queues));
 
     /* And start them */
-    m_driver.start_all_ports();
     m_workers->start(m_context, num_workers());
 }
 
@@ -260,7 +259,6 @@ worker_controller::~worker_controller()
     if (!m_workers) return;
 
     m_workers->stop(m_context, num_workers());
-    m_driver.stop_all_ports();
     m_recycler->writer_process_gc_callbacks();
     rte_eal_mp_wait_lcore();
     worker::port_queues::instance().unset();


### PR DESCRIPTION
Various packetio improvements. The highlights are:

* Don't let the worker control DPDK port start/stop, as some port interrogation functions only work when the port is started and don't generate any errors when they return useless info.
* Add driver quirks so that we can filter and ignore known driver problems.
* prefetch header data before parsing packets in all port callbacks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/522)
<!-- Reviewable:end -->
