### PR TITLE
Transmit behavior updates

### DIFF
--- a/api/client/golang/models/packet_generator_flow_counters.go
+++ b/api/client/golang/models/packet_generator_flow_counters.go
@@ -29,6 +29,13 @@ type PacketGeneratorFlowCounters struct {
 	// Minimum: 0
 	OctetsActual *int64 `json:"octets_actual"`
 
+	// The total number of octets that were dropped due to overrunning the
+	// transmit queue. Transmit packet drops are not enabled by default and
+	// must be explicitly enabled.
+	//
+	// Minimum: 0
+	OctetsDropped *int64 `json:"octets_dropped,omitempty"`
+
 	// The total number of octets that should have been transmitted
 	// Required: true
 	// Minimum: 0
@@ -38,6 +45,13 @@ type PacketGeneratorFlowCounters struct {
 	// Required: true
 	// Minimum: 0
 	PacketsActual *int64 `json:"packets_actual"`
+
+	// The total number of packets that were dropped due to overrunning the
+	// transmit queue. Transmit packet drops are not enabled by default and
+	// must be explicitly enabled.
+	//
+	// Minimum: 0
+	PacketsDropped *int64 `json:"packets_dropped,omitempty"`
 
 	// The total number of packets that should have been transmitted
 	// Required: true
@@ -65,11 +79,19 @@ func (m *PacketGeneratorFlowCounters) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateOctetsDropped(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateOctetsIntended(formats); err != nil {
 		res = append(res, err)
 	}
 
 	if err := m.validatePacketsActual(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validatePacketsDropped(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -117,6 +139,18 @@ func (m *PacketGeneratorFlowCounters) validateOctetsActual(formats strfmt.Regist
 	return nil
 }
 
+func (m *PacketGeneratorFlowCounters) validateOctetsDropped(formats strfmt.Registry) error {
+	if swag.IsZero(m.OctetsDropped) { // not required
+		return nil
+	}
+
+	if err := validate.MinimumInt("octets_dropped", "body", *m.OctetsDropped, 0, false); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (m *PacketGeneratorFlowCounters) validateOctetsIntended(formats strfmt.Registry) error {
 
 	if err := validate.Required("octets_intended", "body", m.OctetsIntended); err != nil {
@@ -137,6 +171,18 @@ func (m *PacketGeneratorFlowCounters) validatePacketsActual(formats strfmt.Regis
 	}
 
 	if err := validate.MinimumInt("packets_actual", "body", *m.PacketsActual, 0, false); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *PacketGeneratorFlowCounters) validatePacketsDropped(formats strfmt.Registry) error {
+	if swag.IsZero(m.PacketsDropped) { // not required
+		return nil
+	}
+
+	if err := validate.MinimumInt("packets_dropped", "body", *m.PacketsDropped, 0, false); err != nil {
 		return err
 	}
 

--- a/api/schema/v1/modules/packet/generator.yaml
+++ b/api/schema/v1/modules/packet/generator.yaml
@@ -585,6 +585,14 @@ definitions:
         description: The total number of octets that have been transmitted
         format: int64
         minimum: 0
+      octets_dropped:
+        type: integer
+        description: |
+          The total number of octets that were dropped due to overrunning the
+          transmit queue. Transmit packet drops are not enabled by default and
+          must be explicitly enabled.
+        format: int64
+        minimum: 0
       octets_intended:
         type: integer
         description: The total number of octets that should have been transmitted
@@ -593,6 +601,14 @@ definitions:
       packets_actual:
         type: integer
         description: The total number of packets that have been transmitted
+        format: int64
+        minimum: 0
+      packets_dropped:
+        type: integer
+        description: |
+          The total number of packets that were dropped due to overrunning the
+          transmit queue. Transmit packet drops are not enabled by default and
+          must be explicitly enabled.
         format: int64
         minimum: 0
       packets_intended:

--- a/src/modules/packet/analyzer/handler.cpp
+++ b/src/modules/packet/analyzer/handler.cpp
@@ -607,6 +607,7 @@ void handler::bulk_stop_analyzers(const request_type& request,
             request);
     if (!swagger_request) {
         response.send(Http::Code::Bad_Request, swagger_request.error());
+        return;
     }
 
     const auto& ids = swagger_request->getIds();

--- a/src/modules/packet/generator/source.cpp
+++ b/src/modules/packet/generator/source.cpp
@@ -85,6 +85,16 @@ void source_result::start(size_t nb_flows)
 
 void source_result::stop() { m_active = false; }
 
+uint64_t source_result::dropped_packets() const { return (m_dropped.packets); }
+
+uint64_t source_result::dropped_octets() const { return (m_dropped.octets); }
+
+void source_result::update_drop_counters(uint16_t packets, size_t octets)
+{
+    m_dropped.packets += packets;
+    m_dropped.octets += octets;
+}
+
 source_helper make_source_helper(packetio::internal::api::client& client,
                                  std::string_view target_id,
                                  [[maybe_unused]] core::event_loop& loop)
@@ -411,6 +421,13 @@ uint16_t source::transform(packetio::packet::packet_buffer* input[],
     }
 
     return (to_send);
+}
+
+void source::update_drop_counters(uint16_t packets, size_t octets) const
+{
+    if (auto* results = m_results.load(std::memory_order_relaxed)) {
+        results->update_drop_counters(packets, octets);
+    }
 }
 
 bool source::supports_learning() const

--- a/src/modules/packet/generator/source.cpp
+++ b/src/modules/packet/generator/source.cpp
@@ -170,17 +170,47 @@ api::protocol_counters_config source::protocol_counters() const
     return (m_protocols);
 }
 
+/*
+ * Calculate the expected transmit count based on the configured
+ * rate and actual transmit duration.
+ */
+static size_t expected_tx(const packets_per_hour& pph,
+                          const source_result* result)
+{
+    const auto& flows = result->flows();
+    assert(!flows.empty());
+
+    /*
+     * The last value has a timestamp iff we've made one full transmit
+     * pass through the flows.
+     */
+    if (!flows.back().last().has_value()) { return (0); }
+
+    auto first = flows.front().first().value();
+    auto last = flows.back().last().value();
+    auto duration = last - first;
+
+    /*
+     * XXX: packets/hour * nanoseconds --> overflow, hence, convert the units
+     * here to avoid overflows. Using milliseconds gives us a time limit of
+     * ~1400 days for 64 byte frames at 100 Gbps.
+     */
+    return (pph
+            * std::chrono::duration_cast<std::chrono::milliseconds>(duration));
+}
+
 bool source::active() const
 {
-    if (m_tx_limit && m_tx_limit.value() == m_tx_idx) {
-        if (auto* results = m_results.load(std::memory_order_relaxed)) {
-            results->stop();
-            m_results.store(nullptr, std::memory_order_relaxed);
-        }
+    auto* results = m_results.load(std::memory_order_relaxed);
+    if (m_tx_limit && results
+        && std::max(expected_tx(packet_rate(), results), m_tx_idx)
+               >= m_tx_limit.value()) {
+        results->stop();
+        m_results.store(nullptr, std::memory_order_relaxed);
         return (false);
     }
 
-    return (m_results.load(std::memory_order_relaxed) != nullptr);
+    return (results != nullptr);
 }
 
 bool source::uses_feature(packetio::packet::source_feature_flags flags) const

--- a/src/modules/packet/generator/source.hpp
+++ b/src/modules/packet/generator/source.hpp
@@ -42,6 +42,12 @@ private:
     using protocol_counters = packet::statistics::generic_protocol_counters;
     protocol_counters m_protocols;
 
+    struct
+    {
+        uint64_t packets = 0;
+        uint64_t octets = 0;
+    } m_dropped;
+
     bool m_active = false;
 
 public:
@@ -59,6 +65,11 @@ public:
 
     void start(size_t nb_flows);
     void stop();
+
+    uint64_t dropped_packets() const;
+    uint64_t dropped_octets() const;
+
+    void update_drop_counters(uint16_t packets, size_t octets);
 };
 
 struct source_load
@@ -113,6 +124,8 @@ public:
     uint16_t transform(packetio::packet::packet_buffer* input[],
                        uint16_t input_length,
                        packetio::packet::packet_buffer* output[]) const;
+
+    void update_drop_counters(uint16_t packets, size_t octets) const;
 
     /*
      * Methods related to ARP/ND learning.

--- a/src/modules/packet/generator/source_transmogrify.cpp
+++ b/src/modules/packet/generator/source_transmogrify.cpp
@@ -186,6 +186,8 @@ generator_result_ptr to_swagger(const core::uuid& id,
                       flow_counters,
                       result.parent().packet_rate(),
                       result.parent().sequence());
+    flow_counters->setOctetsDropped(result.dropped_octets());
+    flow_counters->setPacketsDropped(result.dropped_packets());
     dst->setFlowCounters(flow_counters);
 
     auto protocol_counters =

--- a/src/modules/packet/generator/source_transmogrify.cpp
+++ b/src/modules/packet/generator/source_transmogrify.cpp
@@ -65,10 +65,10 @@ static void populate_flow_counters(
 
     if (src.packet) {
         /* Calculate expected packets/octets */
-        auto exp_seq_packets = std::llround(
+        auto exp_seq_packets =
             result.parent().packet_rate()
-            * std::chrono::duration_cast<std::chrono::duration<double>>(
-                src.last_ - src.first_));
+            * std::chrono::duration_cast<std::chrono::milliseconds>(
+                src.last_ - src.first_);
 
         const auto& sequence = result.parent().sequence();
         auto exp_octets =
@@ -97,10 +97,10 @@ static void populate_counters(
          * Use the actual recorded duration and target rate to generate
          * expected packet/octet counts.
          */
-        auto exp_packets = std::llround(
+        auto exp_packets =
             rate
-            * std::chrono::duration_cast<std::chrono::duration<double>>(
-                src.last_ - src.first_));
+            * std::chrono::duration_cast<std::chrono::milliseconds>(
+                src.last_ - src.first_);
         auto exp_octets = sequence.sum_packet_lengths(exp_packets);
 
         dst->setOctetsIntended(exp_octets);

--- a/src/modules/packetio/drivers/dpdk/arg_parser.cpp
+++ b/src/modules/packetio/drivers/dpdk/arg_parser.cpp
@@ -263,4 +263,14 @@ std::optional<core_mask> tx_core_mask()
     return (get_mask_argument(op_packetio_dpdk_tx_worker_mask));
 }
 
+bool dpdk_drop_tx_overruns()
+{
+    static const auto do_tx_drop =
+        config::file::op_config_get_param<OP_OPTION_TYPE_NONE>(
+            op_packetio_dpdk_drop_tx_overruns)
+            .value_or(false);
+
+    return (do_tx_drop);
+}
+
 } /* namespace openperf::packetio::dpdk::config */

--- a/src/modules/packetio/drivers/dpdk/arg_parser.hpp
+++ b/src/modules/packetio/drivers/dpdk/arg_parser.hpp
@@ -16,6 +16,7 @@ extern const char op_packetio_dpdk_options[];
 extern const char op_packetio_dpdk_port_ids[];
 extern const char op_packetio_dpdk_rx_worker_mask[];
 extern const char op_packetio_dpdk_tx_worker_mask[];
+extern const char op_packetio_dpdk_drop_tx_overruns[];
 
 namespace openperf::packetio::dpdk::config {
 
@@ -59,6 +60,7 @@ inline void add_dpdk_argument(std::vector<std::string>& args,
 
 bool dpdk_disable_lro();
 bool dpdk_disable_rx_irq();
+bool dpdk_drop_tx_overruns();
 
 } /* namespace openperf::packetio::dpdk::config */
 

--- a/src/modules/packetio/drivers/dpdk/arg_parser_register.c
+++ b/src/modules/packetio/drivers/dpdk/arg_parser_register.c
@@ -11,6 +11,8 @@ const char op_packetio_dpdk_rx_worker_mask[] =
     "modules.packetio.dpdk.rx-worker-mask";
 const char op_packetio_dpdk_tx_worker_mask[] =
     "modules.packetio.dpdk.tx-worker-mask";
+const char op_packetio_dpdk_drop_tx_overruns[] =
+    "modules.packetio.dpdk.drop-tx-overruns";
 
 MAKE_OPTION_DATA(
     dpdk,
@@ -43,6 +45,10 @@ MAKE_OPTION_DATA(
     MAKE_OPT("specifies CPU core mask for transmit threads, in hex",
              op_packetio_dpdk_tx_worker_mask,
              'T',
-             OP_OPTION_TYPE_HEX), );
+             OP_OPTION_TYPE_HEX),
+    MAKE_OPT("drop packets if the transmit queue is overrun",
+             op_packetio_dpdk_drop_tx_overruns,
+             0,
+             OP_OPTION_TYPE_NONE), );
 
 REGISTER_CLI_OPTIONS(dpdk)

--- a/src/modules/packetio/drivers/dpdk/primary/arg_parser.cpp
+++ b/src/modules/packetio/drivers/dpdk/primary/arg_parser.cpp
@@ -20,33 +20,41 @@ std::vector<std::string> dpdk_args()
 
 int dpdk_test_portpairs()
 {
-    auto result = config::file::op_config_get_param<OP_OPTION_TYPE_LONG>(
-        op_packetio_dpdk_test_portpairs);
+    static const auto port_pairs =
+        config::file::op_config_get_param<OP_OPTION_TYPE_LONG>(
+            op_packetio_dpdk_test_portpairs)
+            .value_or(dpdk_test_mode() ? 1 : 0);
 
-    return (result.value_or(dpdk_test_mode() ? 1 : 0));
+    return (port_pairs);
 }
 
 bool dpdk_test_mode()
 {
-    auto result = config::file::op_config_get_param<OP_OPTION_TYPE_NONE>(
-        op_packetio_dpdk_test_mode);
+    static const auto test_mode =
+        config::file::op_config_get_param<OP_OPTION_TYPE_NONE>(
+            op_packetio_dpdk_test_mode)
+            .value_or(false);
 
-    return (result.value_or(false));
+    return (test_mode);
 }
 
 bool dpdk_disable_lro()
 {
-    auto no_lro = config::file::op_config_get_param<OP_OPTION_TYPE_NONE>(
-                      op_packetio_dpdk_no_lro)
-                      .value_or(false);
+    static const auto no_lro =
+        config::file::op_config_get_param<OP_OPTION_TYPE_NONE>(
+            op_packetio_dpdk_no_lro)
+            .value_or(false);
+
     return (no_lro);
 }
 
 bool dpdk_disable_rx_irq()
 {
-    auto no_rx_irqs = config::file::op_config_get_param<OP_OPTION_TYPE_NONE>(
-                          op_packetio_dpdk_no_rx_irqs)
-                          .value_or(false);
+    static const auto no_rx_irqs =
+        config::file::op_config_get_param<OP_OPTION_TYPE_NONE>(
+            op_packetio_dpdk_no_rx_irqs)
+            .value_or(false);
+
     return (no_rx_irqs);
 }
 

--- a/src/modules/packetio/workers/dpdk/tx_source.cpp
+++ b/src/modules/packetio/workers/dpdk/tx_source.cpp
@@ -81,4 +81,9 @@ uint16_t tx_source::pull(rte_mbuf* packets[], uint16_t count) const
     return (m);
 }
 
+void tx_source::update_drop_counters(uint16_t packets, size_t octets) const
+{
+    m_source.update_drop_counters(packets, octets);
+}
+
 } // namespace openperf::packetio::dpdk

--- a/src/modules/packetio/workers/dpdk/tx_source.hpp
+++ b/src/modules/packetio/workers/dpdk/tx_source.hpp
@@ -37,6 +37,7 @@ public:
     uint16_t max_packet_length() const;
     packet::packets_per_hour packet_rate() const;
     uint16_t pull(rte_mbuf* packets[], uint16_t count) const;
+    void update_drop_counters(uint16_t packets, size_t octets) const;
 };
 
 } // namespace openperf::packetio::dpdk

--- a/src/swagger/v1/model/PacketGeneratorFlowCounters.cpp
+++ b/src/swagger/v1/model/PacketGeneratorFlowCounters.cpp
@@ -21,8 +21,12 @@ PacketGeneratorFlowCounters::PacketGeneratorFlowCounters()
 {
     m_Errors = 0L;
     m_Octets_actual = 0L;
+    m_Octets_dropped = 0L;
+    m_Octets_droppedIsSet = false;
     m_Octets_intended = 0L;
     m_Packets_actual = 0L;
+    m_Packets_dropped = 0L;
+    m_Packets_droppedIsSet = false;
     m_Packets_intended = 0L;
     m_Timestamp_first = "";
     m_Timestamp_firstIsSet = false;
@@ -46,8 +50,16 @@ nlohmann::json PacketGeneratorFlowCounters::toJson() const
 
     val["errors"] = m_Errors;
     val["octets_actual"] = m_Octets_actual;
+    if(m_Octets_droppedIsSet)
+    {
+        val["octets_dropped"] = m_Octets_dropped;
+    }
     val["octets_intended"] = m_Octets_intended;
     val["packets_actual"] = m_Packets_actual;
+    if(m_Packets_droppedIsSet)
+    {
+        val["packets_dropped"] = m_Packets_dropped;
+    }
     val["packets_intended"] = m_Packets_intended;
     if(m_Timestamp_firstIsSet)
     {
@@ -66,8 +78,16 @@ void PacketGeneratorFlowCounters::fromJson(nlohmann::json& val)
 {
     setErrors(val.at("errors"));
     setOctetsActual(val.at("octets_actual"));
+    if(val.find("octets_dropped") != val.end())
+    {
+        setOctetsDropped(val.at("octets_dropped"));
+    }
     setOctetsIntended(val.at("octets_intended"));
     setPacketsActual(val.at("packets_actual"));
+    if(val.find("packets_dropped") != val.end())
+    {
+        setPacketsDropped(val.at("packets_dropped"));
+    }
     setPacketsIntended(val.at("packets_intended"));
     if(val.find("timestamp_first") != val.end())
     {
@@ -101,6 +121,23 @@ void PacketGeneratorFlowCounters::setOctetsActual(int64_t value)
     m_Octets_actual = value;
     
 }
+int64_t PacketGeneratorFlowCounters::getOctetsDropped() const
+{
+    return m_Octets_dropped;
+}
+void PacketGeneratorFlowCounters::setOctetsDropped(int64_t value)
+{
+    m_Octets_dropped = value;
+    m_Octets_droppedIsSet = true;
+}
+bool PacketGeneratorFlowCounters::octetsDroppedIsSet() const
+{
+    return m_Octets_droppedIsSet;
+}
+void PacketGeneratorFlowCounters::unsetOctets_dropped()
+{
+    m_Octets_droppedIsSet = false;
+}
 int64_t PacketGeneratorFlowCounters::getOctetsIntended() const
 {
     return m_Octets_intended;
@@ -118,6 +155,23 @@ void PacketGeneratorFlowCounters::setPacketsActual(int64_t value)
 {
     m_Packets_actual = value;
     
+}
+int64_t PacketGeneratorFlowCounters::getPacketsDropped() const
+{
+    return m_Packets_dropped;
+}
+void PacketGeneratorFlowCounters::setPacketsDropped(int64_t value)
+{
+    m_Packets_dropped = value;
+    m_Packets_droppedIsSet = true;
+}
+bool PacketGeneratorFlowCounters::packetsDroppedIsSet() const
+{
+    return m_Packets_droppedIsSet;
+}
+void PacketGeneratorFlowCounters::unsetPackets_dropped()
+{
+    m_Packets_droppedIsSet = false;
 }
 int64_t PacketGeneratorFlowCounters::getPacketsIntended() const
 {

--- a/src/swagger/v1/model/PacketGeneratorFlowCounters.h
+++ b/src/swagger/v1/model/PacketGeneratorFlowCounters.h
@@ -59,6 +59,13 @@ public:
     int64_t getOctetsActual() const;
     void setOctetsActual(int64_t value);
         /// <summary>
+    /// The total number of octets that were dropped due to overrunning the transmit queue. Transmit packet drops are not enabled by default and must be explicitly enabled. 
+    /// </summary>
+    int64_t getOctetsDropped() const;
+    void setOctetsDropped(int64_t value);
+    bool octetsDroppedIsSet() const;
+    void unsetOctets_dropped();
+    /// <summary>
     /// The total number of octets that should have been transmitted
     /// </summary>
     int64_t getOctetsIntended() const;
@@ -69,6 +76,13 @@ public:
     int64_t getPacketsActual() const;
     void setPacketsActual(int64_t value);
         /// <summary>
+    /// The total number of packets that were dropped due to overrunning the transmit queue. Transmit packet drops are not enabled by default and must be explicitly enabled. 
+    /// </summary>
+    int64_t getPacketsDropped() const;
+    void setPacketsDropped(int64_t value);
+    bool packetsDroppedIsSet() const;
+    void unsetPackets_dropped();
+    /// <summary>
     /// The total number of packets that should have been transmitted
     /// </summary>
     int64_t getPacketsIntended() const;
@@ -93,10 +107,14 @@ protected:
 
     int64_t m_Octets_actual;
 
+    int64_t m_Octets_dropped;
+    bool m_Octets_droppedIsSet;
     int64_t m_Octets_intended;
 
     int64_t m_Packets_actual;
 
+    int64_t m_Packets_dropped;
+    bool m_Packets_droppedIsSet;
     int64_t m_Packets_intended;
 
     std::string m_Timestamp_first;

--- a/tests/aat/api/v1/client/models/packet_generator_flow_counters.py
+++ b/tests/aat/api/v1/client/models/packet_generator_flow_counters.py
@@ -33,8 +33,10 @@ class PacketGeneratorFlowCounters(object):
     swagger_types = {
         'errors': 'int',
         'octets_actual': 'int',
+        'octets_dropped': 'int',
         'octets_intended': 'int',
         'packets_actual': 'int',
+        'packets_dropped': 'int',
         'packets_intended': 'int',
         'timestamp_first': 'datetime',
         'timestamp_last': 'datetime'
@@ -43,20 +45,24 @@ class PacketGeneratorFlowCounters(object):
     attribute_map = {
         'errors': 'errors',
         'octets_actual': 'octets_actual',
+        'octets_dropped': 'octets_dropped',
         'octets_intended': 'octets_intended',
         'packets_actual': 'packets_actual',
+        'packets_dropped': 'packets_dropped',
         'packets_intended': 'packets_intended',
         'timestamp_first': 'timestamp_first',
         'timestamp_last': 'timestamp_last'
     }
 
-    def __init__(self, errors=None, octets_actual=None, octets_intended=None, packets_actual=None, packets_intended=None, timestamp_first=None, timestamp_last=None):  # noqa: E501
+    def __init__(self, errors=None, octets_actual=None, octets_dropped=None, octets_intended=None, packets_actual=None, packets_dropped=None, packets_intended=None, timestamp_first=None, timestamp_last=None):  # noqa: E501
         """PacketGeneratorFlowCounters - a model defined in Swagger"""  # noqa: E501
 
         self._errors = None
         self._octets_actual = None
+        self._octets_dropped = None
         self._octets_intended = None
         self._packets_actual = None
+        self._packets_dropped = None
         self._packets_intended = None
         self._timestamp_first = None
         self._timestamp_last = None
@@ -64,8 +70,12 @@ class PacketGeneratorFlowCounters(object):
 
         self.errors = errors
         self.octets_actual = octets_actual
+        if octets_dropped is not None:
+            self.octets_dropped = octets_dropped
         self.octets_intended = octets_intended
         self.packets_actual = packets_actual
+        if packets_dropped is not None:
+            self.packets_dropped = packets_dropped
         self.packets_intended = packets_intended
         if timestamp_first is not None:
             self.timestamp_first = timestamp_first
@@ -117,6 +127,28 @@ class PacketGeneratorFlowCounters(object):
         self._octets_actual = octets_actual
 
     @property
+    def octets_dropped(self):
+        """Gets the octets_dropped of this PacketGeneratorFlowCounters.  # noqa: E501
+
+        The total number of octets that were dropped due to overrunning the transmit queue. Transmit packet drops are not enabled by default and must be explicitly enabled.   # noqa: E501
+
+        :return: The octets_dropped of this PacketGeneratorFlowCounters.  # noqa: E501
+        :rtype: int
+        """
+        return self._octets_dropped
+
+    @octets_dropped.setter
+    def octets_dropped(self, octets_dropped):
+        """Sets the octets_dropped of this PacketGeneratorFlowCounters.
+
+        The total number of octets that were dropped due to overrunning the transmit queue. Transmit packet drops are not enabled by default and must be explicitly enabled.   # noqa: E501
+
+        :param octets_dropped: The octets_dropped of this PacketGeneratorFlowCounters.  # noqa: E501
+        :type: int
+        """
+        self._octets_dropped = octets_dropped
+
+    @property
     def octets_intended(self):
         """Gets the octets_intended of this PacketGeneratorFlowCounters.  # noqa: E501
 
@@ -159,6 +191,28 @@ class PacketGeneratorFlowCounters(object):
         :type: int
         """
         self._packets_actual = packets_actual
+
+    @property
+    def packets_dropped(self):
+        """Gets the packets_dropped of this PacketGeneratorFlowCounters.  # noqa: E501
+
+        The total number of packets that were dropped due to overrunning the transmit queue. Transmit packet drops are not enabled by default and must be explicitly enabled.   # noqa: E501
+
+        :return: The packets_dropped of this PacketGeneratorFlowCounters.  # noqa: E501
+        :rtype: int
+        """
+        return self._packets_dropped
+
+    @packets_dropped.setter
+    def packets_dropped(self, packets_dropped):
+        """Sets the packets_dropped of this PacketGeneratorFlowCounters.
+
+        The total number of packets that were dropped due to overrunning the transmit queue. Transmit packet drops are not enabled by default and must be explicitly enabled.   # noqa: E501
+
+        :param packets_dropped: The packets_dropped of this PacketGeneratorFlowCounters.  # noqa: E501
+        :type: int
+        """
+        self._packets_dropped = packets_dropped
 
     @property
     def packets_intended(self):

--- a/tests/aat/api/v1/docs/PacketGeneratorFlowCounters.md
+++ b/tests/aat/api/v1/docs/PacketGeneratorFlowCounters.md
@@ -5,8 +5,10 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **errors** | **int** | The number of packets not transmitted due to errors | 
 **octets_actual** | **int** | The total number of octets that have been transmitted | 
+**octets_dropped** | **int** | The total number of octets that were dropped due to overrunning the transmit queue. Transmit packet drops are not enabled by default and must be explicitly enabled.  | [optional] 
 **octets_intended** | **int** | The total number of octets that should have been transmitted | 
 **packets_actual** | **int** | The total number of packets that have been transmitted | 
+**packets_dropped** | **int** | The total number of packets that were dropped due to overrunning the transmit queue. Transmit packet drops are not enabled by default and must be explicitly enabled.  | [optional] 
 **packets_intended** | **int** | The total number of packets that should have been transmitted | 
 **timestamp_first** | **datetime** | The timestamp of the first transmitted packet | [optional] 
 **timestamp_last** | **datetime** | The timestamp of the most recently transmitted packet | [optional] 

--- a/tests/aat/spec/config.yaml
+++ b/tests/aat/spec/config.yaml
@@ -26,6 +26,13 @@ services:
     init_url: http://127.0.0.1:9000/interfaces/client-v6
     init_timeout: 15s
 
+  # Verify packet generator drops packets when configured to do so.
+  packet-generator-drop:
+    command: '../../build/openperf-linux-x86_64-testing/bin/openperf --modules.packetio.dpdk.test-mode --core.log.level debug --modules.packetio.dpdk.options="-m256m,--no-huge" --modules.packetio.dpdk.port-ids="port0=0, port1=1" --modules.packetio.dpdk.drop-tx-overruns -p 9000 >> openperf.log 2>&1'
+    base_url: http://127.0.0.1:9000
+    init_url: http://127.0.0.1:9000/version
+    init_timeout: 15s
+
   # PacketIO argument test configs
   packetio-args-1:
     command: '../../build/openperf-linux-x86_64-testing/bin/openperf --modules.packetio.cpu-mask 0x0 -p 9000 >> openperf.log 2>&1'

--- a/tests/aat/spec/packet_generator_drop_spec.py
+++ b/tests/aat/spec/packet_generator_drop_spec.py
@@ -1,0 +1,89 @@
+from mamba import description, before, after
+from expects import *
+import os
+import time
+
+import client.api
+import client.models
+from common.helper import (check_modules_exists,
+                           packet_generator_model)
+from common.matcher import (be_valid_packet_generator,
+                            be_valid_packet_generator_result)
+from common import Config, Service
+
+
+CONFIG = Config(os.path.join(os.path.dirname(__file__),
+                             os.environ.get('MAMBA_CONFIG', 'config.yaml')))
+
+POLL_INTERVAL = 0.025
+
+
+def wait_until_done(gen_client, result_id, initial_sleep = None):
+    if (initial_sleep):
+        time.sleep(initial_sleep)
+
+    while True:
+        result = gen_client.get_packet_generator_result(result_id)
+        expect(result).to(be_valid_packet_generator_result)
+        if result.flow_counters.packets_actual > 0 and not result.active:
+            break;
+        time.sleep(POLL_INTERVAL)
+
+
+with description('Packet Generator Drop Mode,', 'packet_generator_drop') as self:
+    with description('Drops and Stops'):
+
+        with before.all:
+            service = Service(CONFIG.service('packet-generator-drop'))
+            self.process = service.start()
+            self.api = client.api.PacketGeneratorsApi(service.client())
+            if not check_modules_exists(service.client(), 'packet-generator'):
+                self.skip()
+
+        with description('overload transmit path,'):
+            with it('stops on-time and drops packets'):
+                time = client.models.TrafficDurationTime()
+                time.value = 100;
+                time.units = "milliseconds"
+                duration = client.models.TrafficDuration()
+                duration.time = time
+                gen = packet_generator_model(self.api.api_client)
+                gen.config.duration = duration
+
+                # Set a load the test environment can't possibly hit
+                gen.config.load.burst_size = 64
+                gen.config.load.rate.value = 148809523
+
+                gen = self.api.create_packet_generator(gen)
+                expect(gen).to(be_valid_packet_generator)
+
+                result = self.api.start_packet_generator(gen.id)
+                expect(result).to(be_valid_packet_generator_result)
+
+                # Wait for automatic stop
+                wait_until_done(self.api, result.id)
+
+                result = self.api.get_packet_generator_result(result.id)
+                expect(result).to(be_valid_packet_generator_result)
+
+                expect(result.flow_counters.packets_actual).to(
+                    be_below(result.flow_counters.packets_intended))
+                expect(result.flow_counters.packets_dropped).to(be_above(0))
+                expect(result.flow_counters.octets_dropped).to(be_above(0))
+
+        with after.each:
+            try:
+                for gen in self.api.list_packet_generators():
+                    if gen.active:
+                        self.api.stop_packet_generator(gen.id)
+                self.api.delete_packet_generators()
+
+            except AttributeError:
+                pass
+
+        with after.all:
+            try:
+                self.process.terminate()
+                self.process.wait()
+            except AttributeError:
+                pass

--- a/tests/aat/spec/packet_generator_spec.py
+++ b/tests/aat/spec/packet_generator_spec.py
@@ -1,6 +1,7 @@
 from mamba import description, before, after
 from expects import *
 import os
+import time
 
 import client.api
 import client.models
@@ -48,6 +49,19 @@ CUSTOM_PAYLOAD = [
     {'custom': {'data': CUSTOM_DATA,
                 'layer': 'payload'}}
 ]
+
+POLL_INTERVAL = 0.025
+
+def wait_until_done(gen_client, result_id, initial_sleep = None):
+    if (initial_sleep):
+        time.sleep(initial_sleep)
+
+    while True:
+        result = gen_client.get_packet_generator_result(result_id)
+        expect(result).to(be_valid_packet_generator_result)
+        if result.flow_counters.packets_actual > 0 and not result.active:
+            break;
+        time.sleep(POLL_INTERVAL)
 
 
 with description('Packet Generator,', 'packet_generator') as self:
@@ -484,6 +498,31 @@ with description('Packet Generator,', 'packet_generator') as self:
                         expect(result).to(be_valid_packet_generator_result)
                     expect([r for r in results if r.active is True]).not_to(be_empty)
                     expect([r for r in results if r.active is False]).not_to(be_empty)
+
+        with description('generator stops automatically,'):
+            with it('succeeds'):
+                time = client.models.TrafficDurationTime()
+                time.value = 10;
+                time.units = "milliseconds"
+                duration = client.models.TrafficDuration()
+                duration.time = time
+                gen = packet_generator_model(self.api.api_client)
+                gen.config.duration = duration
+
+                # Set a load the test environment can't possibly hit
+                gen.config.load.rate.value = 148809523
+
+                gen = self.api.create_packet_generator(gen)
+                expect(gen).to(be_valid_packet_generator)
+
+                result = self.api.start_packet_generator(gen.id)
+                expect(result).to(be_valid_packet_generator_result)
+
+                # Wait for automatic stop
+                wait_until_done(self.api, result.id)
+
+                result = self.api.get_packet_generator_result(result.id)
+                expect(result.flow_counters.packets_actual).to(be_below(gen.config.load.rate.value))
 
         with description('toggle generators,'):
             with before.each:


### PR DESCRIPTION
This PR makes two main changes:

1) Use the expected transmit count instead of the actual transmit count to determine when to stop a running packet generator when the user specifies a transmit limit.

2) Add a new packetio command line option, modules.packetio.dpdk.drop-tx-overruns. This option instructs the transmit path to drop packets instead of buffering them when the transmit queue is full.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/526)
<!-- Reviewable:end -->
