### PR TITLE
modules/packetio: DPDK lcore cpuset support

### DIFF
--- a/src/framework/core/op_cpuset_wrapper.cpp
+++ b/src/framework/core/op_cpuset_wrapper.cpp
@@ -184,7 +184,10 @@ int cpuset_set_affinity(const cpuset& set)
 cpuset cpuset_get_affinity()
 {
     auto set = cpuset();
-    op_thread_get_affinity_mask(set.data());
+    if (auto error = op_thread_get_affinity_mask(set.data())) {
+        throw std::runtime_error("Could not retrieve CPU affinity mask: "
+                                 + std::string(strerror(error)));
+    }
     return (set);
 }
 

--- a/src/modules/packetio/drivers/dpdk/directory.mk
+++ b/src/modules/packetio/drivers/dpdk/directory.mk
@@ -24,6 +24,9 @@ PIO_DRIVER_SOURCES += \
 	quirks.cpp \
 	topology_utils.cpp
 
+# ALLOW_EXPERIMENTAL_API is required for rte_lcore_cpuset()
+$(PIO_OBJ_DIR)/drivers/dpdk/topology_utils.o: OP_CPPFLAGS += -DALLOW_EXPERIMENTAL_API
+
 ifeq ($(OP_PACKETIO_DPDK_PROCESS_TYPE),primary)
 	PIO_DRIVER_SOURCES += \
 		primary/arg_parser.cpp \

--- a/src/modules/packetio/drivers/dpdk/driver.tcc
+++ b/src/modules/packetio/drivers/dpdk/driver.tcc
@@ -246,7 +246,7 @@ static void do_bootstrap()
                "DPDK lcore %d cpuset %s",
                lcore_id,
                lcore_cpuset.to_string().c_str());
-        if (cpuset_saved == cpuset) {
+        if (lcore_cpuset == cpuset_saved) {
             continue; // skip lcore if using all cores (it is not pinned)
         }
         cpuset &= ~lcore_cpuset;

--- a/src/modules/packetio/drivers/dpdk/topology_utils.hpp
+++ b/src/modules/packetio/drivers/dpdk/topology_utils.hpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <unordered_map>
 
+#include "core/op_cpuset.hpp"
 #include "packetio/drivers/dpdk/port_info.hpp"
 #include "packetio/drivers/dpdk/queue_utils.hpp"
 
@@ -17,6 +18,11 @@ namespace openperf::packetio::dpdk::topology {
 std::optional<unsigned> get_stack_lcore_id();
 
 std::vector<uint16_t> get_ports();
+
+/**
+ * Get the cpuset used for the specified lcore ID.
+ */
+core::cpuset get_lcore_cpuset(unsigned lcore_id);
 
 /**
  * Use the port queue counts to generate a vector of queue


### PR DESCRIPTION
This change fixes issues when lcores use more than 1 CPU (cpuset).

When an lcore cpuset spans multiple NUMA nodes the lcore is not assigned to a socket ID.  The stack code was using the invalid socket ID from the lcore thread to determine the mempool and was causing a crash.

The stack code was changed to use socket ID 0 when the socket ID is not valid.  Additional code was added to handle cases where the device NUMA affiliation does not match the CPU NUMA node.

The packetio driver init was also made lcore cpuset aware so it removes cpus from the default cpuset based off of the cpuset assigned to the lcore instead of assuming the lcore ID is the CPU ID.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Spirent/openperf/558)
<!-- Reviewable:end -->
