### PR TITLE
modules/timesync: add more ntp source stats

### DIFF
--- a/api/client/golang/models/time_source_stats.go
+++ b/api/client/golang/models/time_source_stats.go
@@ -147,8 +147,23 @@ func (m *TimeSourceStats) UnmarshalBinary(b []byte) error {
 // swagger:model TimeSourceStatsNtp
 type TimeSourceStatsNtp struct {
 
+	// the time and date of the last accepted NTP reply, in ISO8601 format
+	// Format: date-time
+	LastRxAccepted strfmt.DateTime `json:"last_rx_accepted,omitempty"`
+
+	// The time and date of the last ignored NTP reply, in ISO8601 format
+	// Format: date-time
+	LastRxIgnored strfmt.DateTime `json:"last_rx_ignored,omitempty"`
+
 	// Current NTP server poll period, in seconds
-	PollPeriod int64 `json:"poll_period,omitempty"`
+	// Required: true
+	PollPeriod *int64 `json:"poll_period"`
+
+	// Received packets that were ignored due to an invalid origin timestamp or stratum,
+	// e.g. a Kiss-o'-Death packet
+	//
+	// Required: true
+	RxIgnored *int64 `json:"rx_ignored"`
 
 	// Received packets
 	// Required: true
@@ -167,6 +182,22 @@ type TimeSourceStatsNtp struct {
 func (m *TimeSourceStatsNtp) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateLastRxAccepted(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateLastRxIgnored(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validatePollPeriod(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateRxIgnored(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateRxPackets(formats); err != nil {
 		res = append(res, err)
 	}
@@ -178,6 +209,48 @@ func (m *TimeSourceStatsNtp) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *TimeSourceStatsNtp) validateLastRxAccepted(formats strfmt.Registry) error {
+	if swag.IsZero(m.LastRxAccepted) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("ntp"+"."+"last_rx_accepted", "body", "date-time", m.LastRxAccepted.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *TimeSourceStatsNtp) validateLastRxIgnored(formats strfmt.Registry) error {
+	if swag.IsZero(m.LastRxIgnored) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("ntp"+"."+"last_rx_ignored", "body", "date-time", m.LastRxIgnored.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *TimeSourceStatsNtp) validatePollPeriod(formats strfmt.Registry) error {
+
+	if err := validate.Required("ntp"+"."+"poll_period", "body", m.PollPeriod); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *TimeSourceStatsNtp) validateRxIgnored(formats strfmt.Registry) error {
+
+	if err := validate.Required("ntp"+"."+"rx_ignored", "body", m.RxIgnored); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/api/schema/v1/modules/timesync.yaml
+++ b/api/schema/v1/modules/timesync.yaml
@@ -333,9 +333,23 @@ definitions:
         type: object
         description: NTP statistics
         properties:
+          last_rx_accepted:
+            type: string
+            description: the time and date of the last accepted NTP reply, in ISO8601 format
+            format: date-time
+          last_rx_ignored:
+            type: string
+            description: The time and date of the last ignored NTP reply, in ISO8601 format
+            format: date-time
           poll_period:
             type: integer
             description: Current NTP server poll period, in seconds
+            format: int64
+          rx_ignored:
+            type: integer
+            description: |
+              Received packets that were ignored due to an invalid origin timestamp or stratum,
+              e.g. a Kiss-o'-Death packet
             format: int64
           rx_packets:
             type: integer
@@ -351,6 +365,8 @@ definitions:
               Time source distance from a NTP reference clock, in network hops.
             format: int32
         required:
+          - poll_period
+          - rx_ignored
           - rx_packets
           - tx_packets
       system:

--- a/src/modules/timesync/api.hpp
+++ b/src/modules/timesync/api.hpp
@@ -107,7 +107,11 @@ struct time_source_config_ntp
 
 struct time_source_stats_ntp
 {
+    using time_point = std::chrono::time_point<chrono::realtime>;
+    std::optional<time_point> last_rx_accepted;
+    std::optional<time_point> last_rx_ignored;
     std::chrono::seconds poll_period;
+    int64_t rx_ignored;
     int64_t rx_packets;
     int64_t tx_packets;
     std::optional<uint8_t> stratum;

--- a/src/modules/timesync/api_transmogrify.cpp
+++ b/src/modules/timesync/api_transmogrify.cpp
@@ -233,7 +233,18 @@ to_swagger(const time_source_stats_ntp& src)
     using TimeSourceStats_ntp = swagger::v1::model::TimeSourceStats_ntp;
     auto ntp_stats = std::make_shared<TimeSourceStats_ntp>();
 
+    if (src.last_rx_accepted) {
+        ntp_stats->setLastRxAccepted(
+            to_rfc3339(src.last_rx_accepted->time_since_epoch()));
+    }
+
+    if (src.last_rx_ignored) {
+        ntp_stats->setLastRxIgnored(
+            to_rfc3339(src.last_rx_ignored->time_since_epoch()));
+    }
+
     ntp_stats->setPollPeriod(src.poll_period.count());
+    ntp_stats->setRxIgnored(src.rx_ignored);
     ntp_stats->setRxPackets(src.rx_packets);
     ntp_stats->setTxPackets(src.tx_packets);
     if (src.stratum) { ntp_stats->setStratum(*src.stratum); }

--- a/src/modules/timesync/source_ntp.hpp
+++ b/src/modules/timesync/source_ntp.hpp
@@ -41,7 +41,12 @@ struct ntp
     unsigned poll_loop_id = 0;
     struct
     {
+        std::optional<chrono::realtime::time_point> last_rx_accepted =
+            std::nullopt;
+        std::optional<chrono::realtime::time_point> last_rx_ignored =
+            std::nullopt;
         std::chrono::seconds poll_period = 64s;
+        unsigned rx_ignored = 0;
         unsigned rx = 0;
         unsigned tx = 0;
         std::optional<uint8_t> stratum = std::nullopt; /* unsynchronized */

--- a/src/swagger/v1/model/TimeSourceStats_ntp.cpp
+++ b/src/swagger/v1/model/TimeSourceStats_ntp.cpp
@@ -19,8 +19,12 @@ namespace model {
 
 TimeSourceStats_ntp::TimeSourceStats_ntp()
 {
+    m_Last_rx_accepted = "";
+    m_Last_rx_acceptedIsSet = false;
+    m_Last_rx_ignored = "";
+    m_Last_rx_ignoredIsSet = false;
     m_Poll_period = 0L;
-    m_Poll_periodIsSet = false;
+    m_Rx_ignored = 0L;
     m_Rx_packets = 0L;
     m_Tx_packets = 0L;
     m_Stratum = 0;
@@ -41,10 +45,16 @@ nlohmann::json TimeSourceStats_ntp::toJson() const
 {
     nlohmann::json val = nlohmann::json::object();
 
-    if(m_Poll_periodIsSet)
+    if(m_Last_rx_acceptedIsSet)
     {
-        val["poll_period"] = m_Poll_period;
+        val["last_rx_accepted"] = ModelBase::toJson(m_Last_rx_accepted);
     }
+    if(m_Last_rx_ignoredIsSet)
+    {
+        val["last_rx_ignored"] = ModelBase::toJson(m_Last_rx_ignored);
+    }
+    val["poll_period"] = m_Poll_period;
+    val["rx_ignored"] = m_Rx_ignored;
     val["rx_packets"] = m_Rx_packets;
     val["tx_packets"] = m_Tx_packets;
     if(m_StratumIsSet)
@@ -58,10 +68,18 @@ nlohmann::json TimeSourceStats_ntp::toJson() const
 
 void TimeSourceStats_ntp::fromJson(nlohmann::json& val)
 {
-    if(val.find("poll_period") != val.end())
+    if(val.find("last_rx_accepted") != val.end())
     {
-        setPollPeriod(val.at("poll_period"));
+        setLastRxAccepted(val.at("last_rx_accepted"));
+        
     }
+    if(val.find("last_rx_ignored") != val.end())
+    {
+        setLastRxIgnored(val.at("last_rx_ignored"));
+        
+    }
+    setPollPeriod(val.at("poll_period"));
+    setRxIgnored(val.at("rx_ignored"));
     setRxPackets(val.at("rx_packets"));
     setTxPackets(val.at("tx_packets"));
     if(val.find("stratum") != val.end())
@@ -72,6 +90,40 @@ void TimeSourceStats_ntp::fromJson(nlohmann::json& val)
 }
 
 
+std::string TimeSourceStats_ntp::getLastRxAccepted() const
+{
+    return m_Last_rx_accepted;
+}
+void TimeSourceStats_ntp::setLastRxAccepted(std::string value)
+{
+    m_Last_rx_accepted = value;
+    m_Last_rx_acceptedIsSet = true;
+}
+bool TimeSourceStats_ntp::lastRxAcceptedIsSet() const
+{
+    return m_Last_rx_acceptedIsSet;
+}
+void TimeSourceStats_ntp::unsetLast_rx_accepted()
+{
+    m_Last_rx_acceptedIsSet = false;
+}
+std::string TimeSourceStats_ntp::getLastRxIgnored() const
+{
+    return m_Last_rx_ignored;
+}
+void TimeSourceStats_ntp::setLastRxIgnored(std::string value)
+{
+    m_Last_rx_ignored = value;
+    m_Last_rx_ignoredIsSet = true;
+}
+bool TimeSourceStats_ntp::lastRxIgnoredIsSet() const
+{
+    return m_Last_rx_ignoredIsSet;
+}
+void TimeSourceStats_ntp::unsetLast_rx_ignored()
+{
+    m_Last_rx_ignoredIsSet = false;
+}
 int64_t TimeSourceStats_ntp::getPollPeriod() const
 {
     return m_Poll_period;
@@ -79,15 +131,16 @@ int64_t TimeSourceStats_ntp::getPollPeriod() const
 void TimeSourceStats_ntp::setPollPeriod(int64_t value)
 {
     m_Poll_period = value;
-    m_Poll_periodIsSet = true;
+    
 }
-bool TimeSourceStats_ntp::pollPeriodIsSet() const
+int64_t TimeSourceStats_ntp::getRxIgnored() const
 {
-    return m_Poll_periodIsSet;
+    return m_Rx_ignored;
 }
-void TimeSourceStats_ntp::unsetPoll_period()
+void TimeSourceStats_ntp::setRxIgnored(int64_t value)
 {
-    m_Poll_periodIsSet = false;
+    m_Rx_ignored = value;
+    
 }
 int64_t TimeSourceStats_ntp::getRxPackets() const
 {

--- a/src/swagger/v1/model/TimeSourceStats_ntp.h
+++ b/src/swagger/v1/model/TimeSourceStats_ntp.h
@@ -21,6 +21,7 @@
 
 #include "ModelBase.h"
 
+#include <string>
 
 namespace swagger {
 namespace v1 {
@@ -48,13 +49,30 @@ public:
     /// TimeSourceStats_ntp members
 
     /// <summary>
+    /// the time and date of the last accepted NTP reply, in ISO8601 format
+    /// </summary>
+    std::string getLastRxAccepted() const;
+    void setLastRxAccepted(std::string value);
+    bool lastRxAcceptedIsSet() const;
+    void unsetLast_rx_accepted();
+    /// <summary>
+    /// The time and date of the last ignored NTP reply, in ISO8601 format
+    /// </summary>
+    std::string getLastRxIgnored() const;
+    void setLastRxIgnored(std::string value);
+    bool lastRxIgnoredIsSet() const;
+    void unsetLast_rx_ignored();
+    /// <summary>
     /// Current NTP server poll period, in seconds
     /// </summary>
     int64_t getPollPeriod() const;
     void setPollPeriod(int64_t value);
-    bool pollPeriodIsSet() const;
-    void unsetPoll_period();
-    /// <summary>
+        /// <summary>
+    /// Received packets that were ignored due to an invalid origin timestamp or stratum, e.g. a Kiss-o&#39;-Death packet 
+    /// </summary>
+    int64_t getRxIgnored() const;
+    void setRxIgnored(int64_t value);
+        /// <summary>
     /// Received packets
     /// </summary>
     int64_t getRxPackets() const;
@@ -73,8 +91,14 @@ public:
     void unsetStratum();
 
 protected:
+    std::string m_Last_rx_accepted;
+    bool m_Last_rx_acceptedIsSet;
+    std::string m_Last_rx_ignored;
+    bool m_Last_rx_ignoredIsSet;
     int64_t m_Poll_period;
-    bool m_Poll_periodIsSet;
+
+    int64_t m_Rx_ignored;
+
     int64_t m_Rx_packets;
 
     int64_t m_Tx_packets;

--- a/tests/aat/api/v1/client/models/time_source_stats_ntp.py
+++ b/tests/aat/api/v1/client/models/time_source_stats_ntp.py
@@ -31,34 +31,91 @@ class TimeSourceStatsNtp(object):
                             and the value is json key in definition.
     """
     swagger_types = {
+        'last_rx_accepted': 'datetime',
+        'last_rx_ignored': 'datetime',
         'poll_period': 'int',
+        'rx_ignored': 'int',
         'rx_packets': 'int',
         'tx_packets': 'int',
         'stratum': 'int'
     }
 
     attribute_map = {
+        'last_rx_accepted': 'last_rx_accepted',
+        'last_rx_ignored': 'last_rx_ignored',
         'poll_period': 'poll_period',
+        'rx_ignored': 'rx_ignored',
         'rx_packets': 'rx_packets',
         'tx_packets': 'tx_packets',
         'stratum': 'stratum'
     }
 
-    def __init__(self, poll_period=None, rx_packets=None, tx_packets=None, stratum=None):  # noqa: E501
+    def __init__(self, last_rx_accepted=None, last_rx_ignored=None, poll_period=None, rx_ignored=None, rx_packets=None, tx_packets=None, stratum=None):  # noqa: E501
         """TimeSourceStatsNtp - a model defined in Swagger"""  # noqa: E501
 
+        self._last_rx_accepted = None
+        self._last_rx_ignored = None
         self._poll_period = None
+        self._rx_ignored = None
         self._rx_packets = None
         self._tx_packets = None
         self._stratum = None
         self.discriminator = None
 
-        if poll_period is not None:
-            self.poll_period = poll_period
+        if last_rx_accepted is not None:
+            self.last_rx_accepted = last_rx_accepted
+        if last_rx_ignored is not None:
+            self.last_rx_ignored = last_rx_ignored
+        self.poll_period = poll_period
+        self.rx_ignored = rx_ignored
         self.rx_packets = rx_packets
         self.tx_packets = tx_packets
         if stratum is not None:
             self.stratum = stratum
+
+    @property
+    def last_rx_accepted(self):
+        """Gets the last_rx_accepted of this TimeSourceStatsNtp.  # noqa: E501
+
+        the time and date of the last accepted NTP reply, in ISO8601 format  # noqa: E501
+
+        :return: The last_rx_accepted of this TimeSourceStatsNtp.  # noqa: E501
+        :rtype: datetime
+        """
+        return self._last_rx_accepted
+
+    @last_rx_accepted.setter
+    def last_rx_accepted(self, last_rx_accepted):
+        """Sets the last_rx_accepted of this TimeSourceStatsNtp.
+
+        the time and date of the last accepted NTP reply, in ISO8601 format  # noqa: E501
+
+        :param last_rx_accepted: The last_rx_accepted of this TimeSourceStatsNtp.  # noqa: E501
+        :type: datetime
+        """
+        self._last_rx_accepted = last_rx_accepted
+
+    @property
+    def last_rx_ignored(self):
+        """Gets the last_rx_ignored of this TimeSourceStatsNtp.  # noqa: E501
+
+        The time and date of the last ignored NTP reply, in ISO8601 format  # noqa: E501
+
+        :return: The last_rx_ignored of this TimeSourceStatsNtp.  # noqa: E501
+        :rtype: datetime
+        """
+        return self._last_rx_ignored
+
+    @last_rx_ignored.setter
+    def last_rx_ignored(self, last_rx_ignored):
+        """Sets the last_rx_ignored of this TimeSourceStatsNtp.
+
+        The time and date of the last ignored NTP reply, in ISO8601 format  # noqa: E501
+
+        :param last_rx_ignored: The last_rx_ignored of this TimeSourceStatsNtp.  # noqa: E501
+        :type: datetime
+        """
+        self._last_rx_ignored = last_rx_ignored
 
     @property
     def poll_period(self):
@@ -81,6 +138,28 @@ class TimeSourceStatsNtp(object):
         :type: int
         """
         self._poll_period = poll_period
+
+    @property
+    def rx_ignored(self):
+        """Gets the rx_ignored of this TimeSourceStatsNtp.  # noqa: E501
+
+        Received packets that were ignored due to an invalid origin timestamp or stratum, e.g. a Kiss-o'-Death packet   # noqa: E501
+
+        :return: The rx_ignored of this TimeSourceStatsNtp.  # noqa: E501
+        :rtype: int
+        """
+        return self._rx_ignored
+
+    @rx_ignored.setter
+    def rx_ignored(self, rx_ignored):
+        """Sets the rx_ignored of this TimeSourceStatsNtp.
+
+        Received packets that were ignored due to an invalid origin timestamp or stratum, e.g. a Kiss-o'-Death packet   # noqa: E501
+
+        :param rx_ignored: The rx_ignored of this TimeSourceStatsNtp.  # noqa: E501
+        :type: int
+        """
+        self._rx_ignored = rx_ignored
 
     @property
     def rx_packets(self):

--- a/tests/aat/api/v1/docs/TimeSourceStatsNtp.md
+++ b/tests/aat/api/v1/docs/TimeSourceStatsNtp.md
@@ -3,7 +3,10 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**poll_period** | **int** | Current NTP server poll period, in seconds | [optional] 
+**last_rx_accepted** | **datetime** | the time and date of the last accepted NTP reply, in ISO8601 format | [optional] 
+**last_rx_ignored** | **datetime** | The time and date of the last ignored NTP reply, in ISO8601 format | [optional] 
+**poll_period** | **int** | Current NTP server poll period, in seconds | 
+**rx_ignored** | **int** | Received packets that were ignored due to an invalid origin timestamp or stratum, e.g. a Kiss-o&#39;-Death packet  | 
 **rx_packets** | **int** | Received packets | 
 **tx_packets** | **int** | Transmitted packets | 
 **stratum** | **int** | Time source distance from a NTP reference clock, in network hops.  | [optional] 

--- a/tests/aat/common/matcher/timesync.py
+++ b/tests/aat/common/matcher/timesync.py
@@ -29,6 +29,21 @@ class _be_valid_keeper(Matcher):
         return True, ['is valid keeper']
 
 
+class _be_valid_source_ntp_stats(Matcher):
+    def _match(self, stats):
+        expect(stats).to(be_a(client.models.TimeSourceStatsNtp))
+        expect(stats.poll_period).not_to(be_none)
+        expect(stats.rx_ignored).not_to(be_none)
+        expect(stats.rx_packets).not_to(be_none)
+        expect(stats.tx_packets).not_to(be_none)
+        if stats.rx_packets > 0:
+            expect(stats.last_rx_accepted).to(be_a(datetime))
+            expect(stats.stratum).to(be_above_or_equal(1))
+        if stats.rx_ignored > 0:
+            expect(stats.last_rx_ingored).to(be_a(datetime))
+        return True, ['is valid source ntp stats']
+
+
 class _be_valid_source(Matcher):
     def _match(self, source):
         expect(source).to(be_a(client.models.TimeSource))
@@ -39,9 +54,7 @@ class _be_valid_source(Matcher):
             ntp = source.config.ntp
             expect(ntp).to(be_a(client.models.TimeSourceConfigNtp))
             expect(ntp.hostname).not_to(be_empty)
-
-            expect(source.stats.ntp).to(be_a(client.models.TimeSourceStatsNtp))
-
+            expect(source.stats.ntp).to(be_valid_source_ntp_stats)
             return True, ['is valid ntp source']
         elif source.kind == 'system':
             expect(source.stats.system).to(be_a(client.models.TimeSourceStatsSystem))
@@ -52,4 +65,5 @@ class _be_valid_source(Matcher):
 
 be_valid_counter = _be_valid_counter()
 be_valid_keeper = _be_valid_keeper()
+be_valid_source_ntp_stats = _be_valid_source_ntp_stats()
 be_valid_source = _be_valid_source()


### PR DESCRIPTION
Add three new statistics to the NTP source stats object:

* last_rx_accepted: timestamp of the last accepted NTP reply
* last_rx_ignored: timestamp of the last ignored NTP reply
* rx_ignored: the number of ignored NTP replies

Additionally, change the behavior of the existing rx_packets counter.
From now on it reports the total number of NTP replies instead of just
the NTP replies used to update the clock.

Update AAT's to recongize the new statistics.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/532)
<!-- Reviewable:end -->
