### PR TITLE
add vscode .devcontainer files

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,46 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.158.0/containers/docker-existing-dockerfile
+{
+	"name": "OpenPerf devcontainer",
+	// Dockerfile doesn't need anything local so just use .devcontainer folder
+	"context": ".",
+	// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+	"dockerFile": "../build/Dockerfile",
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"ms-vscode.cpptools",
+		"ms-vscode.cpptools-extension-pack",
+		"streetsidesoftware.code-spell-checker",
+		"xaver.clang-format"
+	],
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [
+		9000
+	],
+	// Command to run before building the container
+	// The make_dockerfile.sh script generates the Dockerfile which will be used
+	"initializeCommand": [
+		"bash",
+		".devcontainer/make_dockerfile.sh"
+	],
+	// Uncomment the next line to run commands after the container is created - for example installing curl.
+	// "postCreateCommand": "apt-get update && apt-get install -y curl",
+	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
+	// NOTE: --privileged option was added so /dev is populated from the host so block io AAT will pass
+	"runArgs": [
+		"--cap-add=IPC_LOCK",
+		"--cap-add=NET_ADMIN",
+		"--cap-add=NET_RAW",
+		"--cap-add=SYS_ADMIN",
+		"--cap-add=SYS_PTRACE",
+		"--security-opt=seccomp=unconfined",
+		"--privileged"
+	],
+	// Uncomment to use the Docker CLI from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker.
+	// "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
+	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "${localEnv:USER}",
+	"containerUser": "root"
+}

--- a/.devcontainer/make_dockerfile.sh
+++ b/.devcontainer/make_dockerfile.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Create Dockerfile from CI Dockerfile for the devcontainer
+#
+
+DEVCONTAINER_DIR=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+TOP_DIR=$(realpath ${DEVCONTAINER_DIR}/..)
+BUILD_DIR=${TOP_DIR}/build
+DOCKERFILE="Dockerfile"
+
+mkdir -p ${BUILD_DIR}
+
+cp -f ${TOP_DIR}/${DOCKERFILE} ${BUILD_DIR}/${DOCKERFILE}
+
+cat << EOF >> ${BUILD_DIR}/${DOCKERFILE}
+
+
+# Install Java for code generator
+RUN apt-get update && apt-get install -y --no-install-recommends default-jre-headless
+
+# Install golang for code generator
+ENV GO_VERSION=1.16.5
+RUN wget https://dl.google.com/go/go\${GO_VERSION}.linux-amd64.tar.gz && \\
+    tar zxf go\${GO_VERSION}.linux-amd64.tar.gz -C /usr/local && \\
+    rm -f go\${GO_VERSION}.linux-amd64.tar.gz && \\
+    update-alternatives --install /usr/bin/go go /usr/local/go/bin/go 1 && \\
+    update-alternatives --install /usr/bin/gofmt gofmt /usr/local/go/bin/gofmt 1
+
+# Install gdb
+RUN apt-get update && apt-get install -y gdb
+
+# Add user account w/ sudo privileges
+RUN useradd ${USER} --home-dir=/home/${USER} --create-home --shell=/bin/bash && \\
+    echo "${USER} ALL=(root) NOPASSWD: ALL" >> /etc/sudoers.d/${USER}
+
+EOF

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,10 @@ build/
 # OSX cruft
 .DS_Store
 
+# vscode cruft
+.vscode/*.log
+
 # clang compiler database
 compile_commands.json
+
+

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,32 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "openperf: (gdb) Unit Test",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/tests-linux-x86_64-testing/bin/test_openperf",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}/tests/unit",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+                {
+                    "description": "Set Disassembly Flavor to Intel",
+                    "text": "-gdb-set disassembly-flavor intel",
+                    "ignoreFailures": true
+                }
+            ]
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,18 @@
+{
+    "editor.formatOnSave": true,
+    "clang-format.executable": "/usr/bin/clang-format-7",
+    "files.watcherExclude": {
+        "build/**": true,
+        "deps/**": true
+    },
+    "cSpell.words": [
+        "cpptools",
+        "devcontainer",
+        "ptrace",
+        "seccomp",
+        "xaver"
+    ],
+    "files.associations": {
+        "string_view": "cpp"
+    }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,151 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "openperf: Build",
+            "type": "shell",
+            "command": "make all",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": true,
+                "clear": true
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "openperf: Make depends",
+            "type": "shell",
+            "command": "make deps",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": true,
+                "clear": true
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "openperf: Run All Tests",
+            "type": "shell",
+            "command": "make test",
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            },
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": true,
+                "clear": true
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "openperf: Run Unit Tests",
+            "type": "shell",
+            "command": "make test_unit",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": true,
+                "clear": true
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "openperf: Run AAT",
+            "type": "shell",
+            "command": "make test_aat",
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            },
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": true,
+                "clear": true
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "openperf: Run AAT (verbose)",
+            "type": "shell",
+            "command": "pushd tests/aat; ./env/bin/mamba spec --format=documentation; popd",
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            },
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": true,
+                "clear": true
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "openperf: Schema Codegen",
+            "type": "shell",
+            "command": "mkdir -p ${HOME}/go && make schema_codegen",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": true,
+                "clear": true
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "openperf: Clean",
+            "type": "shell",
+            "command": "make clean",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": true,
+                "clear": true
+            },
+            "problemMatcher": []
+        }
+    ]
+}


### PR DESCRIPTION
Add vscode files for development using a devcontainer environment.
This has been tested on WSL2 and on a Linux server using SSH.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/555)
<!-- Reviewable:end -->
