### PR TITLE
dpdk: upgrade from 21.11 release to stable branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "deps/dpdk"]
 	path = deps/dpdk
-	url = https://github.com/DPDK/dpdk
+	url = https://github.com/DPDK/dpdk-stable.git
+    branch = 21.11
 [submodule "deps/libzmq"]
 	path = deps/libzmq
 	url = https://github.com/zeromq/libzmq.git


### PR DESCRIPTION
Upgrade the DPDK library from 21.11 release to 21.11 stable branch to pull in additional patches.

The library was upgraded to fix issues with the iavf driver intermittently failing to initialize due to detecting interface in reset state.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Spirent/openperf/569)
<!-- Reviewable:end -->
