### PR TITLE
modules/packetio: add ports-required option

### DIFF
--- a/src/modules/packetio/drivers/dpdk/arg_parser.cpp
+++ b/src/modules/packetio/drivers/dpdk/arg_parser.cpp
@@ -176,6 +176,16 @@ std::map<uint16_t, std::string> dpdk_id_map()
     return (to_return);
 }
 
+bool dpdk_ports_required()
+{
+    static const auto required =
+        config::file::op_config_get_param<OP_OPTION_TYPE_NONE>(
+            op_packetio_dpdk_ports_required)
+            .value_or(false);
+
+    return (required);
+}
+
 static std::optional<core::cpuset> get_mask_argument(std::string_view name)
 {
     if (const auto mask =

--- a/src/modules/packetio/drivers/dpdk/arg_parser.hpp
+++ b/src/modules/packetio/drivers/dpdk/arg_parser.hpp
@@ -14,6 +14,7 @@ extern const char op_packetio_dpdk_misc_worker_mask[];
 extern const char op_packetio_dpdk_no_init[];
 extern const char op_packetio_dpdk_options[];
 extern const char op_packetio_dpdk_port_ids[];
+extern const char op_packetio_dpdk_ports_required[];
 extern const char op_packetio_dpdk_rx_worker_mask[];
 extern const char op_packetio_dpdk_tx_worker_mask[];
 extern const char op_packetio_dpdk_drop_tx_overruns[];
@@ -28,6 +29,8 @@ bool dpdk_disabled();
 
 std::map<uint16_t, std::string>
 dpdk_id_map(); /**< Retrieve a copy of port idx->id map */
+
+bool dpdk_ports_required();
 
 std::optional<core::cpuset> packetio_mask();
 std::optional<core::cpuset> misc_core_mask();

--- a/src/modules/packetio/drivers/dpdk/arg_parser_register.c
+++ b/src/modules/packetio/drivers/dpdk/arg_parser_register.c
@@ -7,6 +7,7 @@ const char op_packetio_dpdk_misc_worker_mask[] =
 const char op_packetio_dpdk_no_init[] = "modules.packetio.dpdk.no-init";
 const char op_packetio_dpdk_options[] = "modules.packetio.dpdk.options";
 const char op_packetio_dpdk_port_ids[] = "modules.packetio.dpdk.port-ids";
+const char op_packetio_dpdk_ports_required[] = "modules.packetio.dpdk.ports-required";
 const char op_packetio_dpdk_rx_worker_mask[] =
     "modules.packetio.dpdk.rx-worker-mask";
 const char op_packetio_dpdk_tx_worker_mask[] =
@@ -34,6 +35,10 @@ MAKE_OPTION_DATA(
              op_packetio_dpdk_port_ids,
              0,
              OP_OPTION_TYPE_MAP),
+    MAKE_OPT("require DPDK ports are present, if not found then exit.",
+             op_packetio_dpdk_ports_required,
+             0,
+             OP_OPTION_TYPE_NONE),
     MAKE_OPT("skip DPDK initialization",
              op_packetio_dpdk_no_init,
              0,

--- a/src/modules/packetio/init.cpp
+++ b/src/modules/packetio/init.cpp
@@ -38,7 +38,19 @@ struct service
 
     bool init(void* context)
     {
-        m_driver = driver::make();
+        try {
+            m_driver = driver::make();
+        } catch (const std::exception& e) {
+            OP_LOG(OP_LOG_CRITICAL,
+                   "Failed to initialize PacketIO driver.  %s",
+                   e.what());
+            // Exit process if driver throws an exception.
+            // This was added to allow restarting the process and trying again.
+            // Note: sleep() allows final log message to get logged
+            sleep(1);
+            exit(EXIT_FAILURE);
+        }
+
         if (!m_driver->is_usable()) {
             OP_LOG(OP_LOG_WARNING,
                    "No usable PacketIO driver available; skipping "


### PR DESCRIPTION
add ports-required option which causes openperf to exit if it does not find all ports specified in the configuration.

This option was added to support recovery when running in container environments (kubernetes).  There were cases where the DPDK library fails to intialize a VF interface due to the interface being in a reset state and cases where the PF driver does not respond to admin messages.  This appears to be a transient condition when the system is under load and the VF interface eventually seems to recover.

Previously without this option enabled, openperf will log a warning and startup without the intefaces.  This makes it hard to detect issues and recover from it.

With the ports-required option enabled, openperf will exit if it does not find all of the ports it expects which makes it easier to detect a problem and try again.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Spirent/openperf/570)
<!-- Reviewable:end -->
