### PR TITLE
tests/aat: add force-unlink option to drop test

### DIFF
--- a/tests/aat/spec/config.yaml
+++ b/tests/aat/spec/config.yaml
@@ -28,7 +28,7 @@ services:
 
   # Verify packet generator drops packets when configured to do so.
   packet-generator-drop:
-    command: '../../build/openperf-linux-x86_64-testing/bin/openperf --modules.packetio.dpdk.test-mode --core.log.level debug --modules.packetio.dpdk.options="-m256m,--no-huge" --modules.packetio.dpdk.port-ids="port0=0, port1=1" --modules.packetio.dpdk.drop-tx-overruns -p 9000 >> openperf.log 2>&1'
+    command: '../../build/openperf-linux-x86_64-testing/bin/openperf --modules.packetio.dpdk.test-mode --core.log.level debug --modules.socket.force-unlink --modules.packetio.dpdk.options="-m256m,--no-huge" --modules.packetio.dpdk.port-ids="port0=0, port1=1" --modules.packetio.dpdk.drop-tx-overruns -p 9000 >> openperf.log 2>&1'
     base_url: http://127.0.0.1:9000
     init_url: http://127.0.0.1:9000/version
     init_timeout: 15s


### PR DESCRIPTION
The generator drop test runs after an AAT suite that sometimes doesn't
properly clean up after itself. As a result, add the `force-unlink`
option to the generator drop configuration so that it will always run.

The issue in the previous suite is related to a mostly harmless shutdown
race that should be fixed, but hasn't been... yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/529)
<!-- Reviewable:end -->
