### PR TITLE
modules/memory: fix read-only test without mlock

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   acceptance_tests:
     machine:
-      image: ubuntu-2004:202201-02
+      image: ubuntu-2404:2024.11.1
     steps:
       - attach_workspace:
           at: "~"


### PR DESCRIPTION
This change fixes the memory generator read-only mode when mlock() is not supported/allowed.

When mlock() is not supported/allowed, a read-only test does not appear to be accessing RAM because the read rates are much higher than the write rates.  This is likely because memory is not being allocated for the mmap.

This change fixes the issue by touching the mmap memory, which forces it to get allocated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Spirent/openperf/575)
<!-- Reviewable:end -->
