### PR TITLE
packetio: clamp port max_rx_pktlen values

### DIFF
--- a/src/modules/packetio/drivers/dpdk/port_info.cpp
+++ b/src/modules/packetio/drivers/dpdk/port_info.cpp
@@ -50,8 +50,9 @@ libpacket::type::mac_address mac_address(uint16_t port_id)
 uint32_t max_rx_pktlen(uint16_t port_id)
 {
     return (
-        std::min(quirks::sane_max_rx_pktlen(port_id),
-                 get_info_field(port_id, &rte_eth_dev_info::max_rx_pktlen)));
+        std::clamp(get_info_field(port_id, &rte_eth_dev_info::max_rx_pktlen),
+                   static_cast<uint32_t>(RTE_MBUF_DEFAULT_BUF_SIZE),
+                   quirks::sane_max_rx_pktlen(port_id)));
 }
 
 uint32_t max_lro_pkt_size(uint16_t port_id)


### PR DESCRIPTION
Don't return rx packet lengths below the default buffer size. We use
the max packet length for calculating buffer sizes and don't want to
allocate any rx buffers smaller than this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/523)
<!-- Reviewable:end -->
