### PR TITLE
Disable Tx Queues When Not Running Stack Thread

### DIFF
--- a/src/modules/packetio/workers/dpdk/worker_controller.cpp
+++ b/src/modules/packetio/workers/dpdk/worker_controller.cpp
@@ -82,10 +82,11 @@ static std::vector<queue::descriptor>
 filter_queue_descriptors(std::vector<queue::descriptor>&& q_descriptors)
 {
     /*
-     * XXX: If we have only one worker thread, then everything should use the
-     * direct transmit functions.  Hence, we don't need any tx queues.
+     * XXX: If we have only one worker thread or no stack thread, then
+     * everything should use the direct transmit functions.
+     * Hence, we don't need any tx queues.
      */
-    if (rte_lcore_count() <= 2) {
+    if (rte_lcore_count() <= 2 || !topology::get_stack_lcore_id()) {
         /* Filter out all tx queues; we don't need them */
         q_descriptors.erase(
             std::remove_if(begin(q_descriptors),


### PR DESCRIPTION
Tx queues are not required when stack is not running. Expand queue
descriptor filtering from just filtering when core count <= 2 to include
filtering when there's no stack thread.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/527)
<!-- Reviewable:end -->
