### PR TITLE
schema: Interface stats should be optional

### DIFF
--- a/api/client/golang/models/interface.go
+++ b/api/client/golang/models/interface.go
@@ -33,8 +33,7 @@ type Interface struct {
 	PortID *string `json:"port_id"`
 
 	// stats
-	// Required: true
-	Stats *InterfaceStats `json:"stats"`
+	Stats *InterfaceStats `json:"stats,omitempty"`
 }
 
 // Validate validates this interface
@@ -100,9 +99,8 @@ func (m *Interface) validatePortID(formats strfmt.Registry) error {
 }
 
 func (m *Interface) validateStats(formats strfmt.Registry) error {
-
-	if err := validate.Required("stats", "body", m.Stats); err != nil {
-		return err
+	if swag.IsZero(m.Stats) { // not required
+		return nil
 	}
 
 	if m.Stats != nil {

--- a/api/schema/v1/modules/packetio.yaml
+++ b/api/schema/v1/modules/packetio.yaml
@@ -322,7 +322,6 @@ definitions:
       - id
       - port_id
       - config
-      - stats
 
   InterfaceProtocolConfig:
     type: object

--- a/src/swagger/v1/model/Interface.cpp
+++ b/src/swagger/v1/model/Interface.cpp
@@ -21,6 +21,7 @@ Interface::Interface()
 {
     m_Id = "";
     m_Port_id = "";
+    m_StatsIsSet = false;
     
 }
 
@@ -40,7 +41,10 @@ nlohmann::json Interface::toJson() const
     val["id"] = ModelBase::toJson(m_Id);
     val["port_id"] = ModelBase::toJson(m_Port_id);
     val["config"] = ModelBase::toJson(m_Config);
-    val["stats"] = ModelBase::toJson(m_Stats);
+    if(m_StatsIsSet)
+    {
+        val["stats"] = ModelBase::toJson(m_Stats);
+    }
     
 
     return val;
@@ -50,6 +54,16 @@ void Interface::fromJson(nlohmann::json& val)
 {
     setId(val.at("id"));
     setPortId(val.at("port_id"));
+    if(val.find("stats") != val.end())
+    {
+        if(!val["stats"].is_null())
+        {
+            std::shared_ptr<InterfaceStats> newItem(new InterfaceStats());
+            newItem->fromJson(val["stats"]);
+            setStats( newItem );
+        }
+        
+    }
     
 }
 
@@ -88,7 +102,15 @@ std::shared_ptr<InterfaceStats> Interface::getStats() const
 void Interface::setStats(std::shared_ptr<InterfaceStats> value)
 {
     m_Stats = value;
-    
+    m_StatsIsSet = true;
+}
+bool Interface::statsIsSet() const
+{
+    return m_StatsIsSet;
+}
+void Interface::unsetStats()
+{
+    m_StatsIsSet = false;
 }
 
 }

--- a/src/swagger/v1/model/Interface.h
+++ b/src/swagger/v1/model/Interface.h
@@ -70,7 +70,9 @@ public:
     /// </summary>
     std::shared_ptr<InterfaceStats> getStats() const;
     void setStats(std::shared_ptr<InterfaceStats> value);
-    
+    bool statsIsSet() const;
+    void unsetStats();
+
 protected:
     std::string m_Id;
 
@@ -79,7 +81,7 @@ protected:
     std::shared_ptr<Interface_config> m_Config;
 
     std::shared_ptr<InterfaceStats> m_Stats;
-
+    bool m_StatsIsSet;
 };
 
 }

--- a/tests/aat/api/v1/client/models/interface.py
+++ b/tests/aat/api/v1/client/models/interface.py
@@ -56,7 +56,8 @@ class Interface(object):
         self.id = id
         self.port_id = port_id
         self.config = config
-        self.stats = stats
+        if stats is not None:
+            self.stats = stats
 
     @property
     def id(self):

--- a/tests/aat/api/v1/docs/Interface.md
+++ b/tests/aat/api/v1/docs/Interface.md
@@ -6,7 +6,7 @@ Name | Type | Description | Notes
 **id** | **str** | Unique interface identifier | 
 **port_id** | **str** | Port identifier | 
 **config** | [**InterfaceConfig**](InterfaceConfig.md) |  | 
-**stats** | [**InterfaceStats**](InterfaceStats.md) |  | 
+**stats** | [**InterfaceStats**](InterfaceStats.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 


### PR DESCRIPTION
Should not require Interface stats when creating an interface.