### PR TITLE
modules/packetio: af_packet driver enhancements

### DIFF
--- a/src/modules/packetio/drivers/dpdk/port_info.cpp
+++ b/src/modules/packetio/drivers/dpdk/port_info.cpp
@@ -67,14 +67,14 @@ uint32_t max_lro_pkt_size(uint16_t port_id)
                 : max_rx_pktlen(port_id));
 }
 
-uint32_t default_rx_mtu(uint16_t port_id)
+uint32_t max_mtu(uint16_t port_id)
 {
-    /*
-     * Some drivers require configuring MTU to receive jumbo packets.
-     */
-    auto max_len = port_info::max_rx_pktlen(port_id);
-    if (max_len >= RTE_ETHER_HDR_LEN) max_len -= RTE_ETHER_HDR_LEN;
-    return std::max(max_len, static_cast<uint32_t>(RTE_ETHER_MIN_MTU));
+    uint32_t eth_size = (RTE_ETHER_HDR_LEN + RTE_ETHER_CRC_LEN + RTE_VLAN_HLEN);
+    return (
+        std::clamp(static_cast<uint32_t>(
+                       get_info_field(port_id, &rte_eth_dev_info::max_mtu)),
+                   static_cast<uint32_t>(RTE_ETHER_MIN_MTU),
+                   max_rx_pktlen(port_id) - eth_size - RTE_PKTMBUF_HEADROOM));
 }
 
 uint32_t max_mac_addrs(uint16_t port_id)

--- a/src/modules/packetio/drivers/dpdk/port_info.hpp
+++ b/src/modules/packetio/drivers/dpdk/port_info.hpp
@@ -24,7 +24,7 @@ libpacket::type::mac_address mac_address(uint16_t port_id);
 uint32_t speeds(uint16_t port_id);
 uint32_t max_speed(uint16_t port_id);
 uint32_t max_rx_pktlen(uint16_t port_id);
-uint32_t default_rx_mtu(uint16_t port_id);
+uint32_t max_mtu(uint16_t port_id);
 uint32_t max_lro_pkt_size(uint16_t port_id);
 uint32_t max_mac_addrs(uint16_t port_id);
 

--- a/src/modules/packetio/drivers/dpdk/primary/utils.cpp
+++ b/src/modules/packetio/drivers/dpdk/primary/utils.cpp
@@ -125,7 +125,7 @@ static rte_eth_conf make_rte_eth_conf(uint16_t port_id)
         .link_speeds = ETH_LINK_SPEED_AUTONEG,
         .rxmode =
             {
-                .mtu = port_info::default_rx_mtu(port_id),
+                .mtu = port_info::max_mtu(port_id),
                 .mq_mode = port_info::rx_mq_mode(port_id),
                 .max_lro_pkt_size = port_info::max_lro_pkt_size(port_id)
                                     - quirks::adjust_max_rx_pktlen(port_id),


### PR DESCRIPTION
- add support for larger MTU.  tested up to 9000 MTU
- add option to af_packet driver to not configure the kernel interface It may not be safe to modify the interface in some environments

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Spirent/openperf/566)
<!-- Reviewable:end -->
