### PR TITLE
modules/packetio: add libpcap dependency

### DIFF
--- a/src/modules/packetio/directory.mk
+++ b/src/modules/packetio/directory.mk
@@ -1,7 +1,7 @@
 #
 # Makefile component to specify PacketIO code
 #
-PIO_DEPENDS += expected framework packet swagger_model versions
+PIO_DEPENDS += expected framework libpcap packet swagger_model versions
 
 PIO_SOURCES += \
 	init.cpp \


### PR DESCRIPTION
This is required because interface BPF support requires pcap.h

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spirent/openperf/557)
<!-- Reviewable:end -->
