### PR TITLE
packet/stack: add ipv6 gateway and prefix length

### DIFF
--- a/src/modules/packet/stack/dpdk/net_interface.hpp
+++ b/src/modules/packet/stack/dpdk/net_interface.hpp
@@ -15,6 +15,14 @@ struct rte_mbuf;
 
 namespace openperf::packet::stack::dpdk {
 
+struct netif_ext
+{
+    // lwip doesn't support IPv6 prefix length or default gateway, so these need
+    // to be stored outside of the netif
+    std::array<uint8_t, LWIP_IPV6_NUM_ADDRESSES> ip6_address_prefix_len;
+    std::optional<ip6_addr_t> ip6_gateway;
+};
+
 class net_interface
 {
 public:
@@ -48,6 +56,8 @@ public:
 
     err_t handle_tx(struct pbuf*);
 
+    friend netif_ext& get_netif_ext(netif*);
+
 private:
     void configure();
     void unconfigure();
@@ -61,9 +71,12 @@ private:
     const packet_filter m_tx_filter;
 
     netif m_netif;
+    netif_ext m_netif_ext;
 };
 
 const net_interface& to_interface(netif*);
+
+netif_ext& get_netif_ext(netif*);
 
 } // namespace openperf::packet::stack::dpdk
 

--- a/src/modules/packet/stack/lwip/include/lwipopts.h
+++ b/src/modules/packet/stack/lwip/include/lwipopts.h
@@ -130,6 +130,10 @@
 #define LWIP_ND6_NUM_NEIGHBORS 127
 #define LWIP_ND6_NUM_DESTINATIONS 127
 
+/* Number of entries in IPv6 default router cache.
+ * The cache is used for all interfaces so probably want at least 1 router per interface.
+ */
+#define LWIP_ND6_NUM_ROUTERS 16
 /*
  * Debugging options
  * Enable the next three options plus whatever content you want.

--- a/src/modules/packet/stack/lwip/nd6_op.h
+++ b/src/modules/packet/stack/lwip/nd6_op.h
@@ -13,10 +13,50 @@
 extern "C" {
 #endif /* __cplusplus */
 
-s8_t nd6_get_next_hop_entry(const ip6_addr_t *ip6addr, struct netif *netif);
+s8_t nd6_get_next_hop_entry_probe(const ip6_addr_t *ip6addr, struct netif *netif, int probe);
 
 int
-neighbor_cache_get_entry(size_t i, ip6_addr_t **ipaddr, u8_t **lladdr_ret);
+neighbor_cache_get_entry(size_t i, ip6_addr_t **ipaddr, u8_t **lladdr_ret, u8_t* state);
+
+/*
+ * lwip only supports IPv6 prefix length /64 and does not support default gateway address.
+ *
+ * The code below adds basic support for both of these features.
+ * The IPv6 prefix length and gateway address are stored in the net_interface class.
+ * Ideally these would be added to the netif struct.
+ */
+
+/**
+ * @ingroup netif
+ * Compare if the addresses have the same prefix.
+ * @param addr1 pointer to first IPv6 address
+ * @param addr2 pointer to second IPv6 address
+ * @param prefix_len The IPv6 network prefix length.
+ */
+static inline int ip6_addr_netcmp_prefix_zoneless(const ip6_addr_t *addr1, const ip6_addr_t *addr2, u8_t prefix_len)
+{
+  const u8_t *a1 = (const u8_t*)addr1;
+  const u8_t *a2 = (const u8_t*)addr2;
+  ldiv_t r;
+  u8_t mask;
+
+  if (prefix_len > 128) prefix_len = 128;
+  r = ldiv(prefix_len, 8);
+  if (r.quot && memcmp(a1, a2, r.quot) != 0) return 0;
+  if (!r.rem) return 1;
+  mask = (0xff << (8 - r.rem));
+  return (a1[r.quot] & mask) == (a2[r.quot] & mask);
+}
+
+#define ip6_addr_netcmp_prefix(addr1, addr2, prefix_len) \
+    (ip6_addr_netcmp_prefix_zoneless((addr1), (addr2), prefix_len) && \
+                                     ip6_addr_cmp_zone((addr1), (addr2)))
+
+u8_t netif_ip6_prefix_len(struct netif *netif, int idx);
+void netif_set_ip6_prefix_len(struct netif *netif, int idx, u8_t prefix_len);
+
+const ip6_addr_t * netif_ip6_gateway_addr(struct netif *netif);
+void netif_set_ip6_gateway_addr(struct netif *netif, const ip6_addr_t *addr);
 
 #ifdef __cplusplus
 }

