### PR TITLE
deb: remove python3 package dependency

### DIFF
--- a/pkg/deb/templates/control
+++ b/pkg/deb/templates/control
@@ -9,7 +9,7 @@ Homepage: https://github.com/Spirent/openperf
 Package: openperf
 Architecture: {{ARCHITECTURE}}
 Multi-Arch: foreign
-Depends: ${misc:Depends}, ${shlibs:Depends}, python3 (>= 3.5)
+Depends: ${misc:Depends}, ${shlibs:Depends}
 Recommends: {{PKG_RECOMMENDS}}
 Description: Spirent Network and Load Generator
  Provides an infrastructure and application test and analysis framework.


### PR DESCRIPTION
python3 is not required for openperf