### PR TITLE
mk: change dpdk ibverbs linking

### DIFF
--- a/mk/dpdk.mk
+++ b/mk/dpdk.mk
@@ -56,6 +56,7 @@ DPDK_MESON_OPTS := --prefix=$(DPDK_TGT_DIR) \
 	-Dc_std=gnu11 \
 	-Denable_driver_sdk=true \
 	-Denable_drivers=$(call op_make_comma_delimited,$(DPDK_DRIVERS)) \
+	-Dibverbs_link=dlopen \
 	-Dlibdir=lib \
 	-Dtests=false
 


### PR DESCRIPTION
Build DPDK with the dlopen option for ibverbs. This minimizes the number
of dynamically linked libraries on the openperf binary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/546)
<!-- Reviewable:end -->