--- a/src/modules/packet/stack/lwip/netifapi_ipv6.c
+++ b/src/modules/packet/stack/lwip/netifapi_ipv6.c
@@ -21,6 +21,7 @@
 #include "lwip/dhcp6.h"
 #include "lwip/priv/tcpip_priv.h"
 #include "packet/stack/lwip/netifapi_ipv6.h"
+#include "packet/stack/lwip/nd6_op.h"
 
 #include <string.h> /* strncpy */
 
@@ -37,8 +38,14 @@ struct netifapi_ipv6_msg
         struct
         {
             NETIFAPI_IPADDR_DEF(ip6_addr_t, ipaddr);
+            NETIFAPI_IPADDR_DEF(ip6_addr_t, gwaddr);
             s8_t addr_idx;
+            u8_t prefix_len;
         } add;
+        struct
+        {
+            NETIFAPI_IPADDR_DEF(ip6_addr_t, ipaddr);
+        } gateway;
     } msg;
 };
 
@@ -70,17 +77,27 @@ static err_t netifapi_do_netif_add_ip6_address(struct tcpip_api_call_data* m)
     /* cast through void* to silence alignment warnings.
      * We know it works because the structs have been instantiated as struct
      * netifapi_msg */
+    err_t err;
     struct netifapi_ipv6_msg* msg = (struct netifapi_ipv6_msg*)(void*)m;
 
-    return netif_add_ip6_address(msg->netif,
+    if ((err = netif_add_ip6_address(msg->netif,
                                  API_EXPR_REF(msg->msg.add.ipaddr),
-                                 &API_EXPR_REF(msg->msg.add.addr_idx));
+                                 &API_EXPR_REF(msg->msg.add.addr_idx))) != 0)
+        return err;
+#if LWIP_IPV6_DUP_DETECT_ATTEMPTS == 0
+    /* Address is always valid when not using duplicate address detection.
+     * netif_create_ip6_linklocal_address() does this, but netif_add_ip6_address() does not.
+     */
+    netif_ip6_addr_set_state(msg->netif, API_EXPR_REF(msg->msg.add.addr_idx), IP6_ADDR_PREFERRED);
+#endif
+    netif_set_ip6_prefix_len(msg->netif, API_EXPR_REF(msg->msg.add.addr_idx), API_EXPR_REF(msg->msg.add.prefix_len));
+    return err;
 }
 
 /**
  * Call netif_ip6_addr_set() inside the tcpip_thread context.
  */
