### PR TITLE
modules/cpu: change aggregate available stat

### DIFF
--- a/src/modules/cpu/cpu_transmogrify.cpp
+++ b/src/modules/cpu/cpu_transmogrify.cpp
@@ -390,7 +390,7 @@ to_swagger(const std::vector<generator::result::core_shard>& shards,
 {
     auto dst = std::make_shared<swagger::v1::model::CpuGeneratorStats>();
 
-    dst->setAvailable(to_nanoseconds(sum.available() * shards.size()).count());
+    dst->setAvailable(to_nanoseconds(sum.available()).count());
     dst->setError(to_nanoseconds(sum.error()).count());
     dst->setSteal(to_nanoseconds(sum.steal()).count());
     dst->setSystem(to_nanoseconds(sum.system).count());


### PR DESCRIPTION
When aggregated, the available CPU stat reported the total run time
times the number of available cores. Adjust that stat to only report the
total run time. This provides consistency with dynamic results and allows
usage calculations to match intended configuration loads, e.g. one fully
loaded core = 100% load.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/553)
<!-- Reviewable:end -->
