### PR TITLE
fix event timeout crash

### DIFF
--- a/src/modules/cpu/generator/coordinator.cpp
+++ b/src/modules/cpu/generator/coordinator.cpp
@@ -323,7 +323,15 @@ template <typename T> using remove_cvref_t = typename remove_cvref<T>::type;
 
 int coordinator::do_load_update()
 {
-    assert(m_results);
+    if (!m_results) {
+        // Prevent crash by validating m_results is still valid.
+
+        // Originally event_loop del() did not prevent callbacks from pending
+        // events. This should not happen anymore.
+        OP_LOG(OP_LOG_ERROR, "do_load_update called with no active results");
+        return 0;
+    }
+
     assert(m_prev_sum);
 
     m_results->do_dynamic_update();

--- a/src/modules/memory/generator/coordinator.cpp
+++ b/src/modules/memory/generator/coordinator.cpp
@@ -303,7 +303,15 @@ std::chrono::duration<double> to_seconds(const Duration& duration)
 
 int coordinator::do_load_update()
 {
-    assert(m_results);
+    if (!m_results) {
+        // Prevent crash by validating m_results is still valid.
+
+        // Originally event_loop del() did not prevent callbacks from pending
+        // events. This should not happen anymore.
+        OP_LOG(OP_LOG_ERROR, "do_load_update called with no active results");
+        return 0;
+    }
+
     assert(m_prev_sum);
 
     m_results->do_dynamic_update();


### PR DESCRIPTION
The cpu/memeory generators intermittently crashed in the load update timeout handler due to accessing a results object previously deleted by stop().

The issue appears to have been caused because the event loop may still dispatch pending events after they have been deleted from the event loop in an event handler because they aren't actually removed until later.

This change fixes the issue by marking the events as deleted so they can be ingored until they can be safely removed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Spirent/openperf/574)
<!-- Reviewable:end -->