-static err_t netifapi_do_netif_ip6_addr_set(struct tcpip_api_call_data* m)
+static err_t netifapi_do_netif_set_ip6_address(struct tcpip_api_call_data* m)
 {
     /* cast through void* to silence alignment warnings.
      * We know it works because the structs have been instantiated as struct
@@ -90,6 +107,20 @@ static err_t netifapi_do_netif_ip6_addr_set(struct tcpip_api_call_data* m)
     netif_ip6_addr_set(msg->netif,
                        API_EXPR_REF(msg->msg.add.addr_idx),
                        API_EXPR_REF(msg->msg.add.ipaddr));
+    netif_set_ip6_prefix_len(msg->netif, API_EXPR_REF(msg->msg.add.addr_idx), API_EXPR_REF(msg->msg.add.prefix_len));
+    return ERR_OK;
+}
+
+/**
+ * Call netif_set_ip6_gateway() inside the tcpip_thread context.
+ */
+static err_t netifapi_do_netif_set_ip6_gateway(struct tcpip_api_call_data* m)
+{
+    /* cast through void* to silence alignment warnings.
+     * We know it works because the structs have been instantiated as struct
+     * netifapi_msg */
+    struct netifapi_ipv6_msg* msg = (struct netifapi_ipv6_msg*)(void*)m;
+    netif_set_ip6_gateway_addr(msg->netif, API_EXPR_REF(msg->msg.gateway.ipaddr));
     return ERR_OK;
 }
 
@@ -125,6 +156,7 @@ err_t netifapi_netif_create_ip6_linklocal_address(struct netif* netif,
  */
 err_t netifapi_netif_add_ip6_address(struct netif* netif,
                                      const ip6_addr_t* ipaddr,
+                                     u8_t prefix_len,
                                      s8_t* chosen_idx)
 {
     err_t err;
@@ -135,6 +167,7 @@ err_t netifapi_netif_add_ip6_address(struct netif* netif,
 
     NETIFAPI_VAR_REF(msg).netif = netif;
     NETIFAPI_VAR_REF(msg).msg.add.ipaddr = NETIFAPI_VAR_REF(ipaddr);
+    NETIFAPI_VAR_REF(msg).msg.add.prefix_len = prefix_len;
     NETIFAPI_VAR_REF(msg).msg.add.addr_idx = 0;
     err = tcpip_api_call(netifapi_do_netif_add_ip6_address,
                          &API_VAR_REF(msg).call);
@@ -150,9 +183,10 @@ err_t netifapi_netif_add_ip6_address(struct netif* netif,
  *
  * @note for params @see netif_ip6_addr_set()
  */
-err_t netifapi_netif_ip6_addr_set(struct netif* netif,
-                                  s8_t addr_idx,
-                                  const ip6_addr_t* ipaddr)
+err_t netifapi_netif_set_ip6_address(struct netif* netif,
+                                     s8_t addr_idx,
+                                     const ip6_addr_t* ipaddr,
+                                     u8_t prefix_len)
 {
     err_t err;
     NETIFAPI_VAR_DECLARE(msg);
@@ -161,10 +195,33 @@ err_t netifapi_netif_ip6_addr_set(struct netif* netif,
     if (ipaddr == NULL) { ipaddr = IP6_ADDR_ANY6; }
 
     NETIFAPI_VAR_REF(msg).netif = netif;
-    NETIFAPI_VAR_REF(msg).msg.add.addr_idx = NETIFAPI_VAR_REF(addr_idx);
+    NETIFAPI_VAR_REF(msg).msg.add.addr_idx = addr_idx;
     NETIFAPI_VAR_REF(msg).msg.add.ipaddr = NETIFAPI_VAR_REF(ipaddr);
+    NETIFAPI_VAR_REF(msg).msg.add.prefix_len = prefix_len;
     err =
-        tcpip_api_call(netifapi_do_netif_ip6_addr_set, &API_VAR_REF(msg).call);
+        tcpip_api_call(netifapi_do_netif_set_ip6_address, &API_VAR_REF(msg).call);
+    NETIFAPI_VAR_FREE(msg);
+    return err;
+}
+
+/**
+ * @ingroup netifapi_netif
+ * Set interface gateway address in a thread-safe way by running that function
+ * inside the tcpip_thread context.
+ */
+err_t netifapi_netif_set_ip6_gateway(struct netif* netif,
+                                     const ip6_addr_t* gateway)
+{
+    err_t err;
+    NETIFAPI_VAR_DECLARE(msg);
+    NETIFAPI_VAR_ALLOC(msg);
+
+    if (gateway == NULL) { gateway = IP6_ADDR_ANY6; }
+
+    NETIFAPI_VAR_REF(msg).netif = netif;
+    NETIFAPI_VAR_REF(msg).msg.gateway.ipaddr = NETIFAPI_VAR_REF(gateway);
+    err =
+        tcpip_api_call(netifapi_do_netif_set_ip6_gateway, &API_VAR_REF(msg).call);
     NETIFAPI_VAR_FREE(msg);
     return err;
 }

--- a/src/modules/packet/stack/lwip/netifapi_ipv6.h
+++ b/src/modules/packet/stack/lwip/netifapi_ipv6.h
@@ -15,11 +15,16 @@ err_t netifapi_netif_create_ip6_linklocal_address(struct netif* netif,
 
 err_t netifapi_netif_add_ip6_address(struct netif* netif,
                                      const ip6_addr_t* ipaddr,
+                                     u8_t prefix_len,
                                      s8_t* chosen_idx);
 
-err_t netifapi_netif_ip6_addr_set(struct netif* netif,
+err_t netifapi_netif_set_ip6_address(struct netif* netif,
                                   s8_t addr_idx,
-                                  const ip6_addr_t* ipaddr);
+                                  const ip6_addr_t* ipaddr,
+                                  u8_t prefix_len);
+
+err_t netifapi_netif_set_ip6_gateway(struct netif* netif,
+                                     const ip6_addr_t* gateway);
 
 err_t netifapi_dhcp6_enable_stateless(struct netif* netif);
 

--- a/src/modules/packetio/interface_utils.cpp
+++ b/src/modules/packetio/interface_utils.cpp
@@ -145,6 +145,13 @@ static void validate(const ipv6_static_protocol_config& config,
             errors.emplace_back("Cannot use multicast address ("
                                 + to_string(*config.gateway)
                                 + ") for gateway.");
+        } else if (is_linklocal(*config.gateway)) {
+            if (!config.link_local_address) {
+                errors.emplace_back(
+                    "Cannot use link local address ("
+                    + to_string(*config.gateway)
+                    + ") for gateway without link local interface address.");
+            }
         } else if (ipv6_network(*config.gateway, config.prefix_length)
                    != ipv6_network(config.address, config.prefix_length)) {
             errors.emplace_back(


### PR DESCRIPTION
This change adds minimal support for lwip IPv6 gateway and prefix length.

The IPv6 gateway and prefix lengths are stored outside of the lwip netif in the network_interface class so that the netif.h header doesn't need to be modified.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Spirent/openperf/560)
<!-- Reviewable:end -->
