### PR TITLE
Upgrade DPDK from 21.11 to 24.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,10 @@
 version: 2.1
 
+parameters:
+  ci_build_image:
+    type: string
+    default: "public.ecr.aws/u6h7q0t4/openperf/openperf-ci:latest"
+
 jobs:
   acceptance_tests:
     machine:
@@ -9,10 +14,10 @@ jobs:
           at: "~"
       - run:
           name: Download latest openperf container
-          command: docker pull spirentorion/openperf:latest
+          command: docker pull << pipeline.parameters.ci_build_image >>
       - run:
           name: Run containerized build and test
-          command: docker run -it --privileged -v ~/project:/root/project spirentorion/openperf:latest /bin/bash -c "cd /root/project/tests/aat && make junit"
+          command: docker run -it --privileged -v ~/project:/root/project << pipeline.parameters.ci_build_image >> /bin/bash -c "cd /root/project/tests/aat && make junit"
       - run:
           name: Collect AAT log
           when: always
@@ -28,7 +33,7 @@ jobs:
 
   build:
     docker:
-      - image: spirentorion/openperf:latest
+      - image: << pipeline.parameters.ci_build_image >>
     steps:
       - checkout
       - run:
@@ -45,7 +50,7 @@ jobs:
 
   build_secondary:
     docker:
-      - image: spirentorion/openperf:latest
+      - image: << pipeline.parameters.ci_build_image >>
     steps:
       - checkout
       - run:
@@ -56,7 +61,7 @@ jobs:
 
   cross_compile_aarch64:
     docker:
-      - image: spirentorion/openperf:latest
+      - image: << pipeline.parameters.ci_build_image >>
     steps:
       - checkout
       - run:
@@ -69,7 +74,7 @@ jobs:
 
   static_analysis:
     docker:
-      - image: spirentorion/openperf:latest
+      - image: << pipeline.parameters.ci_build_image >>
     steps:
       - attach_workspace:
           at: "~"
@@ -79,7 +84,7 @@ jobs:
 
   unit_tests:
     docker:
-      - image: spirentorion/openperf:latest
+      - image: << pipeline.parameters.ci_build_image >>
     steps:
       - checkout
       - run:

--- a/.circleci/run_build.sh
+++ b/.circleci/run_build.sh
@@ -14,4 +14,4 @@ CI_ARCH=core-avx2
 
 # Use bear to generate the compilation database.
 # Treat first CLI argument to this script as additional parameter(s) to make.
-bear make -j${CI_CORES} OP_MACHINE_ARCH=${CI_ARCH} $1 all
+bear -- make -j${CI_CORES} OP_MACHINE_ARCH=${CI_ARCH} $1 all

--- a/.circleci/run_cross_compile_aarch64.sh
+++ b/.circleci/run_cross_compile_aarch64.sh
@@ -1,7 +1,7 @@
 set -xe
 
 SDK_SYSROOT="/usr/aarch64-linux-gnu"
-SDK_CPP_VERSION=8
+SDK_CPP_VERSION=$(aarch64-linux-gnu-gcc -dumpversion)
 SDK_CPPFLAGS="-nostdinc++ -cxx-isystem ${SDK_SYSROOT}/include/c++/${SDK_CPP_VERSION}  -cxx-isystem ${SDK_SYSROOT}/include/c++/${SDK_CPP_VERSION}/aarch64-linux-gnu"
 SDK_CROSS="aarch64-linux-gnu-"
 SDK_LDFLAGS=""
@@ -15,9 +15,10 @@ MAX_CORES=12
 
 CI_CORES=$(if [ $(nproc) -gt ${MAX_CORES} ]; then echo ${MAX_CORES}; else echo $(nproc); fi)
 
+# Note: Need to use / for SYSROOT here because of how debian cross packages work
 make ARCH=aarch64 \
-     OP_SYSROOT="${SDK_SYSROOT}" \
-     OP_EXTRA_CPPFLAGS="${SDK_CPPFLAGS}" \
-     OP_DPDK_CROSS="${SDK_CROSS}" \
-     OP_EXTRA_LDFLAGS="${SDK_LDFLAGS}" \
-     -j${CI_CORES} ${ARGS}
+    OP_SYSROOT="/" \
+    OP_EXTRA_CPPFLAGS="${SDK_CPPFLAGS}" \
+    OP_DPDK_CROSS="${SDK_CROSS}" \
+    OP_EXTRA_LDFLAGS="${SDK_LDFLAGS}" \
+    -j${CI_CORES} ${ARGS}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "deps/dpdk"]
 	path = deps/dpdk
 	url = https://github.com/DPDK/dpdk-stable.git
-    branch = 23.11
+    branch = 24.11
 [submodule "deps/libzmq"]
 	path = deps/libzmq
 	url = https://github.com/zeromq/libzmq.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "deps/dpdk"]
 	path = deps/dpdk
 	url = https://github.com/DPDK/dpdk-stable.git
-    branch = 21.11
+    branch = 23.11
 [submodule "deps/libzmq"]
 	path = deps/libzmq
 	url = https://github.com/zeromq/libzmq.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:bookworm
 
 # Inform apt-get that it'll get no such satisfaction from us
 ENV DEBIAN_FRONTEND noninteractive
@@ -8,21 +8,21 @@ ENV DEBIAN_FRONTEND noninteractive
 ###
 
 # Install LLVM and various other tooling
-ENV LLVM_VERSION 7
+ENV LLVM_VERSION 14
 RUN apt-get clean && \
     apt-get update && \
     apt-get install -y --no-install-recommends autoconf automake \
     bison build-essential ca-certificates crossbuild-essential-arm64 \
-    debhelper devscripts flex git libcap-dev libcap2-bin libibverbs-dev \
-    libnuma-dev libtool lintian meson netcat-openbsd \
-    pkg-config python3 python3-pyelftools sudo virtualenv wget \
+    debhelper devscripts flex git iproute2 iputils-ping libcap-dev libcap2-bin \
+    libibverbs-dev libnuma-dev libtool lintian meson netcat-openbsd \
+    pkg-config procps python3 python3-pyelftools sudo virtualenv wget \
     clang-${LLVM_VERSION} clang-format-${LLVM_VERSION} \
     clang-tidy-${LLVM_VERSION} \
     llvm-${LLVM_VERSION} llvm-${LLVM_VERSION}-dev \
     lld-${LLVM_VERSION} bear
 
 # Install Intel SPMD Program Compiler (ISPC)
-ENV ISPC_VERSION 1.16.1
+ENV ISPC_VERSION 1.19.0
 RUN wget -q -O - https://github.com/ispc/ispc/releases/download/v${ISPC_VERSION}/ispc-v${ISPC_VERSION}-linux.tar.gz \
     | tar -C /opt -xvz && \
     chown -R root:root /opt/ispc-v${ISPC_VERSION}-linux/bin/ispc && \
