### PR TITLE
fixed the Debian packaging support

### DIFF
--- a/pkg/deb/install.mk
+++ b/pkg/deb/install.mk
@@ -18,12 +18,11 @@ OP_LIB_NAME := libopenperf-shim.so
 BUILD_PLUGINS_DIR := $(abspath $(dir $(BUILD_BIN_DIR))/plugins)
 PLUGINS_SRC_FILES := $(shell find $(BUILD_PLUGINS_DIR) -type f -name "*.so")
 PLUGINS_TGT_DIR := $(abspath $(DESTDIR)/usr/lib/openperf/plugins)
-PLUGINS_TGT_FILES := $(subst $(BUILD_PLUGINS_DIR)/,$(PLUGINS_TGT_DIR)/,$(PLUGINS_SRC_FILES))
+PLUGINS_TGT_FILES := $(foreach _f,$(PLUGINS_SRC_FILES),$(PLUGINS_TGT_DIR)/$(notdir $(_f)))
 BUILD_DPDK_LIB_DIR := $(abspath $(dir $(BUILD_BIN_DIR))/dpdk/lib)
 DPDK_LIB_SRC_FILES := $(shell find $(BUILD_DPDK_LIB_DIR) -type f -name "*glue.so*")
 DPDK_LIB_TGT_DIR := $(abspath $(DESTDIR)/usr/lib)
-DPDK_LIB_TGT_FILES := $(subst $(BUILD_DPDK_LIB_DIR)/,$(DPDK_LIB_TGT_DIR)/,$(DPDK_LIB_SRC_FILES))
-
+DPDK_LIB_TGT_FILES := $(foreach _f,$(DPDK_LIB_SRC_FILES),$(DPDK_LIB_TGT_DIR)/$(notdir $(_f)))
 .PHONY: all install
 
 all:

--- a/pkg/deb/templates/lintian-overrides
+++ b/pkg/deb/templates/lintian-overrides
@@ -2,8 +2,5 @@
 openperf: embedded-library usr/bin/openperf: libpcap
 
 # Miscellaneous
-openperf: new-package-should-close-itp-bug
-openperf: sharedobject-in-library-directory-missing-soname usr/lib/libopenperf-shim.so
 openperf: binary-without-manpage usr/bin/openperf
-openperf: package-name-doesnt-match-sonames librte-pmd-mlx4-glue18.02.0 librte-pmd-mlx5-glue19.08.0
-openperf: shlib-in-multi-arch-foreign-package usr/lib/librte_pmd_mlx5_glue.so.19.08.0
+openperf: sharedobject-in-library-directory-missing-soname usr/lib/libopenperf-shim.so


### PR DESCRIPTION
* Recent changes changed the binary output directory structure. The makefiles supporting the Debian packaging only worked when processing shared libraries one directory deep. The makefiles did not account for this. The problem occurred for the shared libraries, but this fix has been applied to the plugin processing as well.
* Adjusted the lintian file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/548)
<!-- Reviewable:end -->
