### PR TITLE
Ipv6 learning fix

### DIFF
--- a/.devcontainer/make_dockerfile.sh
+++ b/.devcontainer/make_dockerfile.sh
@@ -20,17 +20,25 @@ RUN apt-get update && apt-get install -y --no-install-recommends default-jre-hea
 
 # Install golang for code generator
 ENV GO_VERSION=1.16.5
-RUN wget https://dl.google.com/go/go\${GO_VERSION}.linux-amd64.tar.gz && \\
-    tar zxf go\${GO_VERSION}.linux-amd64.tar.gz -C /usr/local && \\
-    rm -f go\${GO_VERSION}.linux-amd64.tar.gz && \\
-    update-alternatives --install /usr/bin/go go /usr/local/go/bin/go 1 && \\
-    update-alternatives --install /usr/bin/gofmt gofmt /usr/local/go/bin/gofmt 1
+RUN wget https://dl.google.com/go/go\${GO_VERSION}.linux-amd64.tar.gz \\
+    && tar zxf go\${GO_VERSION}.linux-amd64.tar.gz -C /usr/local \\
+    && rm -f go\${GO_VERSION}.linux-amd64.tar.gz \\
+    && update-alternatives --install /usr/bin/go go /usr/local/go/bin/go 1 \\
+    && update-alternatives --install /usr/bin/gofmt gofmt /usr/local/go/bin/gofmt 1
 
 # Install gdb
 RUN apt-get update && apt-get install -y gdb
 
+
 # Add user account w/ sudo privileges
-RUN useradd ${USER} --home-dir=/home/${USER} --create-home --shell=/bin/bash && \\
-    echo "${USER} ALL=(root) NOPASSWD: ALL" >> /etc/sudoers.d/${USER}
+# Note:
+#   Current vscode remote development package v0.24.0 has an issue when initializing
+#   the ~/.ssh directory.  The issue does not occur when mounting the host ~/.ssh
+#   directory or if a ~/.ssh/known_hosts file exists.
+RUN useradd ${USER} --home-dir=/home/${USER} --create-home --shell=/bin/bash \\
+    && echo "${USER} ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/${USER} \\
+    && mkdir -p /home/${USER}/.ssh \\
+    && touch /home/${USER}/.ssh/known_hosts \\
+    && chown -R ${USER} /home/${USER}
 
 EOF


### PR DESCRIPTION
 Fix IPv6 learning so that it will send neighbor solict requests the entire learning time.

 Prior to this change learning woud send 1 packet every second for the 1st 3 seconds
 and then wait another 27 seconds doing nothing.

This change restarts the ND probe if the address has not been resolved.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Spirent/openperf/563)
<!-- Reviewable:end -->