@@ -35,7 +35,8 @@ RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${LLVM_VER
     update-alternatives --install /usr/bin/run-clang-tidy run-clang-tidy /usr/bin/run-clang-tidy-${LLVM_VERSION} ${LLVM_VERSION} && \
     update-alternatives --install /usr/bin/llvm-ar llvm-ar /usr/bin/llvm-ar-${LLVM_VERSION} ${LLVM_VERSION} && \
     update-alternatives --install /usr/bin/llvm-objcopy llvm-objcopy /usr/bin/llvm-objcopy-${LLVM_VERSION} ${LLVM_VERSION} && \
-    update-alternatives --install /usr/bin/lld lld /usr/bin/lld-${LLVM_VERSION} ${LLVM_VERSION}
+    update-alternatives --install /usr/bin/lld lld /usr/bin/lld-${LLVM_VERSION} ${LLVM_VERSION} && \
+    update-alternatives --install /usr/bin/ld.lld ld.lld /usr/bin/lld-${LLVM_VERSION} ${LLVM_VERSION}
 
 # Install other Circle CI dependencies
 RUN apt-get install -y --no-install-recommends openssh-client

--- a/mk/bootstrap.mk
+++ b/mk/bootstrap.mk
@@ -37,7 +37,7 @@ OP_CONFIG_OPTS ?=
 
 # ISPC related build variables
 # See arch/*.mk for ISPC target instruction sets
-OP_ISPC := ispc
+OP_ISPC := ispc --pic
 OP_ISPC_FLAGS += --werror $(OP_EXTRA_ISPC_FLAGS)
 
 OP_BUILD_DEPENDENCIES :=

--- a/mk/pistache.mk
+++ b/mk/pistache.mk
@@ -31,6 +31,7 @@ HTTP_COMMON_SOURCES := \
 	common/base64.cc \
 	common/cookie.cc \
 	common/description.cc \
+	common/eventmeth.cc \
 	common/http.cc \
 	common/http_defs.cc \
 	common/http_header.cc \
@@ -39,8 +40,21 @@ HTTP_COMMON_SOURCES := \
 	common/net.cc \
 	common/os.cc \
 	common/peer.cc \
+	common/pist_check.cc \
+	common/pist_clock_gettime.cc \
+	common/pist_fcntl.cc \
+	common/pist_sockfns.cc \
+	common/pist_syslog.cc \
+	common/pist_ifaddrs.cc \
+	common/pist_resource.cc \
+	common/pist_strerror_r.cc \
+	common/pist_timelog.cc \
+	common/ps_basename.cc \
+	common/ps_sendfile.cc \
+	common/ps_strl.cc \
 	common/reactor.cc \
 	common/stream.cc \
+	common/string_logger.cc \
 	common/tcp.cc \
 	common/timer_pool.cc \
 	common/transport.cc \

--- a/src/framework/core/op_crash_handler.c
+++ b/src/framework/core/op_crash_handler.c
@@ -5,9 +5,10 @@
 
 #include "core/op_common.h"
 
-struct sig_name_pair {
+struct sig_name_pair
+{
     int signo;
-    const char *name;
+    const char* name;
 };
 
 struct sig_name_pair crash_sig_table[] = {
@@ -18,28 +19,32 @@ struct sig_name_pair crash_sig_table[] = {
     {SIGSEGV, "SIGSEGV"},
 };
 
-const int crash_sig_table_size = sizeof(crash_sig_table)/sizeof(crash_sig_table[0]);
+const int crash_sig_table_size =
+    sizeof(crash_sig_table) / sizeof(crash_sig_table[0]);
 
-static const char *signal_id_to_name(int signo) {
+static const char* signal_id_to_name(int signo)
+{
     int i;
-    for (i=0; i<crash_sig_table_size; ++i) {
-        if (crash_sig_table[i].signo == signo)
-            return crash_sig_table[i].name;
+    for (i = 0; i < crash_sig_table_size; ++i) {
+        if (crash_sig_table[i].signo == signo) return crash_sig_table[i].name;
     }
     return "?";
 }
 
-static void crash_handler(int signo, siginfo_t *siginfo, void *context) {
+static void crash_handler(int signo, siginfo_t* siginfo, void* context)
+{
     const int max_symbols = 100;
-    void *symbols[max_symbols];
+    void* symbols[max_symbols];
     int symbol_count = backtrace(symbols, max_symbols);
 
-    fprintf(stderr, "Crash handler received signal %s(%d)\n", signal_id_to_name(signo), signo);
+    fprintf(stderr,
+            "Crash handler received signal %s(%d)\n",
+            signal_id_to_name(signo),
+            signo);
     if (siginfo) {
         if (signo == SIGSEGV || signo == SIGBUS) {
             fprintf(stderr, "Fault address %p\n", siginfo->si_addr);
-        }
-        else if (signo == SIGILL || signo == SIGFPE) {
+        } else if (signo == SIGILL || signo == SIGFPE) {
             fprintf(stderr, "Fault instruction address %p\n", siginfo->si_addr);
         }
     }
@@ -47,14 +52,15 @@ static void crash_handler(int signo, siginfo_t *siginfo, void *context) {
     backtrace_symbols_fd(symbols, symbol_count, STDERR_FILENO);
 }
 
-void op_init_crash_handler() {
+void op_init_crash_handler()
+{
     /* Install crash handler to print stack trace */
     struct sigaction s;
     sigemptyset(&s.sa_mask);
     s.sa_sigaction = crash_handler;
     s.sa_flags = SA_RESTART | SA_SIGINFO | SA_RESETHAND;
     int i;
-    for (i=0; i<crash_sig_table_size; ++i) {
+    for (i = 0; i < crash_sig_table_size; ++i) {
         sigaction(crash_sig_table[i].signo, &s, NULL);
     }
 }

--- a/src/framework/core/op_socket.c
+++ b/src/framework/core/op_socket.c
@@ -166,8 +166,8 @@ bool op_socket_has_messages(void* socket)
 
     int error = zmq_getsockopt(socket, ZMQ_EVENTS, &flags, &flag_size);
 
-    return (error == 0 ? flags & ZMQ_POLLIN
-                       : errno == ETERM ? true /* socket context is gone, force
-                                                  a read so client knows */
-                                        : false);
+    return (error == 0       ? flags & ZMQ_POLLIN
+            : errno == ETERM ? true /* socket context is gone, force
+                                       a read so client knows */
+                             : false);
 }

--- a/src/framework/core/op_task.c
+++ b/src/framework/core/op_task.c
@@ -68,7 +68,7 @@ int op_task_launch(task_fn* task,
     assert(notify);
 
     /* Launch a detached thread */
-    int error = pthread_attr_init(&thread_attr);
+    __attribute__((unused)) int error = pthread_attr_init(&thread_attr);
     assert(!error);
     error = pthread_attr_setdetachstate(&thread_attr, PTHREAD_CREATE_DETACHED);
     assert(!error);

--- a/src/framework/memory/std_allocator.hpp
+++ b/src/framework/memory/std_allocator.hpp
@@ -61,7 +61,7 @@ template <class T, class U, class Impl>
 bool operator==(std_allocator<T, Impl> const& lhs,
                 std_allocator<U, Impl> const& rhs) noexcept
 {
-    return (lhs.base() == rhs.base() & lhs.size() == rhs.size());
+    return (lhs.base() == rhs.base() && lhs.size() == rhs.size());
 }
 
 template <class T, class U, class Impl>

--- a/src/framework/utils/associative_array.hpp
+++ b/src/framework/utils/associative_array.hpp
@@ -14,11 +14,12 @@ constexpr auto associative_array(Pairs&&... pairs)
     return {{std::forward<Pairs>(pairs)...}};
 }
 
-template <typename AssociativeArray,
-          typename Key = decltype(
-              std::declval<typename AssociativeArray::value_type>().first),
-          typename Value = decltype(
-              std::declval<typename AssociativeArray::value_type>().second)>
+template <
+    typename AssociativeArray,
+    typename Key =
+        decltype(std::declval<typename AssociativeArray::value_type>().first),
+    typename Value =
+        decltype(std::declval<typename AssociativeArray::value_type>().second)>
 constexpr std::optional<Value> key_to_value(const AssociativeArray& array,
                                             const Key& key)
 {
@@ -31,11 +32,12 @@ constexpr std::optional<Value> key_to_value(const AssociativeArray& array,
     return (std::nullopt);
 }
 
-template <typename AssociativeArray,
-          typename Key = decltype(
-              std::declval<typename AssociativeArray::value_type>().first),
-          typename Value = decltype(
-              std::declval<typename AssociativeArray::value_type>().second)>
+template <
+    typename AssociativeArray,
+    typename Key =
+        decltype(std::declval<typename AssociativeArray::value_type>().first),
+    typename Value =
+        decltype(std::declval<typename AssociativeArray::value_type>().second)>
 constexpr std::optional<Key> value_to_key(const AssociativeArray& array,
                                           const Value& value)
 {

--- a/src/modules/block/server.cpp
+++ b/src/modules/block/server.cpp
@@ -114,7 +114,8 @@ reply_msg server::handle_request(const request_block_file_bulk_add& request)
     // All-or-nothing behavior
     auto reply = reply_block_files{};
 
-    auto remove_created_items = [&]() -> auto {
+    auto remove_created_items = [&]() -> auto
+    {
         for (const auto& item : reply.files) {
             m_file_stack->delete_block_file(item->id());
         }
@@ -220,7 +221,8 @@ server::handle_request(const request_block_generator_bulk_add& request)
     // All-or-nothing behavior
     auto reply = reply_block_generators{};
 
-    auto remove_created_items = [&]() -> auto {
+    auto remove_created_items = [&]() -> auto
+    {
         for (const auto& item : reply.generators) {
             m_generator_stack->delete_block_generator(item->id());
         }

--- a/src/modules/cpu/generator/function_wrapper.hpp
+++ b/src/modules/cpu/generator/function_wrapper.hpp
@@ -66,8 +66,8 @@ namespace instruction_set = openperf::cpu::instruction_set;
     }                                                                          \
     template <>                                                                \
     constexpr openperf::cpu::generator::function_wrapper<decltype(&ispc::f)>:: \
-        functions_map openperf::cpu::generator::function_wrapper<decltype(     \
-            &ispc::f)>::functions = {                                          \
+        functions_map openperf::cpu::generator::function_wrapper<              \
+            decltype(&ispc::f)>::functions = {                                 \
             ISPC_FUNCTION_WRAPPER_INIT_FUNCTION_DATA(f)}
 
 #endif // _OP_CPU_GENERATOR_FUNCTION_WRAPPER_HPP_

--- a/src/modules/memory/generator/buffer.cpp
+++ b/src/modules/memory/generator/buffer.cpp
@@ -32,12 +32,13 @@ buffer::buffer(size_t size)
                "Could not lock memory buffer; do you need to increase your "
                "resource limit?\n");
 
-        /* If memory can't be locked, then touch it to ensure it is allocated and paged in.
+        /* If memory can't be locked, then touch it to ensure it is allocated
+         * and paged in.
          *
-         * Without doing this, read-only tests may have very high read rates.  This is probably
-         * because RAM is not actually being accessed.
-         * The kernel may be doing memory compression or may not be allocating memory
-         * (sparse allocation) because the memory is never written to.
+         * Without doing this, read-only tests may have very high read rates.
+         * This is probably because RAM is not actually being accessed. The
+         * kernel may be doing memory compression or may not be allocating
+         * memory (sparse allocation) because the memory is never written to.
          */
         if (auto error = madvise(m_data, size, MADV_WILLNEED)) {
             OP_LOG(OP_LOG_ERROR,

--- a/src/modules/packet/analyzer/directory.mk
+++ b/src/modules/packet/analyzer/directory.mk
@@ -35,7 +35,6 @@ $(PA_OBJ_DIR)/handler.o: OP_CXXFLAGS += -Wno-unused-parameter
 $(PA_OBJ_DIR)/init.o: OP_CXXFLAGS += -Wno-unused-parameter
 $(PA_OBJ_DIR)/server.o: OP_CXXFLAGS += -Wno-unused-parameter
 $(PA_OBJ_DIR)/sink.o: OP_CXXFLAGS += -Wno-unused-parameter
-$(PA_OBJ_DIR)/statistics/counter_factory.o: OP_CXXFLAGS += -fbracket-depth=1024
 
 PA_VERSIONED_FILES := init.cpp
 PA_UNVERSIONED_OBJECTS :=\

--- a/src/modules/packet/analyzer/statistics/counter_factory.cpp
+++ b/src/modules/packet/analyzer/statistics/counter_factory.cpp
@@ -105,9 +105,11 @@ template <size_t I> constexpr auto make_flow_counters_constructor()
 template <size_t... I>
 auto make_flow_counters_constructor_index(std::index_sequence<I...>)
 {
-    auto constructors = std::vector<std::function<generic_flow_counters(
-        openperf::utils::bit_flags<flow_digest_flags>)>>{};
-    (constructors.emplace_back(make_flow_counters_constructor<I>()), ...);
+    using constructor_type = std::function<generic_flow_counters(
+        openperf::utils::bit_flags<flow_digest_flags>)>;
+
+    auto constructors =
+        std::vector<constructor_type>{make_flow_counters_constructor<I>()...};
     return (constructors);
 }
 

--- a/src/modules/packet/analyzer/statistics/utils.cpp
+++ b/src/modules/packet/analyzer/statistics/utils.cpp
@@ -10,9 +10,10 @@ constexpr auto associative_array(Pairs&&... pairs)
     return {{std::forward<Pairs>(pairs)...}};
 }
 
-template <typename AssociativeArray,
-          typename EnumType = decltype(
-              std::declval<typename AssociativeArray::value_type>().second)>
+template <
+    typename AssociativeArray,
+    typename EnumType =
+        decltype(std::declval<typename AssociativeArray::value_type>().second)>
 constexpr auto to_api_string(const AssociativeArray& array, EnumType value)
 {
     auto cursor = std::begin(array), end = std::end(array);

--- a/src/modules/packet/capture/pistache_utils.cpp
+++ b/src/modules/packet/capture/pistache_utils.cpp
@@ -143,6 +143,7 @@ Pistache::Tcp::Transport* get_transport(Pistache::Http::ResponseWriter& writer)
         Pistache::Tcp::Transport* transport_;
         Pistache::Http::Timeout timeout_;
         ssize_t sent_bytes;
+        Pistache::Http::Header::Encoding contentEncoding_;
     };
     static_assert(sizeof(MockResponseWriter)
                   == sizeof(Pistache::Http::ResponseWriter));

--- a/src/modules/packet/capture/server.cpp
+++ b/src/modules/packet/capture/server.cpp
@@ -288,15 +288,16 @@ reply_msg server::handle_request(const request_list_captures& request)
 
     if (request.filter && request.filter->count(filter_key_type::source_id)) {
         auto& source = (*request.filter)[filter_key_type::source_id];
-        transform_if(std::begin(m_sinks),
-                     std::end(m_sinks),
-                     std::back_inserter(reply.captures),
-                     [&](const auto& item) {
-                         return (item.template get<sink>().source() == source);
-                     },
-                     [&](const auto& item) {
-                         return (to_swagger(item.template get<sink>()));
-                     });
+        transform_if(
+            std::begin(m_sinks),
+            std::end(m_sinks),
+            std::back_inserter(reply.captures),
+            [&](const auto& item) {
+                return (item.template get<sink>().source() == source);
+            },
+            [&](const auto& item) {
+                return (to_swagger(item.template get<sink>()));
+            });
     } else {
         /* return all captures */
         std::transform(std::begin(m_sinks),
@@ -869,15 +870,16 @@ reply_msg server::handle_request(const request_delete_capture_results&)
 {
     std::vector<result_value_ptr> del_list;
     /* Move all inactive results to del_list */
-    move_if(m_results,
-            del_list,
-            [&](const auto& pair) {
-                auto& result = pair.second;
-                return (!result->parent.active());
-            },
-            [&](auto& results, auto& pair) {
-                results.emplace_back(std::move(pair.second));
-            });
+    move_if(
+        m_results,
+        del_list,
+        [&](const auto& pair) {
+            auto& result = pair.second;
+            return (!result->parent.active());
+        },
+        [&](auto& results, auto& pair) {
+            results.emplace_back(std::move(pair.second));
+        });
 
     /* Sort results in del_list so deferred deletes are last */
     auto cursor = std::stable_partition(

--- a/src/modules/packet/generator/api_strings.cpp
+++ b/src/modules/packet/generator/api_strings.cpp
@@ -16,9 +16,10 @@ constexpr auto to_api_type(const AssociativeArray& array, std::string_view name)
     return (enum_type{0}); /* none */
 }
 
-template <typename AssociativeArray,
-          typename EnumType = decltype(
-              std::declval<typename AssociativeArray::value_type>().second)>
+template <
+    typename AssociativeArray,
+    typename EnumType =
+        decltype(std::declval<typename AssociativeArray::value_type>().second)>
 constexpr auto to_api_string(const AssociativeArray& array, EnumType value)
 {
     auto cursor = std::begin(array), end = std::end(array);

--- a/src/modules/packet/generator/traffic/modifier.hpp
+++ b/src/modules/packet/generator/traffic/modifier.hpp
@@ -176,8 +176,8 @@ auto to_sequence_address_range(const sequence_config<AddressField>& config)
 template <typename Config> auto to_range(const Config& config)
 {
     if constexpr (detail::is_sequence_config<Config>::value) {
-        if constexpr (detail::is_endian_field<decltype(
-                          Config().first)>::value) {
+        if constexpr (detail::is_endian_field<
+                          decltype(Config().first)>::value) {
             return (detail::to_sequence_field_range(config));
         } else {
             return (detail::to_sequence_address_range(config));

--- a/src/modules/packet/generator/validation.cpp
+++ b/src/modules/packet/generator/validation.cpp
@@ -891,7 +891,7 @@ static void validate(const duration_ptr& duration,
 
 static void validate(const load_ptr& load, std::vector<std::string>& errors)
 {
-    if (load->burstSizeIsSet() & (load->getBurstSize() < 1)) {
+    if (load->burstSizeIsSet() && (load->getBurstSize() < 1)) {
         errors.emplace_back("Load burst size must be positive.");
     }
 

--- a/src/modules/packet/generator/validation.cpp
+++ b/src/modules/packet/generator/validation.cpp
@@ -425,10 +425,10 @@ static void validate_protocol(const get_protocol_fn& get_fn,
 
 static uint16_t max_modifier_offset(size_t length, const modifier_ptr& modifier)
 {
-    size_t mod_length =
-        (modifier->ipv4IsSet() || modifier->fieldIsSet()
-             ? 4
-             : modifier->ipv6IsSet() ? 16 : modifier->macIsSet() ? 6 : 0);
+    size_t mod_length = (modifier->ipv4IsSet() || modifier->fieldIsSet() ? 4
+                         : modifier->ipv6IsSet()                         ? 16
+                         : modifier->macIsSet()                          ? 6
+                                                                         : 0);
 
     return (mod_length > length ? 0 : length - mod_length);
 }

--- a/src/modules/packet/stack/api_strings.cpp
+++ b/src/modules/packet/stack/api_strings.cpp
@@ -31,9 +31,10 @@ constexpr auto to_api_type(const AssociativeArray& array, std::string_view name)
     return (enum_type{0}); /* none */
 }
 
-template <typename AssociativeArray,
-          typename EnumType = decltype(
-              std::declval<typename AssociativeArray::value_type>().second)>
+template <
+    typename AssociativeArray,
+    typename EnumType =
+        decltype(std::declval<typename AssociativeArray::value_type>().second)>
 constexpr auto to_api_string(const AssociativeArray& array, EnumType value)
 {
     auto cursor = std::begin(array), end = std::end(array);

--- a/src/modules/packet/stack/dpdk/lwip.cpp
+++ b/src/modules/packet/stack/dpdk/lwip.cpp
@@ -80,7 +80,14 @@ static int lwip_link_status_change_callback(uint16_t port_id,
 {
     assert(event == RTE_ETH_EVENT_INTR_LSC);
     struct rte_eth_link link;
-    rte_eth_link_get_nowait(port_id, &link);
+    auto error = rte_eth_link_get_nowait(port_id, &link);
+    if (error < 0) {
+        OP_LOG(OP_LOG_ERROR,
+               "Failed to query link status for port %u: %s\n",
+               port_id,
+               rte_strerror(std::abs(error)));
+        return (0);
+    }
 
     auto& map = *(reinterpret_cast<lwip::interface_map*>(cb_arg));
 

--- a/src/modules/packet/stack/dpdk/lwip.cpp
+++ b/src/modules/packet/stack/dpdk/lwip.cpp
@@ -87,7 +87,7 @@ static int lwip_link_status_change_callback(uint16_t port_id,
     std::for_each(std::begin(map), std::end(map), [&](auto& pair) {
         if (pair.second->port_index() == port_id) {
             pair.second->handle_link_state_change(link.link_status
-                                                  == ETH_LINK_UP);
+                                                  == RTE_ETH_LINK_UP);
         }
     });
 

--- a/src/modules/packet/stack/dpdk/net_interface.cpp
+++ b/src/modules/packet/stack/dpdk/net_interface.cpp
@@ -249,7 +249,9 @@ static err_t net_interface_dpdk_init(netif* netif)
     /* Finally, check link status and set UP flag if needed */
     rte_eth_link link;
     rte_eth_link_get_nowait(ifp->port_index(), &link);
-    if (link.link_status == ETH_LINK_UP) { netif->flags |= NETIF_FLAG_LINK_UP; }
+    if (link.link_status == RTE_ETH_LINK_UP) {
+        netif->flags |= NETIF_FLAG_LINK_UP;
+    }
 
     return (ERR_OK);
 }
@@ -265,7 +267,7 @@ static int net_interface_link_status_change(uint16_t port_id,
     auto* netif = reinterpret_cast<struct netif*>(arg);
     rte_eth_link link;
     rte_eth_link_get_nowait(port_id, &link);
-    return (link.link_status == ETH_LINK_UP
+    return (link.link_status == RTE_ETH_LINK_UP
                 ? netifapi_netif_set_link_up(netif)
                 : netifapi_netif_set_link_down(netif));
 }

--- a/src/modules/packet/stack/dpdk/net_interface.cpp
+++ b/src/modules/packet/stack/dpdk/net_interface.cpp
@@ -248,7 +248,14 @@ static err_t net_interface_dpdk_init(netif* netif)
 
     /* Finally, check link status and set UP flag if needed */
     rte_eth_link link;
-    rte_eth_link_get_nowait(ifp->port_index(), &link);
+    auto error = rte_eth_link_get_nowait(ifp->port_index(), &link);
+    if (error < 0) {
+        OP_LOG(OP_LOG_ERROR,
+               "Failed to query link status for port %u: %s\n",
+               ifp->port_index(),
+               rte_strerror(std::abs(error)));
+        return (ERR_OK);
+    }
     if (link.link_status == RTE_ETH_LINK_UP) {
         netif->flags |= NETIF_FLAG_LINK_UP;
     }
@@ -266,7 +273,14 @@ static int net_interface_link_status_change(uint16_t port_id,
 
     auto* netif = reinterpret_cast<struct netif*>(arg);
     rte_eth_link link;
-    rte_eth_link_get_nowait(port_id, &link);
+    auto error = rte_eth_link_get_nowait(port_id, &link);
+    if (error < 0) {
+        OP_LOG(OP_LOG_ERROR,
+               "Failed to query link status for port %u: %s\n",
+               port_id,
+               rte_strerror(std::abs(error)));
+        return (0);
+    }
     return (link.link_status == RTE_ETH_LINK_UP
                 ? netifapi_netif_set_link_up(netif)
                 : netifapi_netif_set_link_down(netif));

--- a/src/modules/packet/statistics/protocol/packet_type_counters.hpp
+++ b/src/modules/packet/statistics/protocol/packet_type_counters.hpp
@@ -290,8 +290,8 @@ template <typename... T>
 constexpr auto get_packet_type_mask_impl(const std::tuple<T...>&)
 {
     using tuple_type = typename std::tuple_element<0, std::tuple<T...>>::type;
-    using mask_type = typename std::remove_cv<decltype(
-        std::declval<tuple_type>().mask)>::type;
+    using mask_type = typename std::remove_cv<
+        decltype(std::declval<tuple_type>().mask)>::type;
 
     auto masks = std::array<mask_type, sizeof...(T)>{};
     auto idx = 0U;

--- a/src/modules/packetio/drivers/dpdk/arg_parser_register.c
+++ b/src/modules/packetio/drivers/dpdk/arg_parser_register.c
@@ -7,7 +7,8 @@ const char op_packetio_dpdk_misc_worker_mask[] =
 const char op_packetio_dpdk_no_init[] = "modules.packetio.dpdk.no-init";
 const char op_packetio_dpdk_options[] = "modules.packetio.dpdk.options";
 const char op_packetio_dpdk_port_ids[] = "modules.packetio.dpdk.port-ids";
-const char op_packetio_dpdk_ports_required[] = "modules.packetio.dpdk.ports-required";
+const char op_packetio_dpdk_ports_required[] =
+    "modules.packetio.dpdk.ports-required";
 const char op_packetio_dpdk_rx_worker_mask[] =
     "modules.packetio.dpdk.rx-worker-mask";
 const char op_packetio_dpdk_tx_worker_mask[] =

--- a/src/modules/packetio/drivers/dpdk/directory.mk
+++ b/src/modules/packetio/drivers/dpdk/directory.mk
@@ -27,6 +27,11 @@ PIO_DRIVER_SOURCES += \
 # ALLOW_EXPERIMENTAL_API is required for rte_lcore_cpuset()
 $(PIO_OBJ_DIR)/drivers/dpdk/topology_utils.o: OP_CPPFLAGS += -DALLOW_EXPERIMENTAL_API
 
+# ALLOW_EXPERIMENTAL_API is required for DPDK bond member APIs
+# (rte_eth_bond_member_* and rte_eth_bond_members_get())
+$(PIO_OBJ_DIR)/drivers/dpdk/primary/driver_factory.o: OP_CPPFLAGS += -DALLOW_EXPERIMENTAL_API
+$(PIO_OBJ_DIR)/drivers/dpdk/secondary/driver_factory.o: OP_CPPFLAGS += -DALLOW_EXPERIMENTAL_API
+
 ifeq ($(OP_PACKETIO_DPDK_PROCESS_TYPE),primary)
 	PIO_DRIVER_SOURCES += \
 		primary/arg_parser.cpp \

--- a/src/modules/packetio/drivers/dpdk/driver.tcc
+++ b/src/modules/packetio/drivers/dpdk/driver.tcc
@@ -237,7 +237,7 @@ static void do_bootstrap()
 
     bootstrap();
 
-    /* Remove all DPDK slave cores from our original affinity mask */
+    /* Remove all DPDK member cores from our original affinity mask */
     int lcore_id = 0;
     RTE_LCORE_FOREACH_WORKER(lcore_id)
     {
@@ -257,7 +257,7 @@ static void do_bootstrap()
 
     OP_LOG(OP_LOG_DEBUG, "Non DPDK cpuset %s", cpuset.to_string().c_str());
 
-    /* Now restore the original cpu mask less the DPDK slave cores */
+    /* Now restore the original cpu mask less the DPDK member cores */
     if (auto error = core::cpuset_set_affinity(cpuset)) {
         throw std::runtime_error("Could not set CPU affinity mask: "
                                  + std::string(strerror(error)));
@@ -437,14 +437,14 @@ driver<ProcessType>::create_port(std::string_view id,
 
     std::vector<int> success_record;
     for (auto port_idx : port_indexes) {
-        int error = rte_eth_bond_slave_add(id_or_error, port_idx);
+        int error = rte_eth_bond_member_add(id_or_error, port_idx);
         if (error) {
             for (auto added_id : success_record) {
-                rte_eth_bond_slave_remove(id_or_error, added_id);
+                rte_eth_bond_member_remove(id_or_error, added_id);
             }
             rte_eth_bond_free(name.c_str());
             return tl::make_unexpected(
-                "Failed to add slave port " + std::to_string(port_idx)
+                "Failed to add member port " + std::to_string(port_idx)
                 + " to bond port " + std::to_string(id_or_error) + ": "
                 + std::string(rte_strerror(std::abs(error))));
         }
@@ -474,20 +474,20 @@ driver<ProcessType>::delete_port(std::string_view id)
     }
 
     /*
-     * There is apparently no way to query the number of slaves a port has,
+     * There is apparently no way to query the number of members a port has,
      * so resort to brute force here.
      */
-    std::array<uint16_t, RTE_MAX_ETHPORTS> slaves;
+    std::array<uint16_t, RTE_MAX_ETHPORTS> members;
     int length_or_err =
-        rte_eth_bond_slaves_get(port_idx, slaves.data(), slaves.size());
+        rte_eth_bond_members_get(port_idx, members.data(), members.size());
     if (length_or_err < 0) {
         /* Not sure what else we can do here... */
         OP_LOG(OP_LOG_ERROR,
-               "Could not retrieve slave port ids from bonded port %s\n",
+               "Could not retrieve member port ids from bonded port %s\n",
                id.data());
     } else if (length_or_err > 0) {
         for (int i = 0; i < length_or_err; i++) {
-            rte_eth_bond_slave_remove(port_idx, slaves[i]);
+            rte_eth_bond_member_remove(port_idx, members[i]);
         }
     }
     rte_eth_bond_free(m_bonded_ports[port_idx].c_str());

--- a/src/modules/packetio/drivers/dpdk/driver.tcc
+++ b/src/modules/packetio/drivers/dpdk/driver.tcc
@@ -276,15 +276,16 @@ template <typename ProcessType> driver<ProcessType>::driver()
     auto port_indexes = topology::get_ports();
     auto port_ids = config::dpdk_id_map();
     auto ports_required = config::dpdk_ports_required();
-    
+
     /* Verify configured ports exist */
     for (auto it = std::begin(port_ids); it != std::end(port_ids);) {
         if (std::find(
                 std::begin(port_indexes), std::end(port_indexes), it->first)
             == std::end(port_indexes)) {
             if (ports_required) {
-                /* Raise exception and exit if ports are required and port is missing */
-                throw std::runtime_error("DPDK port " + std::to_string(it->first) + " not found");
+                /* Raise exception if ports are required but not found */
+                throw std::runtime_error(
+                    "DPDK port " + std::to_string(it->first) + " not found");
             } else {
                 /* Drop any configured ports we don't know about */
                 port_ids.erase(it++);

--- a/src/modules/packetio/drivers/dpdk/ethdev/.clang-format
+++ b/src/modules/packetio/drivers/dpdk/ethdev/.clang-format
@@ -1,0 +1,7 @@
+# Disable clang-format for files in this directory because the .c files were
+# ported from DPDK and it is easier to compare changes if the files aren't
+# reformatted
+
+DisableFormat: true
+SortIncludes: false
+

--- a/src/modules/packetio/drivers/dpdk/ethdev/af_packet/rte_eth_af_packet.c
+++ b/src/modules/packetio/drivers/dpdk/ethdev/af_packet/rte_eth_af_packet.c
@@ -23,6 +23,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/ioctl.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
 #include <unistd.h>

--- a/src/modules/packetio/drivers/dpdk/physical_port.tcc
+++ b/src/modules/packetio/drivers/dpdk/physical_port.tcc
@@ -20,7 +20,7 @@ public:
     {
         auto link = rte_eth_link{};
         rte_eth_link_get_nowait(m_idx, &link);
-        return (link.link_status == ETH_LINK_UP
+        return (link.link_status == RTE_ETH_LINK_UP
                     ? static_cast<port::link_speed>(link.link_speed)
                     : port::link_speed::SPEED_UNKNOWN);
     }
@@ -29,15 +29,16 @@ public:
     {
         auto link = rte_eth_link{};
         rte_eth_link_get_nowait(m_idx, &link);
-        return (link.link_status == ETH_LINK_UP ? port::link_status::LINK_UP
-                                                : port::link_status::LINK_DOWN);
+        return (link.link_status == RTE_ETH_LINK_UP
+                    ? port::link_status::LINK_UP
+                    : port::link_status::LINK_DOWN);
     }
 
     port::link_duplex duplex() const
     {
         auto link = rte_eth_link{};
         rte_eth_link_get_nowait(m_idx, &link);
-        return (link.link_duplex == ETH_LINK_FULL_DUPLEX
+        return (link.link_duplex == RTE_ETH_LINK_FULL_DUPLEX
                     ? port::link_duplex::DUPLEX_FULL
                     : port::link_duplex::DUPLEX_HALF);
     }
@@ -66,12 +67,12 @@ public:
 
         auto link = rte_eth_link{};
         rte_eth_link_get_nowait(m_idx, &link);
-        if (link.link_autoneg == ETH_LINK_AUTONEG) {
+        if (link.link_autoneg == RTE_ETH_LINK_AUTONEG) {
             config.auto_negotiation = true;
         } else {
             config.auto_negotiation = false;
             config.speed = static_cast<port::link_speed>(link.link_speed);
-            config.duplex = (link.link_duplex == ETH_LINK_FULL_DUPLEX
+            config.duplex = (link.link_duplex == RTE_ETH_LINK_FULL_DUPLEX
                                  ? port::link_duplex::DUPLEX_FULL
                                  : port::link_duplex::DUPLEX_HALF);
         }

--- a/src/modules/packetio/drivers/dpdk/physical_port.tcc
+++ b/src/modules/packetio/drivers/dpdk/physical_port.tcc
@@ -19,7 +19,8 @@ public:
     port::link_speed speed() const
     {
         auto link = rte_eth_link{};
-        rte_eth_link_get_nowait(m_idx, &link);
+        auto error = rte_eth_link_get_nowait(m_idx, &link);
+        if (error < 0) { return port::link_speed::SPEED_UNKNOWN; }
         return (link.link_status == RTE_ETH_LINK_UP
                     ? static_cast<port::link_speed>(link.link_speed)
                     : port::link_speed::SPEED_UNKNOWN);
@@ -28,7 +29,8 @@ public:
     port::link_status link() const
     {
         auto link = rte_eth_link{};
-        rte_eth_link_get_nowait(m_idx, &link);
+        auto error = rte_eth_link_get_nowait(m_idx, &link);
+        if (error < 0) { return port::link_status::LINK_UNKNOWN; }
         return (link.link_status == RTE_ETH_LINK_UP
                     ? port::link_status::LINK_UP
                     : port::link_status::LINK_DOWN);
@@ -37,7 +39,8 @@ public:
     port::link_duplex duplex() const
     {
         auto link = rte_eth_link{};
-        rte_eth_link_get_nowait(m_idx, &link);
+        auto error = rte_eth_link_get_nowait(m_idx, &link);
+        if (error < 0) { return port::link_duplex::DUPLEX_UNKNOWN; }
         return (link.link_duplex == RTE_ETH_LINK_FULL_DUPLEX
                     ? port::link_duplex::DUPLEX_FULL
                     : port::link_duplex::DUPLEX_HALF);
@@ -66,7 +69,11 @@ public:
                               .mac_address = port_info::mac_address(m_idx)};
 
         auto link = rte_eth_link{};
-        rte_eth_link_get_nowait(m_idx, &link);
+        auto error = rte_eth_link_get_nowait(m_idx, &link);
+        if (error < 0) {
+            config.auto_negotiation = true;
+            return (config);
+        }
         if (link.link_autoneg == RTE_ETH_LINK_AUTONEG) {
             config.auto_negotiation = true;
         } else {

--- a/src/modules/packetio/drivers/dpdk/port/packet_type_decoder.cpp
+++ b/src/modules/packetio/drivers/dpdk/port/packet_type_decoder.cpp
@@ -19,7 +19,36 @@ static uint16_t decode_packet_types([[maybe_unused]] uint16_t port_id,
         packets + nb_packets,
         [](const auto* mbuf) { rte_prefetch0(rte_pktmbuf_mtod(mbuf, void*)); },
         [](auto* mbuf) {
+#if (RTE_VERSION >= RTE_VERSION_NUM(23, 11, 7, 0)                              \
+     && RTE_VERSION < RTE_VERSION_NUM(24, 11, 6, 0))
+            /*
+               There is a known issue with rte_net_get_ptype() in 23.11
+               and 24.11 branches which causes it to return
+               RTE_PTYPE_L2_ETHER_QINQ for normal VLAN packets.
+               https://mails.dpdk.org/archives/stable/2026-April/057407.html
+
+               This code works around the issue by verifying the ether type
+               in the header matches VLAN. If it does, the packet type is
+               updated to RTE_PTYPE_L2_ETHER_VLAN.
+            */
             mbuf->packet_type = rte_net_get_ptype(mbuf, nullptr, decode_mask);
+            if ((mbuf->packet_type & RTE_PTYPE_L2_MASK)
+                == RTE_PTYPE_L2_ETHER_QINQ) {
+                struct rte_ether_hdr eh_copy;
+                auto eh = reinterpret_cast<const struct rte_ether_hdr*>(
+                    rte_pktmbuf_read(mbuf, 0, sizeof(eh_copy), &eh_copy));
+                if ((eh != nullptr)
+                    && (eh->ether_type
+                        == rte_cpu_to_be_16(RTE_ETHER_TYPE_VLAN))) {
+                    mbuf->packet_type = (mbuf->packet_type & ~RTE_PTYPE_L2_MASK)
+                                        | RTE_PTYPE_L2_ETHER_VLAN;
+                }
+            }
+#elif RTE_VERSION >= RTE_VERSION_NUM(24, 11, 6, 0)
+#error Verify rte_net_get_ptype() detects VLAN correctly! If so, remove workaround code above.
+#else
+            mbuf->packet_type = rte_net_get_ptype(mbuf, nullptr, decode_mask);
+#endif
         },
         mbuf_prefetch_offset);
 

--- a/src/modules/packetio/drivers/dpdk/port/signature_decoder.cpp
+++ b/src/modules/packetio/drivers/dpdk/port/signature_decoder.cpp
@@ -103,7 +103,7 @@ static uint16_t detect_signatures([[maybe_unused]] uint16_t port_id,
                 packets + start + count,
                 [](const auto* mbuf) {
                     if constexpr (RTE_CACHE_LINE_SIZE == 64) {
-                        __builtin_prefetch(mbuf->cacheline1, 1, 0);
+                        rte_mbuf_prefetch_part2(const_cast<rte_mbuf*>(mbuf));
                     }
                 },
                 [&](auto idx, auto* mbuf) {

--- a/src/modules/packetio/drivers/dpdk/port/signature_encoder.cpp
+++ b/src/modules/packetio/drivers/dpdk/port/signature_encoder.cpp
@@ -46,8 +46,9 @@ static uint32_t get_link_speed_safe(uint16_t port_id)
      * case, then return the maximum speed of the port as a
      * safe default.
      */
-    return (link.link_status == ETH_LINK_UP ? link.link_speed
-                                            : port_info::max_speed(port_id));
+    return (link.link_status == RTE_ETH_LINK_UP
+                ? link.link_speed
+                : port_info::max_speed(port_id));
 }
 
 using picoseconds = std::chrono::duration<int64_t, std::pico>;

--- a/src/modules/packetio/drivers/dpdk/port/signature_encoder.cpp
+++ b/src/modules/packetio/drivers/dpdk/port/signature_encoder.cpp
@@ -38,7 +38,8 @@ static uint32_t get_link_speed_safe(uint16_t port_id)
 {
     /* Query the port's link speed */
     struct rte_eth_link link;
-    rte_eth_link_get_nowait(port_id, &link);
+    auto error = rte_eth_link_get_nowait(port_id, &link);
+    if (error < 0) { return port_info::max_speed(port_id); }
 
     /*
      * Check the link status.  Sometimes, we get packets before

--- a/src/modules/packetio/drivers/dpdk/port/timestamper.cpp
+++ b/src/modules/packetio/drivers/dpdk/port/timestamper.cpp
@@ -14,7 +14,8 @@ static uint32_t get_link_speed_safe(uint16_t port_id)
 {
     /* Query the port's link speed */
     struct rte_eth_link link;
-    rte_eth_link_get_nowait(port_id, &link);
+    auto error = rte_eth_link_get_nowait(port_id, &link);
+    if (error < 0) { return port_info::max_speed(port_id); }
 
     /*
      * Check the link status.  Sometimes, we get packets before

--- a/src/modules/packetio/drivers/dpdk/port/timestamper.cpp
+++ b/src/modules/packetio/drivers/dpdk/port/timestamper.cpp
@@ -22,8 +22,9 @@ static uint32_t get_link_speed_safe(uint16_t port_id)
      * case, then return the maximum speed of the port as a
      * safe default.
      */
-    return (link.link_status == ETH_LINK_UP ? link.link_speed
-                                            : port_info::max_speed(port_id));
+    return (link.link_status == RTE_ETH_LINK_UP
+                ? link.link_speed
+                : port_info::max_speed(port_id));
 }
 
 static uint16_t timestamp_packets(uint16_t port_id,

--- a/src/modules/packetio/drivers/dpdk/port_info.cpp
+++ b/src/modules/packetio/drivers/dpdk/port_info.cpp
@@ -91,34 +91,34 @@ uint32_t max_speed(uint16_t port_id)
 {
     auto speed_capa = get_info_field(port_id, &rte_eth_dev_info::speed_capa);
 
-    if (speed_capa & ETH_LINK_SPEED_100G) {
-        return (ETH_SPEED_NUM_100G);
-    } else if (speed_capa & ETH_LINK_SPEED_56G) {
-        return (ETH_SPEED_NUM_56G);
-    } else if (speed_capa & ETH_LINK_SPEED_50G) {
-        return (ETH_SPEED_NUM_50G);
-    } else if (speed_capa & ETH_LINK_SPEED_40G) {
-        return (ETH_SPEED_NUM_40G);
-    } else if (speed_capa & ETH_LINK_SPEED_25G) {
-        return (ETH_SPEED_NUM_25G);
-    } else if (speed_capa & ETH_LINK_SPEED_20G) {
-        return (ETH_SPEED_NUM_20G);
-    } else if (speed_capa & ETH_LINK_SPEED_10G) {
-        return (ETH_SPEED_NUM_10G);
-    } else if (speed_capa & ETH_LINK_SPEED_5G) {
-        return (ETH_SPEED_NUM_5G);
-    } else if (speed_capa & ETH_LINK_SPEED_2_5G) {
-        return (ETH_SPEED_NUM_2_5G);
-    } else if (speed_capa & ETH_LINK_SPEED_1G) {
-        return (ETH_SPEED_NUM_1G);
-    } else if (speed_capa & ETH_LINK_SPEED_100M
-               || speed_capa & ETH_LINK_SPEED_100M_HD) {
-        return (ETH_SPEED_NUM_100M);
-    } else if (speed_capa & ETH_LINK_SPEED_10M
-               || speed_capa & ETH_LINK_SPEED_10M_HD) {
-        return (ETH_SPEED_NUM_10M);
+    if (speed_capa & RTE_ETH_LINK_SPEED_100G) {
+        return (RTE_ETH_SPEED_NUM_100G);
+    } else if (speed_capa & RTE_ETH_LINK_SPEED_56G) {
+        return (RTE_ETH_SPEED_NUM_56G);
+    } else if (speed_capa & RTE_ETH_LINK_SPEED_50G) {
+        return (RTE_ETH_SPEED_NUM_50G);
+    } else if (speed_capa & RTE_ETH_LINK_SPEED_40G) {
+        return (RTE_ETH_SPEED_NUM_40G);
+    } else if (speed_capa & RTE_ETH_LINK_SPEED_25G) {
+        return (RTE_ETH_SPEED_NUM_25G);
+    } else if (speed_capa & RTE_ETH_LINK_SPEED_20G) {
+        return (RTE_ETH_SPEED_NUM_20G);
+    } else if (speed_capa & RTE_ETH_LINK_SPEED_10G) {
+        return (RTE_ETH_SPEED_NUM_10G);
+    } else if (speed_capa & RTE_ETH_LINK_SPEED_5G) {
+        return (RTE_ETH_SPEED_NUM_5G);
+    } else if (speed_capa & RTE_ETH_LINK_SPEED_2_5G) {
+        return (RTE_ETH_SPEED_NUM_2_5G);
+    } else if (speed_capa & RTE_ETH_LINK_SPEED_1G) {
+        return (RTE_ETH_SPEED_NUM_1G);
+    } else if (speed_capa & RTE_ETH_LINK_SPEED_100M
+               || speed_capa & RTE_ETH_LINK_SPEED_100M_HD) {
+        return (RTE_ETH_SPEED_NUM_100M);
+    } else if (speed_capa & RTE_ETH_LINK_SPEED_10M
+               || speed_capa & RTE_ETH_LINK_SPEED_10M_HD) {
+        return (RTE_ETH_SPEED_NUM_10M);
     } else {
-        return (ETH_SPEED_NUM_NONE);
+        return (RTE_ETH_SPEED_NUM_NONE);
     }
 }
 
@@ -143,7 +143,8 @@ uint64_t rss_offloads(uint16_t port_id)
 
 enum rte_eth_rx_mq_mode rx_mq_mode(uint16_t port_id)
 {
-    return (rx_queue_max(port_id) == 1 ? ETH_MQ_RX_NONE : ETH_MQ_RX_RSS);
+    return (rx_queue_max(port_id) == 1 ? RTE_ETH_MQ_RX_NONE
+                                       : RTE_ETH_MQ_RX_RSS);
 }
 
 uint16_t rx_queue_count(uint16_t port_id)

--- a/src/modules/packetio/drivers/dpdk/port_info.hpp
+++ b/src/modules/packetio/drivers/dpdk/port_info.hpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <stdexcept>
 
 #ifndef _NETINET_IP6_H
 #define _NETINET_IP6_H
@@ -53,10 +54,15 @@ uint16_t tx_tso_segment_max(uint16_t port_id);
 bool lsc_interrupt(uint16_t port_id);
 
 template <typename T>
-static T get_info_field(int id, T rte_eth_dev_info::*field)
+static T get_info_field(int port_id, T rte_eth_dev_info::*field)
 {
     auto info = rte_eth_dev_info{};
-    rte_eth_dev_info_get(id, &info);
+    auto error = rte_eth_dev_info_get(port_id, &info);
+    if (error < 0) {
+        throw std::runtime_error(
+            std::string("Failed to get device info for port ")
+            + std::to_string(port_id) + ": " + rte_strerror(-error));
+    }
     return (info.*field);
 }
 

--- a/src/modules/packetio/drivers/dpdk/primary/eal_process.cpp
+++ b/src/modules/packetio/drivers/dpdk/primary/eal_process.cpp
@@ -85,12 +85,12 @@ static int log_link_status_change(uint16_t port_id,
     assert(event == RTE_ETH_EVENT_INTR_LSC);
     struct rte_eth_link link;
     rte_eth_link_get_nowait(port_id, &link);
-    if (link.link_status == ETH_LINK_UP) {
+    if (link.link_status == RTE_ETH_LINK_UP) {
         OP_LOG(OP_LOG_INFO,
                "Port %u Link Up - speed %u Mbps - %s-duplex\n",
                port_id,
                link.link_speed,
-               link.link_duplex == ETH_LINK_FULL_DUPLEX ? "full" : "half");
+               link.link_duplex == RTE_ETH_LINK_FULL_DUPLEX ? "full" : "half");
     } else {
         OP_LOG(OP_LOG_INFO, "Port %u Link Down\n", port_id);
     }

--- a/src/modules/packetio/drivers/dpdk/primary/eal_process.cpp
+++ b/src/modules/packetio/drivers/dpdk/primary/eal_process.cpp
@@ -84,7 +84,14 @@ static int log_link_status_change(uint16_t port_id,
 {
     assert(event == RTE_ETH_EVENT_INTR_LSC);
     struct rte_eth_link link;
-    rte_eth_link_get_nowait(port_id, &link);
+    auto error = rte_eth_link_get_nowait(port_id, &link);
+    if (error < 0) {
+        OP_LOG(OP_LOG_ERROR,
+               "Failed to query link status for port %u: %s\n",
+               port_id,
+               rte_strerror(std::abs(error)));
+        return (0);
+    }
     if (link.link_status == RTE_ETH_LINK_UP) {
         OP_LOG(OP_LOG_INFO,
                "Port %u Link Up - speed %u Mbps - %s-duplex\n",

--- a/src/modules/packetio/drivers/dpdk/primary/queue_utils.cpp
+++ b/src/modules/packetio/drivers/dpdk/primary/queue_utils.cpp
@@ -10,16 +10,12 @@ uint16_t suggested_queue_count(uint16_t nb_ports,
                                uint16_t nb_queues,
                                uint16_t nb_threads)
 {
-    return (
-        nb_threads == 1
-            ? 1
+    return (nb_threads == 1 ? 1
             : nb_ports < nb_threads
-                  ? (nb_threads % nb_ports == 0
-                         ? std::min(
-                             nb_queues,
-                             static_cast<uint16_t>(nb_threads / nb_ports))
-                         : std::min(nb_queues, nb_threads))
-                  : std::min(nb_queues, static_cast<uint16_t>(nb_threads - 1)));
+                ? (nb_threads % nb_ports == 0 ? std::min(
+                       nb_queues, static_cast<uint16_t>(nb_threads / nb_ports))
+                                              : std::min(nb_queues, nb_threads))
+                : std::min(nb_queues, static_cast<uint16_t>(nb_threads - 1)));
 }
 
 } // namespace openperf::packetio::dpdk::queue

--- a/src/modules/packetio/drivers/dpdk/primary/topology_utils.cpp
+++ b/src/modules/packetio/drivers/dpdk/primary/topology_utils.cpp
@@ -8,9 +8,7 @@ std::vector<uint16_t> get_ports()
 {
     auto ids = std::vector<uint16_t>{};
     uint16_t port_id = 0;
-    RTE_ETH_FOREACH_DEV (port_id) {
-        ids.emplace_back(port_id);
-    }
+    RTE_ETH_FOREACH_DEV (port_id) { ids.emplace_back(port_id); }
 
     return (ids);
 }

--- a/src/modules/packetio/drivers/dpdk/primary/utils.cpp
+++ b/src/modules/packetio/drivers/dpdk/primary/utils.cpp
@@ -73,23 +73,23 @@ static uint32_t eth_link_speed_flag(port::link_speed speed,
                                     port::link_duplex duplex)
 {
     static std::unordered_map<port::link_speed, uint32_t> hd_flags = {
-        {port::link_speed::SPEED_10M, ETH_LINK_SPEED_10M_HD},
-        {port::link_speed::SPEED_100M, ETH_LINK_SPEED_100M_HD},
+        {port::link_speed::SPEED_10M, RTE_ETH_LINK_SPEED_10M_HD},
+        {port::link_speed::SPEED_100M, RTE_ETH_LINK_SPEED_100M_HD},
     };
 
     static std::unordered_map<port::link_speed, uint32_t> fd_flags = {
-        {port::link_speed::SPEED_10M, ETH_LINK_SPEED_10M},
-        {port::link_speed::SPEED_100M, ETH_LINK_SPEED_100M},
-        {port::link_speed::SPEED_1G, ETH_LINK_SPEED_1G},
-        {port::link_speed::SPEED_2_5G, ETH_LINK_SPEED_2_5G},
-        {port::link_speed::SPEED_5G, ETH_LINK_SPEED_5G},
-        {port::link_speed::SPEED_10G, ETH_LINK_SPEED_10G},
-        {port::link_speed::SPEED_20G, ETH_LINK_SPEED_20G},
-        {port::link_speed::SPEED_25G, ETH_LINK_SPEED_25G},
-        {port::link_speed::SPEED_40G, ETH_LINK_SPEED_40G},
-        {port::link_speed::SPEED_50G, ETH_LINK_SPEED_50G},
-        {port::link_speed::SPEED_56G, ETH_LINK_SPEED_56G},
-        {port::link_speed::SPEED_100G, ETH_LINK_SPEED_100G}};
+        {port::link_speed::SPEED_10M, RTE_ETH_LINK_SPEED_10M},
+        {port::link_speed::SPEED_100M, RTE_ETH_LINK_SPEED_100M},
+        {port::link_speed::SPEED_1G, RTE_ETH_LINK_SPEED_1G},
+        {port::link_speed::SPEED_2_5G, RTE_ETH_LINK_SPEED_2_5G},
+        {port::link_speed::SPEED_5G, RTE_ETH_LINK_SPEED_5G},
+        {port::link_speed::SPEED_10G, RTE_ETH_LINK_SPEED_10G},
+        {port::link_speed::SPEED_20G, RTE_ETH_LINK_SPEED_20G},
+        {port::link_speed::SPEED_25G, RTE_ETH_LINK_SPEED_25G},
+        {port::link_speed::SPEED_40G, RTE_ETH_LINK_SPEED_40G},
+        {port::link_speed::SPEED_50G, RTE_ETH_LINK_SPEED_50G},
+        {port::link_speed::SPEED_56G, RTE_ETH_LINK_SPEED_56G},
+        {port::link_speed::SPEED_100G, RTE_ETH_LINK_SPEED_100G}};
 
     if (duplex == port::link_duplex::DUPLEX_HALF) {
         return (hd_flags.find(speed) != hd_flags.end() ? hd_flags.at(speed)
@@ -122,18 +122,18 @@ static constexpr uint64_t filter_tx_offloads(uint64_t tx_capa)
 static rte_eth_conf make_rte_eth_conf(uint16_t port_id)
 {
     return {
-        .link_speeds = ETH_LINK_SPEED_AUTONEG,
+        .link_speeds = RTE_ETH_LINK_SPEED_AUTONEG,
         .rxmode =
             {
-                .mtu = port_info::max_mtu(port_id),
                 .mq_mode = port_info::rx_mq_mode(port_id),
+                .mtu = port_info::max_mtu(port_id),
                 .max_lro_pkt_size = port_info::max_lro_pkt_size(port_id)
                                     - quirks::adjust_max_rx_pktlen(port_id),
                 .offloads = filter_rx_offloads(port_info::rx_offloads(port_id)),
             },
         .txmode =
             {
-                .mq_mode = ETH_MQ_TX_NONE,
+                .mq_mode = RTE_ETH_MQ_TX_NONE,
                 .offloads = filter_tx_offloads(port_info::tx_offloads(port_id)),
             },
         .rx_adv_conf = {.rss_conf =
@@ -144,7 +144,6 @@ static rte_eth_conf make_rte_eth_conf(uint16_t port_id)
                                    port supports */
                             }},
         .tx_adv_conf = {},
-        .fdir_conf = {},
         .intr_conf = {.lsc = !!port_info::lsc_interrupt(port_id),
                       .rxq = !config::dpdk_disable_rx_irq()}};
 }
@@ -254,7 +253,7 @@ reconfigure_port(uint16_t port_id,
     }
 
     /* Update port config and then try to update port */
-    port_conf.link_speeds = ETH_LINK_SPEED_FIXED | link_flag;
+    port_conf.link_speeds = RTE_ETH_LINK_SPEED_FIXED | link_flag;
     return (do_port_config(port_id,
                            port_conf,
                            mempool,

--- a/src/modules/packetio/drivers/dpdk/primary/utils.cpp
+++ b/src/modules/packetio/drivers/dpdk/primary/utils.cpp
@@ -26,7 +26,12 @@ tl::expected<void, std::string> stop_port(uint16_t port_id)
      * that.
      */
     auto info = rte_eth_dev_info{};
-    rte_eth_dev_info_get(port_id, &info);
+    auto error = rte_eth_dev_info_get(port_id, &info);
+    if (error < 0) {
+        return (tl::make_unexpected("Failed to get port info for port "
+                                    + std::to_string(port_id) + ": "
+                                    + rte_strerror(std::abs(error))));
+    }
 
     auto errors = std::vector<std::string>{};
     for (int q = 0; q < info.nb_tx_queues; q++) {

--- a/src/modules/packetio/drivers/dpdk/secondary/topology_utils.cpp
+++ b/src/modules/packetio/drivers/dpdk/secondary/topology_utils.cpp
@@ -9,9 +9,7 @@ std::vector<uint16_t> get_ports()
 {
     auto ids = std::vector<uint16_t>{};
     uint16_t port_id = 0;
-    RTE_ETH_FOREACH_DEV (port_id) {
-        ids.emplace_back(port_id);
-    }
+    RTE_ETH_FOREACH_DEV (port_id) { ids.emplace_back(port_id); }
 
     return (ids);
 }

--- a/src/modules/packetio/port_utils.cpp
+++ b/src/modules/packetio/port_utils.cpp
@@ -146,10 +146,9 @@ static dpdk_config from_swagger(const std::shared_ptr<PortConfig_dpdk>& config)
         if (link->duplexIsSet()) {
             auto duplex = link->getDuplex();
             to_return.duplex =
-                (duplex == "full"
-                     ? link_duplex::DUPLEX_FULL
-                     : duplex == "half" ? link_duplex::DUPLEX_HALF
-                                        : link_duplex::DUPLEX_UNKNOWN);
+                (duplex == "full"   ? link_duplex::DUPLEX_FULL
+                 : duplex == "half" ? link_duplex::DUPLEX_HALF
+                                    : link_duplex::DUPLEX_UNKNOWN);
         }
     }
 

--- a/src/modules/packetio/workers/dpdk/event_loop_adapter.cpp
+++ b/src/modules/packetio/workers/dpdk/event_loop_adapter.cpp
@@ -14,8 +14,8 @@ event_loop_adapter::event_loop_adapter(event_loop_adapter&& other) noexcept
     , m_runnables(std::move(other.m_runnables))
 {}
 
-event_loop_adapter& event_loop_adapter::
-operator=(event_loop_adapter&& other) noexcept
+event_loop_adapter&
+event_loop_adapter::operator=(event_loop_adapter&& other) noexcept
 {
     if (this != &other) {
         m_additions = std::move(other.m_additions);

--- a/src/modules/packetio/workers/dpdk/rx_queue.cpp
+++ b/src/modules/packetio/workers/dpdk/rx_queue.cpp
@@ -1,3 +1,4 @@
+#include <cmath>
 #include <optional>
 #include <sys/epoll.h>
 

--- a/src/modules/packetio/workers/dpdk/tx_scheduler.cpp
+++ b/src/modules/packetio/workers/dpdk/tx_scheduler.cpp
@@ -191,7 +191,7 @@ static bool link_down(uint16_t port_idx)
 {
     auto link = rte_eth_link{};
     rte_eth_link_get_nowait(port_idx, &link);
-    return (link.link_status == ETH_LINK_DOWN);
+    return (link.link_status == RTE_ETH_LINK_DOWN);
 }
 
 static bool have_active_sources(const worker::tib& tib,
@@ -248,7 +248,7 @@ static uint32_t get_link_speed_safe(uint16_t port_id)
     rte_eth_link_get_nowait(port_id, &link);
 
     /* Caller should only call this when the link is up */
-    assert(link.link_status == ETH_LINK_UP);
+    assert(link.link_status == RTE_ETH_LINK_UP);
     return (link.link_speed);
 }
 

--- a/src/modules/packetio/workers/dpdk/tx_scheduler.cpp
+++ b/src/modules/packetio/workers/dpdk/tx_scheduler.cpp
@@ -1,6 +1,7 @@
 #include <sys/timerfd.h>
 #include <unistd.h>
 
+#include "packetio/drivers/dpdk/port_info.hpp"
 #include "packetio/drivers/dpdk/arg_parser.hpp"
 #include "packetio/workers/dpdk/tx_scheduler.hpp"
 #include "timesync/chrono.hpp"
@@ -190,7 +191,8 @@ tx_scheduler::event_callback_function() const
 static bool link_down(uint16_t port_idx)
 {
     auto link = rte_eth_link{};
-    rte_eth_link_get_nowait(port_idx, &link);
+    auto error = rte_eth_link_get_nowait(port_idx, &link);
+    if (error < 0) { return true; }
     return (link.link_status == RTE_ETH_LINK_DOWN);
 }
 
@@ -245,7 +247,8 @@ static uint32_t get_link_speed_safe(uint16_t port_id)
 {
     /* Query the port's link speed */
     struct rte_eth_link link;
-    rte_eth_link_get_nowait(port_id, &link);
+    auto error = rte_eth_link_get_nowait(port_id, &link);
+    if (error < 0) { return port_info::max_speed(port_id); }
 
     /* Caller should only call this when the link is up */
     assert(link.link_status == RTE_ETH_LINK_UP);

--- a/src/modules/packetio/workers/dpdk/worker_gro.cpp
+++ b/src/modules/packetio/workers/dpdk/worker_gro.cpp
@@ -96,8 +96,8 @@ tcp_flow_key get_ipv6_tcp_flow_key(const struct rte_mbuf* packet)
 
     return (tcp_flow_key{mac_address(eth_hdr->src_addr.addr_bytes),
                          mac_address(eth_hdr->dst_addr.addr_bytes),
-                         ipv6_address(ip6_hdr->src_addr),
-                         ipv6_address(ip6_hdr->dst_addr),
+                         ipv6_address(ip6_hdr->src_addr.a),
+                         ipv6_address(ip6_hdr->dst_addr.a),
                          tcp_hdr->src_port,
                          tcp_hdr->dst_port,
                          tcp_hdr->recv_ack});

--- a/src/modules/socket/process_control_linux.cpp
+++ b/src/modules/socket/process_control_linux.cpp
@@ -44,13 +44,10 @@ static std::string to_string(cap_value_t cap_values[], size_t nb_cap_values)
         std::string(),
         [&](const std::string& s, auto& cap_value) -> std::string {
             return (s
-                    + (s.length() == 0
-                           ? ""
-                           : nb_cap_values == 2
-                                 ? " and "
-                                 : cap_values[nb_cap_values - 1] == cap_value
-                                       ? ", and "
-                                       : ", ")
+                    + (s.length() == 0                              ? ""
+                       : nb_cap_values == 2                         ? " and "
+                       : cap_values[nb_cap_values - 1] == cap_value ? ", and "
+                                                                    : ", ")
                     + cap_to_name(cap_value));
         }));
 }

--- a/src/modules/socket/server/dgram_channel.cpp
+++ b/src/modules/socket/server/dgram_channel.cpp
@@ -235,8 +235,8 @@ bool dgram_channel::send(pbuf* p)
  */
 static constexpr auto ipv6_addr_octets = 16;
 static_assert(
-    std::is_same_v<std::remove_reference_t<decltype(
-                       std::declval<sockaddr_in6>().sin6_addr.s6_addr)>,
+    std::is_same_v<std::remove_reference_t<decltype(std::declval<sockaddr_in6>()
+                                                        .sin6_addr.s6_addr)>,
                    uint8_t[ipv6_addr_octets]>);
 
 std::optional<dgram_channel_addr>

--- a/src/modules/socket/server/tcp_socket.cpp
+++ b/src/modules/socket/server/tcp_socket.cpp
@@ -505,7 +505,7 @@ do_tcp_connect(tcp_pcb* pcb, const api::request_connect& connect)
     auto ip_addr = get_address(sstorage, IP_IS_V6_VAL(pcb->local_ip));
     auto ip_port = get_port(sstorage);
 
-    if (!ip_addr | !ip_port) { return (tl::make_unexpected(EINVAL)); }
+    if (!ip_addr || !ip_port) { return (tl::make_unexpected(EINVAL)); }
 
     auto error = tcp_connect(pcb, &*ip_addr, *ip_port, nullptr);
     if (error != ERR_OK) { return (tl::make_unexpected(err_to_errno(error))); }

--- a/src/modules/tvlp/api_transmogrify.cpp
+++ b/src/modules/tvlp/api_transmogrify.cpp
@@ -23,8 +23,8 @@ serialized_msg serialize(api_request&& msg)
                      return openperf::message::push(serialized, start.id)
                             || openperf::message::push(
                                 serialized,
-                                std::make_unique<decltype(
-                                    start.start_configuration)>(
+                                std::make_unique<
+                                    decltype(start.start_configuration)>(
                                     std::move(start.start_configuration)));
                  },
                  [&](const id_message& msg) {

--- a/targets/sink-benchmark/main.cpp
+++ b/targets/sink-benchmark/main.cpp
@@ -79,9 +79,9 @@ public:
 
     bool active() const { return m_active; }
 
-    bool uses_feature([
-        [maybe_unused]] openperf::packetio::packet::sink_feature_flags
-                          sink_feature_flags) const
+    bool
+    uses_feature([[maybe_unused]] openperf::packetio::packet::sink_feature_flags
+                     sink_feature_flags) const
     {
         return false;
     }

--- a/targets/sink-example/main.cpp
+++ b/targets/sink-example/main.cpp
@@ -95,9 +95,9 @@ public:
 
     bool active() const { return m_active; }
 
-    bool uses_feature([
-        [maybe_unused]] openperf::packetio::packet::sink_feature_flags
-                          sink_feature_flags) const
+    bool
+    uses_feature([[maybe_unused]] openperf::packetio::packet::sink_feature_flags
+                     sink_feature_flags) const
     {
         return false;
     }


### PR DESCRIPTION
Upgrade DPDK from 21.11 to 24.11.5 due to Mellanox DPDK driver compatibility issues with RDMA kernel drivers

```
[ 9816.651256] WARNING: CPU: 37 PID: 135957 at drivers/infiniband/core/rdma_core.c:902 __uverbs_cleanup_ufile+0x101/0x130 [ib_uverbs]
```

DPDK upgrade required a newer version of meson and the build container image was using debian:buster is EOL
so the build container was upgraded to debian:bookworm which needs LLVM >= 14.
Didn't use latest debian because still need to support older GLIBC versions.

The Pistache C++ library had compile errors with LLVM 14, so it was updated as well.

Upgraded DPDK in stages going from 12.11 to 23.11 to 24.11.
Upgrading too much at once is more risky and it may be necessary to down version DPDK if there are compatibility issues with newer versions on older systems.